### PR TITLE
Complete multi-tenancy and uploadable asset serving

### DIFF
--- a/e2e/lib/e2e_project_web/endpoint.ex
+++ b/e2e/lib/e2e_project_web/endpoint.ex
@@ -29,6 +29,8 @@ defmodule E2eProjectWeb.Endpoint do
   #
   # You should set gzip to true if you are running phoenix.digest
   # when deploying your static files in production.
+  plug Brando.Plug.SiteAssets
+
   plug Plug.Static,
     at: "/",
     from: :e2e_project,

--- a/guides/tenancy_and_environments.md
+++ b/guides/tenancy_and_environments.md
@@ -8,14 +8,13 @@ environments backed by PostgreSQL schemas.
 >
 > The tenant registry, schema lifecycle, routing context, archive/copy/rollback
 > operations, scheduling and management UI, admin environment switcher, and
-> cross-environment local-media cleanup are available.
+> cross-environment local-media cleanup are available. Multi-site roles,
+> strict host and admin authorization, compensated site provisioning,
+> retention-aware site deletion, per-site media, tenant-scoped caches,
+> uploadable frontend asset sets, and the existing-installation migration task
+> are also available.
 > Before enabling tenancy for an application, you must provide tenant migrations
 > for every table the application queries as tenant content.
->
-> Existing-installation data migration, multi-site roles, per-site upload paths,
-> and strict multi-site authorization are not complete. Keep existing
-> installations on `:none`, and do not deploy `:multi` as a tenant-security
-> boundary yet.
 
 ## Choose a mode
 
@@ -23,7 +22,7 @@ environments backed by PostgreSQL schemas.
 | --- | --- | --- |
 | `:none` | Existing content remains in `public`; no tenant prefix is injected | Traditional Brando installation; default |
 | `:single` | One configured site can have any number of schema-backed environments | Standalone site with production, staging, and project environments |
-| `:multi` | The registry can contain multiple sites, each with named environments | Brando Master; requires the unfinished multi-site authorization phase |
+| `:multi` | Multiple isolated sites with per-site roles, media, assets, domains, and environments | Agencies and Brando Master installations |
 
 The registry itself always lives in `public`:
 
@@ -33,6 +32,8 @@ public
 ├── environments
 ├── users
 ├── users_tokens
+├── user_sites
+├── site_asset_sets
 └── environment_operation_logs
 
 tenant_acme_production
@@ -48,6 +49,46 @@ tenant_acme_staging
 Environment names are ordinary data. `production` and `staging` are useful
 defaults, not reserved keys. A site can have any number of environments, while
 a partial database index guarantees that no more than one is marked live.
+
+## Choose a delivery mode
+
+`delivery_mode` describes how a site's public frontend is published. It is
+independent of `tenancy_mode`: a site in a multi-tenant installation can be
+dynamic or static, and uploadable frontend asset sets can be used by either.
+
+| Mode | Public delivery | Content publication |
+| --- | --- | --- |
+| `:dynamic` | Phoenix serves each request from the site's current live environment | A live-environment change is visible on the next request; no static build or deploy is required |
+| `:static` | A generated HTML build is intended to be served by a static host or CDN | Content becomes public only after an SSG build is generated and deployed |
+
+For `:dynamic`, the request host resolves the site and live environment,
+`Brando.Plug.Tenant` installs that environment's database prefix, and the
+normal Phoenix router renders the response. `Brando.Plug.SiteAssets` may serve
+an activated uploaded CSS/JS set first, but a miss still falls through to the
+assets packaged in `priv/static`. Activating an asset set therefore changes
+frontend files without changing the site's content environment or requiring a
+full application release.
+
+For `:static`, the flag records that the site belongs to the SSG delivery
+workflow. The current tenancy phases provide the field and a tenant-aware
+manual `mix brando.ssg --site SITE_KEY` command. They do **not** yet enqueue,
+version, deploy, or route traffic to static builds automatically. Those build
+records, workers, deploy targets, previews, and rollbacks belong to the
+versioned SSG phase. Until that phase or an application-owned deploy pipeline
+is configured, selecting `:static` does not stop Phoenix from serving the
+site's domains and does not itself publish a build.
+
+An asset set and a delivery mode answer different questions:
+
+- the asset set selects which compiled CSS, JavaScript, fonts, and other
+  frontend files Brando serves or copies into an SSG build;
+- the delivery mode states whether Phoenix responses or a deployed static
+  snapshot are intended to be the public site.
+
+Choose `:dynamic` unless the site already has an SSG build-and-deploy pipeline.
+Changing the field later does not move traffic or activate an asset set; treat
+that change and the corresponding infrastructure cutover as separate
+operations.
 
 ## New installations
 
@@ -73,7 +114,7 @@ mix brando.install --tenancy-mode none
 # Standalone site with environments
 mix brando.install --tenancy-mode single --site-key acme
 
-# Multi-site registry; not yet a production authorization boundary
+# Multi-site registry
 mix brando.install --tenancy-mode multi
 
 # Preserve the default without prompting
@@ -152,47 +193,45 @@ rolling releases across multiple nodes. Run public migrations before tenant
 migrations, and tenant migrations before routing traffic to code that requires
 the new columns.
 
-## Create the registry and initial environments
+## Provision sites and initial environments
 
-Once tenant migrations exist, create the site record and its initial
-environments. The following can be placed in an application seed/setup task or
-run in a controlled IEx session:
+Once tenant migrations exist, provision a complete site from the superuser
+screen at `/admin/sites`, or call the same compensated API from setup tooling:
 
 ```elixir
-alias Brando.Environments
-alias Brando.Tenant.Registry
-
 {:ok, site} =
-  Registry.create_site(%{
-    name: "Acme",
-    key: "acme",
-    languages: ["en"],
-    default_language: "en",
-    status: :active,
-    delivery_mode: :dynamic
-  })
-
-{:ok, production} =
-  Environments.create_environment(site, %{
-    name: "Production",
-    key: "production",
-    domain: "www.acme.test",
-    live: true
-  })
-
-{:ok, staging} =
-  Environments.create_environment(site, %{
-    name: "Staging",
-    key: "staging",
-    domain: "staging.acme.test",
-    live: false
-  })
+  Brando.Tenant.Setup.create_site(
+    %{
+      name: "Acme",
+      key: "acme",
+      languages: ["en"],
+      default_language: "en",
+      status: :active,
+      delivery_mode: :dynamic
+    },
+    current_user
+  )
 ```
 
-`create_environment/2` creates `tenant_{site}_{environment}`, runs all tenant
-migrations in that prefix, writes an operation-log entry, and warms the routing
-cache. If schema creation or migration fails, it removes both the partial schema
-and registry row.
+Provisioning creates live Production and non-live Staging environments, runs
+tenant migrations, seeds Production, copies it to Staging, creates
+`media/{site_key}` and `sites/{site_key}/assets`, and grants the creator the
+site admin role. A PostgreSQL advisory lock serializes creation for the key. If
+any database, seed, copy, assignment, or filesystem step fails, Brando removes
+the partial schemas, registry rows, and directories.
+
+The default seeder creates identity and SEO records for every site language.
+Applications normally provide a home page and application-specific initial
+content by configuring a module that implements `Brando.Tenant.Seeder`:
+
+```elixir
+config :brando, tenant_seeder: MyApp.TenantSeeder
+```
+
+Individual working environments can still be created with
+`Brando.Environments.create_environment/2`. It creates
+`tenant_{site}_{environment}`, runs all tenant migrations, writes an operation
+log, and compensates a failed schema creation or migration.
 
 In `single` mode, the site key in the registry must match the configured
 `site_key`.
@@ -234,10 +273,12 @@ session:
 - the sidebar switcher marks the live environment and warns while editing a
   non-live environment.
 
-Administrators and superusers can open `/admin/config/environments` to create
-and delete working environments, queue or schedule copies and live switches,
-cancel pending jobs, restore the newest archive, and prune old archives. Editors
-can inspect the same state without lifecycle mutation controls.
+Per-site administrators and global superusers can open
+`/admin/config/environments` to create and delete working environments, queue
+or schedule copies and live switches, cancel pending jobs, restore the newest
+archive, and prune old archives. Editors can inspect the same state without
+lifecycle mutation controls. In multi-site mode the sidebar contains only sites
+assigned to the current user; global superusers see every active site.
 
 `Brando.Repo` applies the current prefix to reads, writes, preloads, bulk
 updates, and bulk soft deletion. An explicit prefix always wins:
@@ -254,9 +295,45 @@ Shared schemas should set `@schema_prefix "public"`. The wrapper recognizes
 that metadata and keeps shared models in `public` even when an admin is working
 inside a tenant environment.
 
-In `:multi`, an unknown frontend host currently clears tenant context and lets
-the application continue. Until strict unknown-host rejection and per-site user
-authorization land, do not treat this mode as a production isolation boundary.
+In `:multi`, a suspended, archived, or unknown frontend host receives `404`
+before content plugs run. A stale or forged admin site selection is checked
+against `public.user_sites`; it can never restore another tenant's schema
+prefix.
+
+## Per-site roles and lifecycle
+
+Users remain global accounts in `public.users`. Multi-site access is explicit:
+
+```text
+superuser  global role; bypasses assignments for every active site
+admin      per-site role; content plus site/environment lifecycle management
+editor     per-site role; content editing without lifecycle mutation
+```
+
+The superuser Sites screen at `/admin/sites` provisions sites, shows
+environment/page/media/last-edit summaries, changes lifecycle state, and grants
+or revokes roles. The underlying API is also available to application tooling:
+
+```elixir
+{:ok, assignment} = Brando.Tenant.Access.grant(user, site, :editor)
+:ok = Brando.Tenant.Access.revoke(user, site)
+
+{:ok, suspended} = Brando.Tenant.Setup.suspend_site(site)
+{:ok, active} = Brando.Tenant.Setup.activate_site(suspended)
+{:ok, archived} = Brando.Tenant.Setup.archive_site(active)
+```
+
+Permanent deletion is deliberately a second step. A site must be archived for
+30 days by default, after which deletion removes every current/archive schema,
+registry row, assignment, media directory, and uploaded asset directory:
+
+```elixir
+{:ok, _deleted} = Brando.Tenant.Setup.delete_site(archived)
+```
+
+Configure `site_delete_retention_days` to change the window. `force: true` is
+available to controlled recovery/migration code, but the admin UI never uses
+it.
 
 ## Copy content safely
 
@@ -298,8 +375,11 @@ same site. If source-to-target restore fails, Brando drops the partial target
 and restores its archive.
 
 Media bytes are not copied. In `:single`, every environment shares the existing
-configured media root. `:multi` reserves `media/{site_key}` roots; wiring upload
-paths into those roots belongs to the multi-site isolation phase.
+configured media root. In `:multi`, local uploads, processing, crops, exports,
+sitemaps, downloads, frontend media serving, and orphan cleanup all resolve
+inside `media/{site_key}`. The database continues storing relative paths such
+as `images/hero.jpg`, so the same URL can safely resolve to different bytes on
+different site domains.
 
 Local orphan cleanup unions image and file records from **every** environment
 schema before deleting a byte:
@@ -402,6 +482,103 @@ jobs = Brando.Environments.list_scheduled_operations(site)
 The environment management panel shows these jobs with their scheduled time and
 state, and exposes the same site-ownership-checked cancellation path.
 
+## Uploadable frontend asset sets
+
+Uploaded frontend builds persist outside releases. Standalone installations use
+`site_assets/sets/{set}`; multi-site installations use
+`sites/{site_key}/assets/sets/{set}`. `Brando.Plug.SiteAssets` must run before
+the release `Plug.Static`; new installers and the E2E application already have
+this order.
+
+Florist uploads a clean `priv/static` build and registers it by RPC without
+activating it:
+
+```elixir
+# tenancy_mode :none or :single
+Brando.Assets.SiteAssets.register_set(
+  "/srv/my_app/site_assets/sets/20260816_abc123",
+  %{revision: "abc123", uploaded_at: DateTime.utc_now()}
+)
+
+# tenancy_mode :multi
+Brando.Assets.SiteAssets.register_set(
+  "acme",
+  "/srv/my_app/sites/acme/assets/sets/20260816_abc123",
+  %{revision: "abc123"}
+)
+```
+
+Registration validates that the directory is an immediate child of the
+managed `sets` root, rejects symlinks and special files, and records the actual
+byte size and file count. A superuser activates or rolls back sets at
+`/admin/config/assets`. Activation caches both the complete regular-file
+`MapSet` and optional Vite manifest in `:persistent_term`. Requests absent from
+that set fall through to release assets without a filesystem lookup. Reverting
+clears the active cache and immediately restores `priv/static` fallback.
+
+Vite manifest and critical CSS resolution follow the same active-set-first,
+release-fallback order. In multi-site mode caches are keyed by the full tenant
+prefix, so Production, Staging, and another site cannot share rendered content
+or manifests. `mix brando.ssg --site acme` copies Acme's active uploaded set and
+media root when present; without an active set it retains the existing local
+Vite build flow.
+
+The storage roots can be made explicit; otherwise they are derived alongside
+the configured media directory:
+
+```elixir
+config :brando,
+  media_path: "/srv/my_app/media",
+  sites_path: "/srv/my_app/sites",
+  site_assets_path: "/srv/my_app/site_assets"
+```
+
+Back up `sites/` and `site_assets/` alongside `media/`. Florist remains
+responsible for clean builds, upload transport, retention pruning, and
+blue/green shared-directory symlinks; Brando owns registration, activation,
+serving, manifest selection, and the management UI.
+
+## Migrate an existing installation
+
+After writing and applying tenant migrations, copy an existing public-schema
+site with:
+
+```bash
+mix brando.migrate_to_tenant --site-key=my-site
+```
+
+Use `--name` to override the generated display name and `--creator-email` when
+the first active superuser should not own the new site. The task:
+
+1. provisions a migrated, empty Production schema without default seeding;
+2. discovers tables present in both `public` and the migrated tenant schema;
+3. excludes users, sessions, sites, environments, assignments, Oban jobs,
+   operation logs, asset metadata, transient previews/uploads, and migration
+   history;
+4. copies only matching table data with `pg_dump` and `psql`;
+5. copies classic local media into `media/{site_key}` without deleting the
+   legacy media tree;
+6. creates Staging as a complete copy of Production; and
+7. removes the entire partial site if data, media, or Staging creation fails.
+
+The media copy rejects symlinks and special files so it cannot cross a tenant
+storage boundary. Provisioning also refuses to reuse an existing
+`media/{site_key}` or `sites/{site_key}` directory; a failed setup never removes
+storage it did not create. Keep the original public data and legacy media until
+the migrated site has been verified and the rollback window has closed.
+
+Run the conversion in a maintenance window after draining tenant-owned Oban
+work such as publishing, rendering, image processing, and CDN uploads. Jobs
+created before tenancy do not contain a tenant prefix and are deliberately
+cancelled rather than allowed to query `public` after tenancy is enabled;
+recreate any future publication schedules after migration. Standalone uploaded
+asset-set records are also not assigned to the new site automatically. Upload
+or register a fresh site-scoped set, verify it, and then activate it from the
+asset management screen.
+
+The source `public` data is not deleted. Keep it and a restorable external
+backup until the tenant installation has been verified and cut over.
+
 ## Operation log
 
 Lifecycle operations write immutable records to
@@ -418,19 +595,21 @@ create  copy  set_live  rollback  delete
 
 ## Operational checklist
 
-Before enabling `:single` or experimenting with `:multi`:
+Before enabling `:single` or `:multi`:
 
 1. Keep a restorable external database backup.
 2. Apply public migrations.
 3. Provide tenant migrations for every tenant content table.
-4. Create matching site and environment registry records.
+4. Provision the site or run `mix brando.migrate_to_tenant` for existing data.
 5. Add `Brando.Plug.Tenant` before content-loading plugs in existing routers.
 6. Verify `pg_dump` and `psql` availability from the release environment.
 7. Run tenant migrations for every environment.
 8. Exercise copy and recovery on representative production-sized data.
-9. Verify each domain resolves to the intended environment.
-10. Keep `:multi` disabled in production until site roles and strict isolation
-    are complete.
+9. Verify each domain resolves to the intended environment and unknown hosts
+   return `404`.
+10. Verify an editor cannot switch to or query an unassigned site.
+11. Verify uploaded assets and media return different bytes for two site hosts.
+12. Back up the database, `media/`, `sites/`, and `site_assets/` together.
 
 If a tenant request reports that a relation does not exist, first verify the
 resolved prefix and tenant migration history. The most common cause is a table

--- a/lib/brando/assets/site_asset_set.ex
+++ b/lib/brando/assets/site_asset_set.ex
@@ -1,0 +1,39 @@
+defmodule Brando.Assets.SiteAssetSet do
+  @moduledoc "Metadata for one persistent frontend asset bundle."
+
+  use Ecto.Schema
+
+  import Ecto.Changeset
+
+  alias Brando.Sites.Site
+
+  @schema_prefix "public"
+  @timestamps_opts [type: :utc_datetime_usec]
+
+  @type t :: %__MODULE__{}
+
+  schema "site_asset_sets" do
+    belongs_to :site, Site
+    field :name, :string
+    field :path, :string
+    field :active, :boolean, default: false
+    field :uploaded_at, :utc_datetime_usec
+    field :size, :integer, default: 0
+    field :file_count, :integer, default: 0
+    field :metadata, :map, default: %{}
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(asset_set \\ %__MODULE__{}, attrs) do
+    asset_set
+    |> cast(attrs, [:site_id, :name, :path, :active, :uploaded_at, :size, :file_count, :metadata])
+    |> validate_required([:name, :path, :uploaded_at, :size, :file_count])
+    |> validate_number(:size, greater_than_or_equal_to: 0)
+    |> validate_number(:file_count, greater_than_or_equal_to: 0)
+    |> assoc_constraint(:site)
+    |> unique_constraint(:name, name: :site_asset_sets_standalone_name_index)
+    |> unique_constraint([:site_id, :name], name: :site_asset_sets_site_name_index)
+  end
+end

--- a/lib/brando/assets/site_assets.ex
+++ b/lib/brando/assets/site_assets.ex
@@ -1,0 +1,424 @@
+defmodule Brando.Assets.SiteAssets do
+  @moduledoc """
+  Registry and runtime cache for persistent, uploadable frontend asset sets.
+
+  Standalone installations use `site_assets/sets/{set}`. Multi-site
+  installations use `sites/{site_key}/assets/sets/{set}`. Activation caches
+  the complete regular-file listing as a `MapSet` and the optional Vite
+  manifest in `:persistent_term`, making non-matching request rejection a
+  memory lookup with no filesystem access.
+  """
+
+  import Ecto.Query, only: [from: 2]
+
+  alias Brando.Assets.SiteAssetSet
+  alias Brando.Repo
+  alias Brando.Sites.Site
+  alias Brando.Tenant
+  alias Brando.Tenant.Registry
+  alias Brando.Tenant.Storage
+
+  @public_opts [prefix: "public"]
+  @cache_keys_key {:brando, :site_assets, :cache_keys}
+
+  @type scope :: Site.t() | nil
+  @type cached_set :: %{
+          set: SiteAssetSet.t(),
+          path: String.t(),
+          files: MapSet.t(String.t()),
+          manifest: map() | nil
+        }
+
+  @doc "Registers an uploaded standalone set without activating it."
+  @spec register_set(String.t(), map()) :: {:ok, SiteAssetSet.t()} | {:error, term()}
+  def register_set(path, metadata \\ %{}) when is_binary(path) and is_map(metadata) do
+    register(nil, path, metadata)
+  end
+
+  @doc "Registers an uploaded set for one site without activating it."
+  @spec register_set(Site.t() | String.t(), String.t(), map()) ::
+          {:ok, SiteAssetSet.t()} | {:error, term()}
+  def register_set(%Site{} = site, path, metadata) when is_binary(path) and is_map(metadata) do
+    register(site, path, metadata)
+  end
+
+  def register_set(site_key, path, metadata)
+      when is_binary(site_key) and is_binary(path) and is_map(metadata) do
+    case Registry.get_site_by_key(site_key) do
+      %Site{} = site -> register(site, path, metadata)
+      nil -> {:error, :site_not_found}
+    end
+  end
+
+  @doc "Lists registered sets newest first for a standalone or site scope."
+  @spec list_sets(scope()) :: [SiteAssetSet.t()]
+  def list_sets(site \\ nil) do
+    site
+    |> scope_query()
+    |> then(&from(asset_set in &1, order_by: [desc: asset_set.uploaded_at, desc: asset_set.id]))
+    |> Repo.all(@public_opts)
+  end
+
+  @doc "Returns the persisted active set for a scope."
+  @spec active_set(scope()) :: SiteAssetSet.t() | nil
+  def active_set(site \\ nil) do
+    site
+    |> scope_query()
+    |> then(&from(asset_set in &1, where: asset_set.active))
+    |> Repo.one(@public_opts)
+  end
+
+  @doc "Activates a registered set and atomically deactivates its predecessor."
+  @spec activate_set(pos_integer()) :: {:ok, SiteAssetSet.t()} | {:error, term()}
+  def activate_set(set_id) do
+    with %SiteAssetSet{} = asset_set <- Repo.get(SiteAssetSet, set_id, @public_opts),
+         {:ok, cached} <- build_cache(asset_set),
+         {:ok, active_set} <- persist_activation(asset_set) do
+      put_cache(scope_key(active_set), %{cached | set: active_set})
+      invalidate_vite(active_set.site_id)
+      {:ok, active_set}
+    else
+      nil -> {:error, :asset_set_not_found}
+      {:error, _reason} = error -> error
+    end
+  end
+
+  @doc "Deactivates uploaded assets for a scope and restores release fallback."
+  @spec deactivate(scope()) :: :ok | {:error, term()}
+  def deactivate(site \\ nil) do
+    case Repo.transaction(fn ->
+           site
+           |> scope_query()
+           |> Repo.update_all([set: [active: false]], @public_opts)
+         end) do
+      {:ok, _updated} ->
+        put_cache(scope_key(site), :none)
+        invalidate_vite(site_id(site))
+        :ok
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  @doc "Returns the cached active-set information, warming it on first use."
+  @spec cached(scope()) :: cached_set() | nil
+  def cached(site \\ nil) do
+    key = cache_key(scope_key(site))
+
+    case :persistent_term.get(key, :not_cached) do
+      :not_cached -> warm_scope(site)
+      :none -> nil
+      cached -> cached
+    end
+  end
+
+  @doc "Warms every persisted active set. Safe to call during application boot."
+  @spec warm() :: :ok
+  def warm do
+    invalidate_cache()
+
+    from(asset_set in SiteAssetSet, where: asset_set.active)
+    |> Repo.all(@public_opts)
+    |> Enum.each(fn asset_set ->
+      case build_cache(asset_set) do
+        {:ok, cached} -> put_cache(scope_key(asset_set), cached)
+        {:error, _reason} -> put_cache(scope_key(asset_set), :none)
+      end
+    end)
+
+    :ok
+  rescue
+    _migration_not_applied_yet -> :ok
+  end
+
+  @doc "Clears all active-set runtime caches."
+  @spec invalidate_cache() :: :ok
+  def invalidate_cache do
+    @cache_keys_key
+    |> :persistent_term.get([])
+    |> Enum.each(&:persistent_term.erase/1)
+
+    :persistent_term.erase(@cache_keys_key)
+    :ok
+  end
+
+  @doc "Returns the current scope's cached uploaded Vite manifest, if present."
+  @spec current_manifest() :: map() | nil
+  def current_manifest do
+    case current_scope() do
+      {:ok, site} -> cached(site) |> cached_value(:manifest)
+      :error -> nil
+    end
+  end
+
+  @doc "Resolves a regular file within the current active set."
+  @spec current_file(String.t()) :: String.t() | nil
+  def current_file(relative_path) when is_binary(relative_path) do
+    with {:ok, site} <- current_scope(),
+         %{files: files, path: root} <- cached(site),
+         normalized when is_binary(normalized) <- normalize_relative_path(relative_path),
+         true <- MapSet.member?(files, normalized) do
+      Path.join(root, normalized)
+    else
+      _ -> nil
+    end
+  end
+
+  @doc "Returns the current scope's active set root for static export tooling."
+  @spec current_root() :: String.t() | nil
+  def current_root do
+    case current_scope() do
+      {:ok, site} -> cached(site) |> cached_value(:path)
+      :error -> nil
+    end
+  end
+
+  @doc false
+  def standalone_root do
+    Brando.config(:site_assets_path) ||
+      Brando.config(:media_path) |> Path.expand() |> Path.dirname() |> Path.join("site_assets")
+  end
+
+  @doc false
+  def sets_root(nil), do: Path.join(standalone_root(), "sets")
+  def sets_root(%Site{} = site), do: Path.join(Storage.assets_root(site), "sets")
+
+  defp register(site, path, metadata) do
+    with {:ok, normalized_path} <- validate_set_path(site, path),
+         {:ok, files, size} <- scan_files(normalized_path) do
+      attrs = %{
+        site_id: site_id(site),
+        name: Path.basename(normalized_path),
+        path: normalized_path,
+        active: false,
+        uploaded_at: uploaded_at(metadata),
+        size: size,
+        file_count: MapSet.size(files),
+        metadata: stringify_metadata(metadata)
+      }
+
+      %SiteAssetSet{}
+      |> SiteAssetSet.changeset(attrs)
+      |> Repo.insert(@public_opts)
+    end
+  end
+
+  defp validate_set_path(site, path) do
+    expanded_path = Path.expand(path)
+    expected_parent = site |> sets_root() |> Path.expand()
+
+    cond do
+      Path.dirname(expanded_path) != expected_parent ->
+        {:error, {:invalid_asset_set_path, expanded_path, expected_parent}}
+
+      not File.dir?(expanded_path) ->
+        {:error, {:asset_set_directory_not_found, expanded_path}}
+
+      true ->
+        {:ok, expanded_path}
+    end
+  end
+
+  defp scan_files(root), do: scan_directory(root, root, MapSet.new(), 0)
+
+  defp scan_directory(root, directory, files, size) do
+    case File.ls(directory) do
+      {:ok, entries} ->
+        Enum.reduce_while(entries, {:ok, files, size}, fn entry, {:ok, acc_files, acc_size} ->
+          path = Path.join(directory, entry)
+
+          case File.lstat(path) do
+            {:ok, %{type: :directory}} ->
+              case scan_directory(root, path, acc_files, acc_size) do
+                {:ok, nested_files, nested_size} -> {:cont, {:ok, nested_files, nested_size}}
+                {:error, reason} -> {:halt, {:error, reason}}
+              end
+
+            {:ok, %{type: :regular, size: file_size}} ->
+              relative_path = Path.relative_to(path, root)
+              {:cont, {:ok, MapSet.put(acc_files, relative_path), acc_size + file_size}}
+
+            {:ok, _symlink_or_special} ->
+              {:halt, {:error, {:unsupported_asset_file, path}}}
+
+            {:error, reason} ->
+              {:halt, {:error, {:asset_file_stat_failed, path, reason}}}
+          end
+        end)
+
+      {:error, reason} ->
+        {:error, {:asset_directory_scan_failed, directory, reason}}
+    end
+  end
+
+  defp build_cache(%SiteAssetSet{} = asset_set) do
+    with {:ok, files, _size} <- scan_files(asset_set.path),
+         {:ok, manifest} <- read_manifest(asset_set.path) do
+      {:ok, %{set: asset_set, path: asset_set.path, files: files, manifest: manifest}}
+    end
+  end
+
+  defp read_manifest(root) do
+    path = Path.join(root, "manifest.json")
+
+    case File.read(path) do
+      {:ok, json} ->
+        case Jason.decode(json) do
+          {:ok, manifest} -> {:ok, manifest}
+          {:error, reason} -> {:error, {:invalid_asset_manifest, path, reason}}
+        end
+
+      {:error, :enoent} ->
+        {:ok, nil}
+
+      {:error, reason} ->
+        {:error, {:asset_manifest_read_failed, path, reason}}
+    end
+  end
+
+  defp persist_activation(asset_set) do
+    Repo.transaction(fn ->
+      asset_set
+      |> scope_query_for_set()
+      |> Repo.update_all([set: [active: false]], @public_opts)
+
+      asset_set
+      |> SiteAssetSet.changeset(%{active: true})
+      |> Repo.update(@public_opts)
+      |> case do
+        {:ok, active_set} -> active_set
+        {:error, changeset} -> Repo.rollback(changeset)
+      end
+    end)
+  end
+
+  defp warm_scope(site) do
+    case active_set(site) do
+      nil ->
+        put_cache(scope_key(site), :none)
+        nil
+
+      asset_set ->
+        case build_cache(asset_set) do
+          {:ok, cached} ->
+            put_cache(scope_key(site), cached)
+            cached
+
+          {:error, _reason} ->
+            put_cache(scope_key(site), :none)
+            nil
+        end
+    end
+  rescue
+    _migration_not_applied_yet -> nil
+  end
+
+  defp current_scope do
+    case Tenant.mode() do
+      :multi ->
+        case Tenant.current_site_key() do
+          nil ->
+            :error
+
+          site_key ->
+            case Brando.Tenant.Cache.get_site(site_key) do
+              nil -> :error
+              site -> {:ok, site}
+            end
+        end
+
+      _standalone ->
+        {:ok, nil}
+    end
+  end
+
+  defp scope_query(nil), do: from(asset_set in SiteAssetSet, where: is_nil(asset_set.site_id))
+
+  defp scope_query(%Site{id: site_id}),
+    do: from(asset_set in SiteAssetSet, where: asset_set.site_id == ^site_id)
+
+  defp scope_query_for_set(%SiteAssetSet{site_id: nil}), do: scope_query(nil)
+
+  defp scope_query_for_set(%SiteAssetSet{site_id: site_id}),
+    do: from(asset_set in SiteAssetSet, where: asset_set.site_id == ^site_id)
+
+  defp scope_key(%SiteAssetSet{site_id: nil}), do: :standalone
+  defp scope_key(%SiteAssetSet{site_id: site_id}), do: {:site_id, site_id}
+  defp scope_key(nil), do: :standalone
+  defp scope_key(%Site{id: site_id}), do: {:site_id, site_id}
+
+  defp cache_key(scope_key), do: {:brando, :site_assets, :active, scope_key}
+
+  defp put_cache(scope_key, value) do
+    key = cache_key(scope_key)
+    :persistent_term.put(key, value)
+
+    keys = :persistent_term.get(@cache_keys_key, [])
+    :persistent_term.put(@cache_keys_key, Enum.uniq([key | keys]))
+  end
+
+  defp cached_value(nil, _key), do: nil
+  defp cached_value(cached, key), do: Map.get(cached, key)
+
+  defp normalize_relative_path(path) do
+    normalized = path |> String.trim_leading("/") |> Path.expand("/") |> Path.relative_to("/")
+
+    if normalized in ["", "."] or String.starts_with?(normalized, "../"),
+      do: nil,
+      else: normalized
+  end
+
+  defp uploaded_at(metadata) do
+    case Map.get(metadata, :uploaded_at, Map.get(metadata, "uploaded_at")) do
+      %DateTime{} = uploaded_at -> uploaded_at
+      uploaded_at when is_binary(uploaded_at) -> parse_uploaded_at(uploaded_at)
+      _missing -> DateTime.utc_now()
+    end
+  end
+
+  defp parse_uploaded_at(uploaded_at) do
+    case DateTime.from_iso8601(uploaded_at) do
+      {:ok, parsed, _offset} -> parsed
+      _invalid -> DateTime.utc_now()
+    end
+  end
+
+  defp stringify_metadata(metadata) do
+    Map.new(metadata, fn {key, value} -> {to_string(key), json_value(value)} end)
+  end
+
+  defp json_value(%DateTime{} = value), do: DateTime.to_iso8601(value)
+  defp json_value(value), do: value
+
+  defp site_id(nil), do: nil
+  defp site_id(%Site{id: site_id}), do: site_id
+
+  defp invalidate_vite(site_id) do
+    vite_prefixes(site_id)
+    |> Enum.each(fn prefix ->
+      :persistent_term.erase(Tenant.cache_key({:vite, "cache_manifest"}, prefix))
+      :persistent_term.erase(Tenant.cache_key({:vite, "critical_css"}, prefix))
+    end)
+  end
+
+  defp vite_prefixes(nil) do
+    case Tenant.mode() do
+      :single ->
+        case Registry.get_site_by_key(Brando.config(:site_key)) do
+          nil -> [nil]
+          site -> [nil | Enum.map(site.environments, &Tenant.prefix(site, &1))]
+        end
+
+      _none_or_multi ->
+        [nil]
+    end
+  end
+
+  defp vite_prefixes(site_id) do
+    case Registry.get_site(site_id) do
+      nil -> []
+      site -> Enum.map(site.environments, &Tenant.prefix(site, &1))
+    end
+  end
+end

--- a/lib/brando/assets/vite.ex
+++ b/lib/brando/assets/vite.ex
@@ -14,6 +14,8 @@ defmodule Brando.Assets.Vite do
     def read(manifest_file, cache_key, force \\ nil)
 
     def read(manifest_file, cache_key, nil) do
+      cache_key = Brando.Tenant.cache_key(cache_key)
+
       case :persistent_term.get(cache_key, nil) do
         nil ->
           hmr? = Application.get_env(Brando.otp_app(), :hmr, false)
@@ -28,6 +30,7 @@ defmodule Brando.Assets.Vite do
     end
 
     def read(manifest_file, cache_key, :force) do
+      cache_key = Brando.Tenant.cache_key(cache_key)
       hmr? = Application.get_env(Brando.otp_app(), :hmr, false)
       res = do_read(manifest_file, hmr?)
       parsed_manifest = Manifest.parse(res)
@@ -112,7 +115,18 @@ defmodule Brando.Assets.Vite do
     end
 
     @spec read(atom) :: map()
+    def read(:app = scope) do
+      case Brando.Assets.SiteAssets.current_manifest() do
+        nil -> read_release_manifest(scope)
+        uploaded_manifest -> parse(uploaded_manifest)
+      end
+    end
+
     def read(scope) do
+      read_release_manifest(scope)
+    end
+
+    defp read_release_manifest(scope) do
       scope
       |> config()
       |> Map.get(:manifest_file)
@@ -120,7 +134,18 @@ defmodule Brando.Assets.Vite do
     end
 
     @spec refresh(atom) :: map()
+    def refresh(:app = scope) do
+      case Brando.Assets.SiteAssets.current_manifest() do
+        nil -> refresh_release_manifest(scope)
+        uploaded_manifest -> parse(uploaded_manifest)
+      end
+    end
+
     def refresh(scope) do
+      refresh_release_manifest(scope)
+    end
+
+    defp refresh_release_manifest(scope) do
       scope
       |> config()
       |> Map.get(:manifest_file)
@@ -172,7 +197,9 @@ defmodule Brando.Assets.Vite do
     end
 
     def critical_css(scope \\ :app) do
-      case :persistent_term.get(config(scope).critical_css_cache_key, nil) do
+      cache_key = Brando.Tenant.cache_key(config(scope).critical_css_cache_key)
+
+      case :persistent_term.get(cache_key, nil) do
         nil ->
           manifest = Manifest.read(scope)
 
@@ -188,7 +215,7 @@ defmodule Brando.Assets.Vite do
               |> Phoenix.HTML.raw()
             end
 
-          :persistent_term.put(config(scope).critical_css_cache_key, res)
+          :persistent_term.put(cache_key, res)
           res
 
         res ->
@@ -203,10 +230,11 @@ defmodule Brando.Assets.Vite do
     def critical_css(:prod, critical_css_files) do
       Enum.reduce(critical_css_files, "", fn file, acc ->
         full_path =
-          Application.app_dir(
-            Brando.endpoint().config(:otp_app),
-            Path.join("priv/static", file)
-          )
+          Brando.Assets.SiteAssets.current_file(file) ||
+            Application.app_dir(
+              Brando.endpoint().config(:otp_app),
+              Path.join("priv/static", file)
+            )
 
         if File.exists?(full_path) do
           acc <> File.read!(full_path)
@@ -222,7 +250,7 @@ defmodule Brando.Assets.Vite do
 
     def critical_css(_, critical_css_files) do
       Enum.reduce(critical_css_files, "", fn file, acc ->
-        full_path = Path.join("priv/static", file)
+        full_path = Brando.Assets.SiteAssets.current_file(file) || Path.join("priv/static", file)
 
         if File.exists?(full_path) do
           acc <> File.read!(full_path)

--- a/lib/brando/cache.ex
+++ b/lib/brando/cache.ex
@@ -23,18 +23,24 @@ defmodule Brando.Cache do
   def put(key, var, ttl \\ :timer.minutes(15))
 
   def put(key, val, :infinite) do
-    @cache_module.put(:cache, key, val)
+    @cache_module.put(:cache, cache_key(key), val)
   end
 
   def put(key, val, ttl) do
-    @cache_module.put(:cache, key, val, expire: ttl)
+    @cache_module.put(:cache, cache_key(key), val, expire: ttl)
+  end
+
+  def update(key, val) do
+    @cache_module.update(:cache, cache_key(key), val)
   end
 
   def del(key) do
-    @cache_module.del(:cache, key)
+    @cache_module.del(:cache, cache_key(key))
   end
 
   defp get_from_cache(key) do
-    @cache_module.get(:cache, key)
+    @cache_module.get(:cache, cache_key(key))
   end
+
+  defp cache_key(key), do: Brando.Tenant.cache_key(key)
 end

--- a/lib/brando/cache/globals.ex
+++ b/lib/brando/cache/globals.ex
@@ -30,7 +30,7 @@ defmodule Brando.Cache.Globals do
   def set do
     {:ok, global_sets} = Sites.list_global_sets()
     global_map = process_globals(global_sets)
-    Cachex.put(:cache, :globals, global_map)
+    Cache.put(:globals, global_map, :infinite)
     global_map
   end
 
@@ -42,7 +42,7 @@ defmodule Brando.Cache.Globals do
   def update({:ok, global_set}) do
     {:ok, global_sets} = Sites.list_global_sets()
     global_map = process_globals(global_sets)
-    Cachex.update(:cache, :globals, global_map)
+    Cache.update(:globals, global_map)
 
     {:ok, global_set}
   end

--- a/lib/brando/cache/identity.ex
+++ b/lib/brando/cache/identity.ex
@@ -29,7 +29,7 @@ defmodule Brando.Cache.Identity do
   def set do
     {:ok, identities} = Sites.list_identities(%{preload: [:logo]})
     identity_map = process_identities(identities)
-    Cachex.put(:cache, :identity, identity_map)
+    Cache.put(:identity, identity_map, :infinite)
     identity_map
   end
 
@@ -41,7 +41,7 @@ defmodule Brando.Cache.Identity do
   def update({:ok, identity}) do
     {:ok, identities} = Sites.list_identities(%{preload: [:logo]})
     identity_map = process_identities(identities)
-    Cachex.update(:cache, :identity, identity_map)
+    Cache.update(:identity, identity_map)
     {:ok, identity}
   end
 

--- a/lib/brando/cache/navigation.ex
+++ b/lib/brando/cache/navigation.ex
@@ -11,7 +11,16 @@ defmodule Brando.Cache.Navigation do
   Get all menus from cache
   """
   @spec get :: map() | nil
-  def get, do: Cache.get(:navigation)
+  def get do
+    case Cache.get(:navigation) do
+      nil ->
+        set()
+        Cache.get(:navigation)
+
+      navigation ->
+        navigation
+    end
+  end
 
   @doc """
   Get menu from cache by path
@@ -38,7 +47,7 @@ defmodule Brando.Cache.Navigation do
   @spec set :: {:error, boolean} | {:ok, boolean}
   def set do
     menu_map = get_menu_map()
-    Cachex.put(:cache, :navigation, menu_map)
+    Cache.put(:navigation, menu_map, :infinite)
   end
 
   @doc """
@@ -48,7 +57,7 @@ defmodule Brando.Cache.Navigation do
           {:ok, map()} | {:error, changeset}
   def update({:ok, menu}) do
     menu_map = get_menu_map()
-    Cachex.update(:cache, :navigation, menu_map)
+    Cache.update(:navigation, menu_map)
     {:ok, menu}
   end
 

--- a/lib/brando/cache/palettes.ex
+++ b/lib/brando/cache/palettes.ex
@@ -3,6 +3,7 @@ defmodule Brando.Cache.Palettes do
   Interaction with palettes cache
   """
   alias Brando.Content
+  alias Brando.Cache
 
   @type changeset :: Ecto.Changeset.t()
 
@@ -11,16 +12,24 @@ defmodule Brando.Cache.Palettes do
   """
   @spec get_css :: binary() | nil
   def get_css do
-    case Cachex.get(:cache, :palettes_css) do
-      {:ok, css} -> css
-      css -> css
+    case Cache.get(:palettes_css) do
+      nil ->
+        set()
+        Cache.get(:palettes_css)
+
+      css ->
+        css
     end
   end
 
   def get do
-    case Cachex.get(:cache, :palettes) do
-      {:ok, palettes} -> palettes
-      palettes -> palettes
+    case Cache.get(:palettes) do
+      nil ->
+        set()
+        Cache.get(:palettes)
+
+      palettes ->
+        palettes
     end
   end
 
@@ -31,8 +40,11 @@ defmodule Brando.Cache.Palettes do
   def set do
     {:ok, palettes} = get_palettes()
     palettes_css = get_palettes_css(palettes)
-    Cachex.put(:cache, :palettes, palettes)
-    Cachex.put(:cache, :palettes_css, palettes_css)
+
+    with {:ok, true} <- Cache.put(:palettes, palettes, :infinite),
+         {:ok, true} <- Cache.put(:palettes_css, palettes_css, :infinite) do
+      {:ok, true}
+    end
   end
 
   @doc """
@@ -43,8 +55,8 @@ defmodule Brando.Cache.Palettes do
   def update({:ok, palette}) do
     {:ok, palettes} = get_palettes()
     palettes_css = get_palettes_css(palettes)
-    Cachex.put(:cache, :palettes, palettes)
-    Cachex.update(:cache, :palettes_css, palettes_css)
+    Cache.put(:palettes, palettes, :infinite)
+    Cache.update(:palettes_css, palettes_css)
     {:ok, palette}
   end
 

--- a/lib/brando/cache/query.ex
+++ b/lib/brando/cache/query.ex
@@ -8,9 +8,10 @@ defmodule Brando.Cache.Query do
   @doc """
   Hashes a query key into the canonical cache-key representation.
   """
-  @spec hash_query({atom(), binary(), term()}) :: {atom(), binary(), binary()}
+  @spec hash_query({atom(), binary(), term()}) :: term()
   def hash_query({query_type, query_name, _} = query_key) do
-    {query_type, query_name, Base.encode16(<<:erlang.phash2(Jason.encode!(query_key))::size(32)>>)}
+    key = {query_type, query_name, Base.encode16(<<:erlang.phash2(Jason.encode!(query_key))::size(32)>>)}
+    Brando.Tenant.cache_key(key)
   end
 
   @doc """
@@ -44,9 +45,14 @@ defmodule Brando.Cache.Query do
   def put(key, val, ttl \\ :timer.minutes(15))
   def put(key, val, ttl), do: @cache_module.put(:query, key, val, expire: ttl)
 
-  def put({:single, src, hash}, val, ttl, id), do: @cache_module.put(:query, {:single, src, hash, id}, val, expire: ttl)
+  def put({:single, src, hash}, val, ttl, id),
+    do: @cache_module.put(:query, {:single, src, hash, id}, val, expire: ttl)
+
+  def put({:tenant, prefix, {:single, src, hash}}, val, ttl, id),
+    do: @cache_module.put(:query, {:tenant, prefix, {:single, src, hash, id}}, val, expire: ttl)
 
   defp get_from_cache({:single, source, key}), do: find_single_entry(source, key)
+  defp get_from_cache({:tenant, prefix, {:single, source, key}}), do: find_single_entry(source, key, prefix)
   defp get_from_cache(key), do: @cache_module.get(:query, key)
 
   @spec evict({:ok, map()} | {:error, changeset}) :: {:ok, map()} | {:error, changeset}
@@ -89,7 +95,8 @@ defmodule Brando.Cache.Query do
 
   @spec perform_eviction(:list, binary()) :: [:ok]
   defp perform_eviction(:list, schema) do
-    ms = [{{:entry, {:list, schema, :_}, :_, :_, :_}, [], [:"$_"]}]
+    key_pattern = scoped_pattern({:list, schema, :_})
+    ms = [{{:entry, key_pattern, :_, :_, :_}, [], [:"$_"]}]
 
     :query
     |> Cachex.stream!(ms)
@@ -100,7 +107,8 @@ defmodule Brando.Cache.Query do
 
   @spec perform_eviction(:single, binary(), integer()) :: [:ok]
   defp perform_eviction(:single, schema, id) do
-    ms = [{{:entry, {:single, schema, :_, id}, :_, :_, :_}, [], [:"$_"]}]
+    key_pattern = scoped_pattern({:single, schema, :_, id})
+    ms = [{{:entry, key_pattern, :_, :_, :_}, [], [:"$_"]}]
 
     :query
     |> Cachex.stream!(ms)
@@ -109,8 +117,13 @@ defmodule Brando.Cache.Query do
     Cachex.Error -> :ok
   end
 
-  defp find_single_entry(source, key) do
-    ms = [{{:entry, {:single, source, key, :_}, :_, :_, :_}, [], [:"$_"]}]
+  defp find_single_entry(source, key, prefix \\ nil) do
+    key_pattern =
+      if prefix,
+        do: {:tenant, prefix, {:single, source, key, :_}},
+        else: {:single, source, key, :_}
+
+    ms = [{{:entry, key_pattern, :_, :_, :_}, [], [:"$_"]}]
 
     :query
     |> Cachex.stream!(ms)
@@ -119,6 +132,13 @@ defmodule Brando.Cache.Query do
     |> case do
       nil -> {:error, nil}
       entry -> {:ok, entry}
+    end
+  end
+
+  defp scoped_pattern(key_pattern) do
+    case Brando.Tenant.current_prefix() do
+      nil -> key_pattern
+      prefix -> {:tenant, prefix, key_pattern}
     end
   end
 end

--- a/lib/brando/cache/seo.ex
+++ b/lib/brando/cache/seo.ex
@@ -34,7 +34,7 @@ defmodule Brando.Cache.SEO do
   def set do
     {:ok, seos} = Sites.list_seos(%{preload: [:fallback_meta_image]})
     seo_map = process_seos(seos)
-    Cachex.put(:cache, :seo, seo_map)
+    Cache.put(:seo, seo_map, :infinite)
     seo_map
   end
 
@@ -46,7 +46,7 @@ defmodule Brando.Cache.SEO do
   def update({:ok, seo}) do
     {:ok, seos} = Sites.list_seos(%{preload: [:fallback_meta_image]})
     seo_map = process_seos(seos)
-    Cachex.update(:cache, :seo, seo_map)
+    Cache.update(:seo, seo_map)
     {:ok, seo}
   end
 

--- a/lib/brando/cdn/cdn.ex
+++ b/lib/brando/cdn/cdn.ex
@@ -162,12 +162,13 @@ defmodule Brando.CDN do
   def queue_upload(file_or_image, user, field_full_path \\ [])
 
   def queue_upload(%Brando.Files.File{} = file, user, field_full_path) do
-    args = %{
-      file_id: file.id,
-      config_target: file.config_target,
-      user_id: user.id,
-      field_full_path: field_full_path
-    }
+    args =
+      Brando.Tenant.Job.attach(%{
+        file_id: file.id,
+        config_target: file.config_target,
+        user_id: user.id,
+        field_full_path: field_full_path
+      })
 
     Brando.Repo.delete_all(
       from j in Oban.Job,
@@ -213,6 +214,8 @@ defmodule Brando.CDN do
   end
 
   defp create_image_upload_job(args) do
+    args = Brando.Tenant.Job.attach(args)
+
     Brando.Repo.delete_all(
       from j in Oban.Job,
         where: fragment("? @> ?", j.args, ^args)

--- a/lib/brando/content/blocks.ex
+++ b/lib/brando/content/blocks.ex
@@ -505,6 +505,7 @@ defmodule Brando.Content.Blocks do
   """
   def enqueue_entry_cascade(module, entry, identifier_id) do
     %{schema: to_string(module), entry_id: entry.id, identifier_id: identifier_id}
+    |> Brando.Tenant.Job.attach()
     |> Brando.Worker.EntryCascade.new()
     |> Oban.insert()
   end

--- a/lib/brando/content/render_queue.ex
+++ b/lib/brando/content/render_queue.ex
@@ -34,6 +34,7 @@ defmodule Brando.Content.RenderQueue do
     worker = @entry_renderer
 
     args
+    |> Brando.Tenant.Job.attach()
     |> worker.new(replace_args: true, tags: [:render_entry])
     |> Oban.insert()
   end

--- a/lib/brando/environments/schema_cloner/postgres.ex
+++ b/lib/brando/environments/schema_cloner/postgres.ex
@@ -19,7 +19,7 @@ defmodule Brando.Environments.SchemaCloner.Postgres do
          :ok <- validate_identifier(target_prefix),
          {:ok, dump} <- dump_schema(source_prefix),
          {:ok, rewritten_dump} <- rewrite_schema(dump, source_prefix, target_prefix),
-         :ok <- restore_schema(rewritten_dump) do
+         :ok <- restore_dump(rewritten_dump) do
       :ok
     end
   end
@@ -59,8 +59,10 @@ defmodule Brando.Environments.SchemaCloner.Postgres do
     String.starts_with?(line, "COPY ") and String.ends_with?(line, " FROM stdin;")
   end
 
-  defp dump_schema(prefix) do
-    with {:ok, executable} <- executable(:pg_dump_path, "pg_dump"),
+  @doc false
+  def dump_schema(prefix, extra_args \\ []) do
+    with :ok <- validate_identifier(prefix),
+         {:ok, executable} <- executable(:pg_dump_path, "pg_dump"),
          {output, 0} <-
            System.cmd(
              executable,
@@ -73,7 +75,7 @@ defmodule Brando.Environments.SchemaCloner.Postgres do
                  "--no-owner",
                  "--no-privileges",
                  "--quote-all-identifiers"
-               ],
+               ] ++ extra_args,
              env: connection_env(),
              stderr_to_stdout: true
            ) do
@@ -87,7 +89,8 @@ defmodule Brando.Environments.SchemaCloner.Postgres do
     end
   end
 
-  defp restore_schema(sql) do
+  @doc false
+  def restore_dump(sql) do
     with {:ok, executable} <- executable(:psql_path, "psql"),
          {:ok, path} <- write_temporary_dump(sql) do
       try do

--- a/lib/brando/images/crop.ex
+++ b/lib/brando/images/crop.ex
@@ -4,6 +4,7 @@ defmodule Brando.Images.Crop do
   """
 
   alias Brando.Images
+  alias Brando.Tenant.Storage
 
   @doc """
   Save a cropped image as a new copy.
@@ -81,7 +82,7 @@ defmodule Brando.Images.Crop do
   end
 
   defp write_and_measure(path, binary_data, fallback_dimensions) do
-    media_path = Brando.config(:media_path)
+    media_path = Storage.current_media_root()
     dest_file = Path.join(media_path, path)
 
     File.mkdir_p!(Path.dirname(dest_file))

--- a/lib/brando/images/operations.ex
+++ b/lib/brando/images/operations.ex
@@ -101,7 +101,7 @@ defmodule Brando.Images.Operations do
     operation_results =
       if max_concurrency > 1 do
         operations
-        |> Task.async_stream(&__MODULE__.resize_image/1,
+        |> Task.async_stream(Brando.Tenant.capture_context(&__MODULE__.resize_image/1),
           max_concurrency: max_concurrency,
           timeout: 60_000
         )

--- a/lib/brando/images/processing.ex
+++ b/lib/brando/images/processing.ex
@@ -5,6 +5,7 @@ defmodule Brando.Images.Processing do
   alias Brando.Images
   alias Brando.Images.Image
   alias Brando.Images.Operations
+  alias Brando.Tenant.Job, as: TenantJob
   alias Brando.Upload
   alias Brando.Users.User
   alias Brando.Worker
@@ -20,13 +21,14 @@ defmodule Brando.Images.Processing do
   Queue an image for processing
   """
   def queue_processing(image, user, field_full_path \\ [], opts \\ []) do
-    args = %{
-      image_id: image.id,
-      config_target: image.config_target,
-      user_id: user.id,
-      field_full_path: field_full_path,
-      silent: Keyword.get(opts, :silent, false)
-    }
+    args =
+      TenantJob.attach(%{
+        image_id: image.id,
+        config_target: image.config_target,
+        user_id: user.id,
+        field_full_path: field_full_path,
+        silent: Keyword.get(opts, :silent, false)
+      })
 
     Brando.Repo.delete_all(
       from j in Oban.Job,
@@ -54,13 +56,14 @@ defmodule Brando.Images.Processing do
   """
   def processing_queued?(%{id: image_id}) when not is_nil(image_id) do
     worker = Oban.Worker.to_string(Worker.ImageProcessor)
+    args = TenantJob.attach(%{image_id: image_id})
 
     query =
       from j in Oban.Job,
         where:
           j.worker == ^worker and
             j.state in ^@unfinished_states and
-            fragment("? @> ?", j.args, ^%{image_id: image_id}),
+            fragment("? @> ?", j.args, ^args),
         select: true,
         limit: 1
 

--- a/lib/brando/images/utils.ex
+++ b/lib/brando/images/utils.ex
@@ -6,6 +6,7 @@ defmodule Brando.Images.Utils do
   import SweetXml
 
   alias Brando.Images.Image
+  alias Brando.Tenant.Storage
 
   @type id :: binary | integer
   @type image_struct :: Brando.Images.Image.t()
@@ -66,7 +67,7 @@ defmodule Brando.Images.Utils do
     if String.ends_with?(file, ".svg") do
       nil
     else
-      file = Path.join([Brando.config(:media_path), file])
+      file = Path.join(Storage.current_media_root(), file)
       File.rm(file)
     end
   end
@@ -164,7 +165,7 @@ defmodule Brando.Images.Utils do
 
   @spec media_path() :: binary
   @spec media_path(nil | binary) :: binary
-  def media_path, do: Brando.config(:media_path)
-  def media_path(nil), do: Brando.config(:media_path)
-  def media_path(file), do: Path.join([Brando.config(:media_path), file])
+  def media_path, do: Storage.current_media_root()
+  def media_path(nil), do: Storage.current_media_root()
+  def media_path(file), do: Path.join(Storage.current_media_root(), file)
 end

--- a/lib/brando/live_preview.ex
+++ b/lib/brando/live_preview.ex
@@ -391,6 +391,7 @@ defmodule Brando.LivePreview do
     {:ok, preview} = Brando.Sites.create_preview(preview, user)
 
     %{id: preview.id}
+    |> Brando.Tenant.Job.attach()
     |> Worker.PreviewPurger.new(scheduled_at: expires_at, tags: [:preview_purger])
     |> Oban.insert()
 

--- a/lib/brando/media/orphan_cleanup.ex
+++ b/lib/brando/media/orphan_cleanup.ex
@@ -21,6 +21,7 @@ defmodule Brando.Media.OrphanCleanup do
   alias Brando.Sites.Site
   alias Brando.Tenant
   alias Brando.Tenant.Registry
+  alias Brando.Tenant.Storage
 
   @managed_directories ~w(images videos files)
   @default_grace_seconds :timer.hours(24) |> div(1_000)
@@ -71,7 +72,7 @@ defmodule Brando.Media.OrphanCleanup do
   @spec media_root(Site.t()) :: String.t()
   def media_root(%Site{} = site) do
     case Tenant.mode() do
-      :multi -> Path.join(Brando.config(:media_path), site.key)
+      :multi -> Storage.media_root(site)
       _single_or_none -> Brando.config(:media_path)
     end
   end

--- a/lib/brando/plug/admin_tenant.ex
+++ b/lib/brando/plug/admin_tenant.ex
@@ -13,7 +13,7 @@ defmodule Brando.Plug.AdminTenant do
 
   @impl Plug
   def call(conn, _opts) do
-    case AdminContext.resolve(%{}, get_session(conn)) do
+    case AdminContext.resolve(%{}, get_session(conn), conn.assigns[:current_user]) do
       {site, environment} ->
         prefix = Tenant.prefix(site, environment)
         Tenant.put_prefix(prefix)

--- a/lib/brando/plug/site_assets.ex
+++ b/lib/brando/plug/site_assets.ex
@@ -1,0 +1,60 @@
+defmodule Brando.Plug.SiteAssets do
+  @moduledoc """
+  Serves files from the active persistent frontend asset set.
+
+  Place this plug before the application's release `Plug.Static`. A cached
+  `MapSet` rejects misses without touching the filesystem; misses fall through
+  unchanged so release assets remain the fallback.
+  """
+
+  import Plug.Conn, only: [halt: 1, put_resp_header: 3, send_file: 3]
+
+  alias Brando.Assets.SiteAssets
+  alias Brando.Tenant.Frontend
+
+  @behaviour Plug
+  @allowed_methods ~w(GET HEAD)
+
+  @impl Plug
+  def init(opts), do: opts
+
+  @impl Plug
+  def call(%Plug.Conn{method: method} = conn, _opts) when method in @allowed_methods do
+    with {:ok, site} <- request_scope(conn),
+         %{files: files, path: root} <- SiteAssets.cached(site),
+         relative_path when is_binary(relative_path) <- relative_path(conn.path_info),
+         true <- MapSet.member?(files, relative_path) do
+      conn
+      |> put_resp_header("cache-control", "public, max-age=31536000, immutable")
+      |> send_file(200, Path.join(root, relative_path))
+      |> halt()
+    else
+      _miss -> conn
+    end
+  end
+
+  def call(conn, _opts), do: conn
+
+  defp request_scope(conn) do
+    case Brando.Tenant.mode() do
+      :multi ->
+        case Frontend.resolve(conn.host) do
+          {site, _environment} -> {:ok, site}
+          nil -> :error
+        end
+
+      _standalone ->
+        {:ok, nil}
+    end
+  end
+
+  defp relative_path(path_info) do
+    decoded = Enum.map(path_info, &URI.decode/1)
+
+    if decoded == [] or Enum.any?(decoded, &(&1 in ["", ".", ".."] or String.contains?(&1, ["/", "\\"]))) do
+      nil
+    else
+      Path.join(decoded)
+    end
+  end
+end

--- a/lib/brando/plug/tenant.ex
+++ b/lib/brando/plug/tenant.ex
@@ -5,13 +5,14 @@ defmodule Brando.Plug.Tenant do
   Multi-site requests resolve by normalized host through `Brando.Tenant.Cache`.
   Single-site mode falls back to the configured site's live environment when no
   domain is assigned. Unknown hosts clear process context instead of inheriting
-  stale state.
+  stale state. In multi-site mode they are rejected so an application cannot
+  accidentally serve unscoped or another tenant's content.
   """
 
-  import Plug.Conn, only: [assign: 3]
+  import Plug.Conn, only: [assign: 3, halt: 1, send_resp: 3]
 
   alias Brando.Tenant
-  alias Brando.Tenant.Cache
+  alias Brando.Tenant.Frontend
 
   @behaviour Plug
 
@@ -20,7 +21,7 @@ defmodule Brando.Plug.Tenant do
 
   @impl Plug
   def call(conn, _opts) do
-    case resolve(conn.host) do
+    case Frontend.resolve(conn.host) do
       {site, environment} ->
         prefix = Tenant.prefix(site, environment)
         Tenant.put_prefix(prefix)
@@ -32,26 +33,17 @@ defmodule Brando.Plug.Tenant do
 
       nil ->
         Tenant.put_prefix(nil)
-        conn
+        reject_missing_multi_site(conn)
     end
   end
 
-  defp resolve(host) do
-    if Tenant.enabled?() do
-      Cache.get_env_by_domain(host) || resolve_single_site()
-    end
-  end
-
-  defp resolve_single_site do
-    if Tenant.mode() == :single do
-      site_key = Brando.config(:site_key)
-
-      with site when not is_nil(site) <- Cache.get_site(site_key),
-           environment when not is_nil(environment) <- Cache.get_live_env(site_key) do
-        {site, environment}
-      else
-        _ -> nil
-      end
+  defp reject_missing_multi_site(conn) do
+    if Tenant.mode() == :multi do
+      conn
+      |> send_resp(404, "Not found")
+      |> halt()
+    else
+      conn
     end
   end
 end

--- a/lib/brando/plugs/media.ex
+++ b/lib/brando/plugs/media.ex
@@ -1,6 +1,9 @@
 defmodule Brando.Plug.Media do
-  @moduledoc false
+  @moduledoc "Serves media from the host's isolated site directory in multi-site mode."
   import Plug.Conn
+
+  alias Brando.Tenant.Frontend
+  alias Brando.Tenant.Storage
 
   def init(opts) do
     static_opts = [
@@ -19,7 +22,7 @@ defmodule Brando.Plug.Media do
         conn
 
       _path_match ->
-        conn = Plug.Static.call(conn, opts)
+        conn = Plug.Static.call(conn, media_opts(conn, opts))
 
         if conn.state in [:sent, :file] do
           conn
@@ -28,6 +31,19 @@ defmodule Brando.Plug.Media do
           |> send_resp(404, "not found")
           |> halt()
         end
+    end
+  end
+
+  defp media_opts(conn, opts) do
+    case Brando.Tenant.mode() do
+      :multi ->
+        case Frontend.resolve(conn.host) do
+          {site, _environment} -> Map.put(opts, :from, Storage.media_root(site))
+          nil -> Map.put(opts, :from, Path.join(Brando.config(:media_path), "__unresolved_tenant__"))
+        end
+
+      _single_or_none ->
+        opts
     end
   end
 

--- a/lib/brando/publisher.ex
+++ b/lib/brando/publisher.ex
@@ -7,6 +7,7 @@ defmodule Brando.Publisher do
   alias Brando.Blueprint.Identifier
   alias Brando.Repo
   alias Brando.Revisions
+  alias Brando.Tenant.Job, as: TenantJob
   alias Brando.Users.User
   alias Brando.Worker
   alias Ecto.Changeset
@@ -30,7 +31,9 @@ defmodule Brando.Publisher do
       # the publishing date is in the past, just leave it
       {:ok, entry}
     else
-      args = %{schema: schema, id: id, user_id: user_id(user), status: :published}
+      args =
+        TenantJob.attach(%{schema: schema, id: id, user_id: user_id(user), status: :published})
+
       entry_identifier = Identifier.identifier_for(entry)
 
       Repo.delete_all(
@@ -71,12 +74,13 @@ defmodule Brando.Publisher do
            false <- revision.active,
            :ok <- cancel_revision_job(schema, id, revision_number),
            {1, _} <- Revisions.mark_revision_scheduled(schema, id, revision_number, true),
-           args = %{
-             schema: to_string(schema),
-             id: id,
-             revision: revision_number,
-             user_id: user_id(user)
-           },
+           args =
+             TenantJob.attach(%{
+               schema: to_string(schema),
+               id: id,
+               revision: revision_number,
+               user_id: user_id(user)
+             }),
            revision_identifier =
              decoded_entry
              |> Identifier.identifier_for()
@@ -100,7 +104,7 @@ defmodule Brando.Publisher do
       meta: %{identifier: job_identifier(revision_identifier)},
       unique: [
         fields: [:worker, :args],
-        keys: [:schema, :id, :revision],
+        keys: [:tenant_prefix, :schema, :id, :revision],
         period: :infinity,
         states: :incomplete
       ]
@@ -131,12 +135,13 @@ defmodule Brando.Publisher do
   @doc "Cancel all revision publishing jobs for an entry."
   def cancel_revision_jobs(schema, id) do
     schema = to_string(schema)
+    args = Map.merge(%{"schema" => schema, "id" => id}, TenantJob.context_fragment())
 
     from(j in Oban.Job,
       where:
         j.worker == ^inspect(Worker.EntryPublisher) and
           j.state in ["available", "scheduled", "executing", "retryable"] and
-          fragment("? @> ?", j.args, ^%{"schema" => schema, "id" => id})
+          fragment("? @> ?", j.args, ^args)
     )
     |> Oban.cancel_all_jobs()
 
@@ -146,19 +151,17 @@ defmodule Brando.Publisher do
   defp cancel_revision_job(schema, id, revision_number) do
     schema = to_string(schema)
 
+    args =
+      Map.merge(
+        %{"schema" => schema, "id" => id, "revision" => revision_number},
+        TenantJob.context_fragment()
+      )
+
     from(j in Oban.Job,
       where:
         j.worker == ^inspect(Worker.EntryPublisher) and
           j.state in ["available", "scheduled", "executing", "retryable"] and
-          fragment(
-            "? @> ?",
-            j.args,
-            ^%{
-              "schema" => schema,
-              "id" => id,
-              "revision" => revision_number
-            }
-          )
+          fragment("? @> ?", j.args, ^args)
     )
     |> Oban.cancel_all_jobs()
 
@@ -229,22 +232,28 @@ defmodule Brando.Publisher do
   end
 
   def list_jobs do
+    context = TenantJob.context_fragment()
+
     query =
       from j in Oban.Job,
-        where: "publisher" in j.tags,
+        where: "publisher" in j.tags and fragment("? @> ?", j.args, ^context),
         order_by: j.scheduled_at
 
     {:ok, Repo.all(query)}
   end
 
   def delete_job(id) do
+    context = TenantJob.context_fragment()
+
     with {:ok, id} <- cast_entry_id(id),
          %Oban.Job{} = job <- Repo.get(Oban.Job, id),
+         true <- map_size(context) == 0 or Map.take(job.args, Map.keys(context)) == context,
          :ok <- Oban.cancel_job(job) do
       clear_revision_schedule(job)
       Repo.delete_all(from j in Oban.Job, where: j.id == ^id)
     else
       nil -> {0, nil}
+      false -> {0, nil}
       {:error, _reason} = error -> error
     end
   end

--- a/lib/brando/repo.ex
+++ b/lib/brando/repo.ex
@@ -163,7 +163,8 @@ defmodule Brando.Repo do
   defp public_source?(_source), do: false
 
   defp public_schema?(schema) do
-    Code.ensure_loaded?(schema) and function_exported?(schema, :__schema__, 1) and
-      schema.__schema__(:prefix) == "public"
+    schema == Oban.Job or
+      (Code.ensure_loaded?(schema) and function_exported?(schema, :__schema__, 1) and
+         schema.__schema__(:prefix) == "public")
   end
 end

--- a/lib/brando/router.ex
+++ b/lib/brando/router.ex
@@ -99,6 +99,7 @@ defmodule Brando.Router do
                 {Brando.Tenant.LiveView, :default}
               ] do
           # brando routes
+          live "/sites", BrandoAdmin.Sites.SiteLive
           live "/assets/images", BrandoAdmin.Images.ImageListLive
           live "/assets/images/update/:entry_id", BrandoAdmin.Images.ImageFormLive, :update
           live "/assets/videos", BrandoAdmin.Videos.VideoListLive

--- a/lib/brando/router.ex
+++ b/lib/brando/router.ex
@@ -112,6 +112,7 @@ defmodule Brando.Router do
           live "/assets/files", BrandoAdmin.Files.FileListLive
 
           scope "/config" do
+            live "/assets", BrandoAdmin.Sites.AssetLive
             live "/environments", BrandoAdmin.Sites.EnvironmentLive
             live "/cache", BrandoAdmin.Sites.CacheLive
             live "/global_sets", BrandoAdmin.Sites.GlobalSetListLive

--- a/lib/brando/sitemap.ex
+++ b/lib/brando/sitemap.ex
@@ -89,7 +89,7 @@ defmodule Brando.Sitemap do
     sitemap_functions = sitemap_module.__info__(:functions)
     entries = Stream.flat_map(sitemap_functions, &apply(sitemap_module, elem(&1, 0), []))
 
-    sitemap_path = Path.join([Brando.config(:media_path), "sitemaps"])
+    sitemap_path = Path.join([Brando.Tenant.Storage.current_media_root(), "sitemaps"])
     File.mkdir_p!(sitemap_path)
 
     default_opts = [

--- a/lib/brando/sites/four_oh_four.ex
+++ b/lib/brando/sites/four_oh_four.ex
@@ -1,21 +1,34 @@
 defmodule Brando.Sites.FourOhFour do
   @moduledoc false
   def add_404(conn) do
-    Cachex.incr(:four_oh_four, Path.join(["/" | conn.path_info]), 1)
+    key = Path.join(["/" | conn.path_info]) |> Brando.Tenant.cache_key()
+    Cachex.incr(:four_oh_four, key, 1)
     conn
   end
 
   def list do
+    current_prefix = Brando.Tenant.current_prefix()
+
     :four_oh_four
     |> Cachex.stream!()
-    |> Enum.map(fn {:entry, url, hits, timestamp, _} ->
+    |> Enum.filter(fn {:entry, key, _hits, _timestamp, _} ->
+      matches_prefix?(key, current_prefix)
+    end)
+    |> Enum.map(fn {:entry, key, hits, timestamp, _} ->
       last_hit_at =
         timestamp
         |> DateTime.from_unix!(:millisecond)
         |> Brando.Utils.Datetime.format_datetime("%d/%m/%y, %H:%M")
 
-      %{url: url, hits: hits, last_hit_at: last_hit_at}
+      %{url: unwrap_key(key), hits: hits, last_hit_at: last_hit_at}
     end)
     |> Enum.sort(&(&1.hits >= &2.hits))
   end
+
+  defp matches_prefix?({:tenant, prefix, _key}, prefix), do: true
+  defp matches_prefix?(key, nil) when not is_tuple(key), do: true
+  defp matches_prefix?(_key, _prefix), do: false
+
+  defp unwrap_key({:tenant, _prefix, key}), do: key
+  defp unwrap_key(key), do: key
 end

--- a/lib/brando/sites/site.ex
+++ b/lib/brando/sites/site.ex
@@ -30,6 +30,7 @@ defmodule Brando.Sites.Site do
     field :languages, {:array, :string}, default: []
     field :default_language, :string
     field :status, Ecto.Enum, values: @statuses, default: :active
+    field :archived_at, :utc_datetime_usec
     field :delivery_mode, Ecto.Enum, values: @delivery_modes, default: :dynamic
 
     embeds_one :deploy_config, DeployConfig, on_replace: :update
@@ -40,10 +41,11 @@ defmodule Brando.Sites.Site do
   end
 
   @required_fields [:name, :key, :languages, :default_language, :status, :delivery_mode]
+  @optional_fields [:archived_at]
 
   def changeset(site \\ %__MODULE__{}, attrs) do
     site
-    |> cast(attrs, @required_fields)
+    |> cast(attrs, @required_fields ++ @optional_fields)
     |> cast_embed(:deploy_config, with: &DeployConfig.changeset/2)
     |> validate_required(@required_fields)
     |> validate_length(:name, min: 1)

--- a/lib/brando/system.ex
+++ b/lib/brando/system.ex
@@ -11,12 +11,19 @@ defmodule Brando.System do
   def initialize do
     run_checks()
     Brando.Tenant.Cache.warm()
-    Cache.Identity.set()
-    Cache.SEO.set()
-    Cache.Globals.set()
-    Cache.Navigation.set()
-    Cache.Palettes.set()
+    Brando.Assets.SiteAssets.warm()
+    initialize_content_caches()
     :ok
+  end
+
+  defp initialize_content_caches do
+    unless Brando.Tenant.enabled?() do
+      Cache.Identity.set()
+      Cache.SEO.set()
+      Cache.Globals.set()
+      Cache.Navigation.set()
+      Cache.Palettes.set()
+    end
   end
 
   def run_checks do

--- a/lib/brando/tenant.ex
+++ b/lib/brando/tenant.ex
@@ -95,6 +95,19 @@ defmodule Brando.Tenant do
     end
   end
 
+  @doc "Captures the current tenant context for work that will run in another process."
+  @spec capture_context((-> result)) :: (-> result) when result: var
+  def capture_context(fun) when is_function(fun, 0) do
+    prefix = current_prefix()
+    fn -> run_captured(prefix, fun) end
+  end
+
+  @spec capture_context((arg -> result)) :: (arg -> result) when arg: var, result: var
+  def capture_context(fun) when is_function(fun, 1) do
+    prefix = current_prefix()
+    fn arg -> run_captured(prefix, fn -> fun.(arg) end) end
+  end
+
   @spec validate_config!() :: :ok
   def validate_config! do
     case mode() do
@@ -106,6 +119,9 @@ defmodule Brando.Tenant do
   @spec valid_key?(term()) :: boolean()
   def valid_key?(key), do: is_binary(key) and Regex.match?(@key_format, key)
 
+  @spec valid_prefix?(term()) :: boolean()
+  def valid_prefix?(prefix), do: is_binary(prefix) and Regex.match?(@prefix_format, prefix)
+
   defp validate_single_site_key! do
     case Brando.config(:site_key) do
       site_key when is_binary(site_key) ->
@@ -115,6 +131,9 @@ defmodule Brando.Tenant do
         raise_invalid_site_key(site_key)
     end
   end
+
+  defp run_captured(nil, fun), do: fun.()
+  defp run_captured(prefix, fun), do: with_prefix(prefix, fun)
 
   defp raise_invalid_mode(mode) do
     raise ConfigError,

--- a/lib/brando/tenant.ex
+++ b/lib/brando/tenant.ex
@@ -49,6 +49,27 @@ defmodule Brando.Tenant do
     if enabled?(), do: Process.get(@process_prefix_key), else: nil
   end
 
+  @doc "Returns the site key encoded in the current tenant prefix."
+  @spec current_site_key() :: String.t() | nil
+  def current_site_key do
+    case current_prefix() do
+      "tenant_" <> remainder ->
+        case String.split(remainder, "_", parts: 2) do
+          [site_key, _environment_key] -> site_key
+          _invalid -> nil
+        end
+
+      _no_prefix ->
+        nil
+    end
+  end
+
+  @doc "Namespaces an application cache key by the active tenant prefix."
+  @spec cache_key(term(), String.t() | nil) :: term()
+  def cache_key(key, prefix \\ current_prefix()) do
+    if is_binary(prefix), do: {:tenant, prefix, key}, else: key
+  end
+
   @spec put_prefix(String.t() | nil) :: String.t() | nil
   def put_prefix(nil) do
     Process.delete(@process_prefix_key)

--- a/lib/brando/tenant/access.ex
+++ b/lib/brando/tenant/access.ex
@@ -1,0 +1,107 @@
+defmodule Brando.Tenant.Access do
+  @moduledoc """
+  Authorization boundary for entering and managing site tenants.
+
+  A global superuser may access every active site. Other users require a
+  `Brando.Users.UserSite` assignment and receive the role stored on that
+  assignment. Suspended and archived sites are not enterable, even through a
+  stale signed session.
+  """
+
+  import Ecto.Query, only: [from: 2]
+
+  alias Brando.Repo
+  alias Brando.Sites.Site
+  alias Brando.Users.User
+  alias Brando.Users.UserSite
+
+  @public_opts [prefix: "public"]
+
+  @spec list_sites(User.t() | nil) :: [Site.t()]
+  def list_sites(%User{role: :superuser}) do
+    from(site in Site,
+      where: site.status == :active,
+      order_by: [asc: site.name, asc: site.id],
+      preload: [:environments]
+    )
+    |> Repo.all(@public_opts)
+  end
+
+  def list_sites(%User{id: user_id}) do
+    from(site in Site,
+      join: user_site in UserSite,
+      on: user_site.site_id == site.id,
+      where: user_site.user_id == ^user_id and site.status == :active,
+      order_by: [asc: site.name, asc: site.id],
+      preload: [:environments]
+    )
+    |> Repo.all(@public_opts)
+  end
+
+  def list_sites(nil), do: []
+
+  @spec role_for(User.t(), Site.t()) :: :superuser | :admin | :editor | nil
+  def role_for(%User{role: :superuser}, %Site{status: :active}), do: :superuser
+
+  def role_for(%User{id: user_id}, %Site{id: site_id, status: :active}) do
+    from(user_site in UserSite,
+      where: user_site.user_id == ^user_id and user_site.site_id == ^site_id,
+      select: user_site.role
+    )
+    |> Repo.one(@public_opts)
+  end
+
+  def role_for(%User{}, %Site{}), do: nil
+
+  @spec can_access?(User.t() | nil, Site.t()) :: boolean()
+  def can_access?(%User{} = user, %Site{} = site), do: not is_nil(role_for(user, site))
+  def can_access?(nil, %Site{}), do: false
+
+  @spec can_manage?(User.t() | nil, Site.t()) :: boolean()
+  def can_manage?(%User{} = user, %Site{} = site), do: role_for(user, site) in [:admin, :superuser]
+  def can_manage?(nil, %Site{}), do: false
+
+  @spec grant(User.t(), Site.t(), :editor | :admin) ::
+          {:ok, UserSite.t()} | {:error, Ecto.Changeset.t()}
+  def grant(%User{} = user, %Site{} = site, role) when role in [:editor, :admin] do
+    case get_assignment(user, site) do
+      nil -> %UserSite{user_id: user.id, site_id: site.id}
+      assignment -> assignment
+    end
+    |> UserSite.changeset(%{role: role})
+    |> then(fn changeset ->
+      if changeset.data.id, do: Repo.update(changeset, @public_opts), else: Repo.insert(changeset, @public_opts)
+    end)
+  end
+
+  @spec revoke(User.t(), Site.t()) :: :ok | {:error, Ecto.Changeset.t()}
+  def revoke(%User{} = user, %Site{} = site) do
+    case get_assignment(user, site) do
+      nil ->
+        :ok
+
+      assignment ->
+        case Repo.delete(assignment, @public_opts) do
+          {:ok, _deleted} -> :ok
+          {:error, changeset} -> {:error, changeset}
+        end
+    end
+  end
+
+  @spec list_assignments(Site.t()) :: [UserSite.t()]
+  def list_assignments(%Site{id: site_id}) do
+    from(user_site in UserSite,
+      where: user_site.site_id == ^site_id,
+      order_by: [asc: user_site.id],
+      preload: [:user]
+    )
+    |> Repo.all(@public_opts)
+  end
+
+  defp get_assignment(%User{id: user_id}, %Site{id: site_id}) do
+    from(user_site in UserSite,
+      where: user_site.user_id == ^user_id and user_site.site_id == ^site_id
+    )
+    |> Repo.one(@public_opts)
+  end
+end

--- a/lib/brando/tenant/admin_context.ex
+++ b/lib/brando/tenant/admin_context.ex
@@ -2,20 +2,22 @@ defmodule Brando.Tenant.AdminContext do
   @moduledoc false
 
   alias Brando.Tenant
+  alias Brando.Tenant.Access
   alias Brando.Tenant.Cache
+  alias Brando.Users.User
 
   @site_session_key "brando_site_key"
   @environment_session_key "brando_environment_key"
 
-  @spec resolve(map() | :not_mounted_at_router, map()) ::
+  @spec resolve(map() | :not_mounted_at_router, map(), User.t() | nil) ::
           {Brando.Sites.Site.t(), Brando.Environments.Environment.t()} | nil
-  def resolve(params, session) do
+  def resolve(params, session, current_user \\ nil) do
     if Tenant.enabled?() do
       params = if is_map(params), do: params, else: %{}
-      site_key = selected_site_key(params, session)
+      site = selected_site(params, session, current_user)
       environment_key = params[@environment_session_key] || session[@environment_session_key]
 
-      with site when not is_nil(site) <- Cache.get_site(site_key),
+      with site when not is_nil(site) <- site,
            environment when not is_nil(environment) <-
              selected_environment(site.key, environment_key) do
         {site, environment}
@@ -25,19 +27,38 @@ defmodule Brando.Tenant.AdminContext do
     end
   end
 
-  defp selected_site_key(params, session) do
+  defp selected_site(params, session, current_user) do
     case Tenant.mode() do
-      :single -> Brando.config(:site_key)
-      :multi -> params[@site_session_key] || session[@site_session_key] || default_multi_site_key()
+      :single -> Cache.get_site(Brando.config(:site_key))
+      :multi -> selected_multi_site(params, session, current_user)
     end
   end
 
-  defp default_multi_site_key do
-    Cache.list_sites()
-    |> Enum.find(&(&1.status == :active))
+  defp selected_multi_site(params, session, %User{} = current_user) do
+    requested_site =
+      case params[@site_session_key] || session[@site_session_key] do
+        nil -> nil
+        site_key -> Cache.get_site(site_key)
+      end
+
+    case requested_site do
+      site when not is_nil(site) ->
+        if Access.can_access?(current_user, site), do: site, else: default_multi_site(current_user)
+
+      nil ->
+        default_multi_site(current_user)
+    end
+  end
+
+  defp selected_multi_site(_params, _session, nil), do: nil
+
+  defp default_multi_site(current_user) do
+    current_user
+    |> Access.list_sites()
+    |> List.first()
     |> case do
       nil -> nil
-      site -> site.key
+      site -> Cache.get_site(site.key)
     end
   end
 

--- a/lib/brando/tenant/cache.ex
+++ b/lib/brando/tenant/cache.ex
@@ -89,9 +89,17 @@ defmodule Brando.Tenant.Cache do
         by_key = [{{:brando, :env, site.key, environment.key}, environment}]
 
         by_domain =
-          if environment.domain, do: [{{:brando, :env_domain, environment.domain}, {site, environment}}], else: []
+          if site.status == :active and environment.domain do
+            domain = environment.domain |> String.trim() |> String.downcase()
+            [{{:brando, :env_domain, domain}, {site, environment}}]
+          else
+            []
+          end
 
-        live = if environment.live, do: [{{:brando, :live_env, site.key}, environment}], else: []
+        live =
+          if site.status == :active and environment.live,
+            do: [{{:brando, :live_env, site.key}, environment}],
+            else: []
 
         by_key ++ by_domain ++ live
       end)

--- a/lib/brando/tenant/frontend.ex
+++ b/lib/brando/tenant/frontend.ex
@@ -1,0 +1,27 @@
+defmodule Brando.Tenant.Frontend do
+  @moduledoc false
+
+  alias Brando.Tenant
+  alias Brando.Tenant.Cache
+
+  @spec resolve(String.t()) ::
+          {Brando.Sites.Site.t(), Brando.Environments.Environment.t()} | nil
+  def resolve(host) do
+    if Tenant.enabled?() do
+      Cache.get_env_by_domain(host) || resolve_single_site()
+    end
+  end
+
+  defp resolve_single_site do
+    if Tenant.mode() == :single do
+      site_key = Brando.config(:site_key)
+
+      with site when not is_nil(site) <- Cache.get_site(site_key),
+           environment when not is_nil(environment) <- Cache.get_live_env(site_key) do
+        {site, environment}
+      else
+        _ -> nil
+      end
+    end
+  end
+end

--- a/lib/brando/tenant/job.ex
+++ b/lib/brando/tenant/job.ex
@@ -1,0 +1,77 @@
+defmodule Brando.Tenant.Job do
+  @moduledoc """
+  Carries tenant context across background-job process boundaries.
+
+  Oban serializes jobs in the shared `public` schema and executes them in a new
+  process. The process-local prefix used by requests and LiveViews must
+  therefore be copied into tenant-owned job arguments and restored before the
+  worker touches content or media.
+  """
+
+  alias Brando.Tenant
+  alias Brando.Tenant.Registry
+
+  @prefix_key "tenant_prefix"
+
+  @doc "Adds the current tenant prefix to job arguments when tenancy is enabled."
+  @spec attach(map()) :: map()
+  def attach(args) when is_map(args) do
+    case {Tenant.mode(), Tenant.current_prefix()} do
+      {:none, nil} -> args
+      {_enabled_mode, prefix} when is_binary(prefix) -> Map.put(args, @prefix_key, prefix)
+      {_enabled_mode, nil} -> raise ArgumentError, "tenant-owned jobs require a current tenant prefix"
+    end
+  end
+
+  @doc "Runs a tenant-owned job under the prefix captured when it was enqueued."
+  @spec run(Oban.Job.t() | map(), (-> result)) :: result | {:cancel, atom()} when result: var
+  def run(%Oban.Job{args: args}, fun), do: run(args, fun)
+
+  def run(args, fun) when is_map(args) and is_function(fun, 0) do
+    case {Tenant.mode(), prefix_from(args)} do
+      {:none, _prefix} ->
+        fun.()
+
+      {_enabled_mode, prefix} when is_binary(prefix) ->
+        if Tenant.valid_prefix?(prefix),
+          do: Tenant.with_prefix(prefix, fun),
+          else: {:cancel, :invalid_tenant_prefix}
+
+      {_enabled_mode, nil} ->
+        {:cancel, :missing_tenant_prefix}
+    end
+  end
+
+  @doc "Runs a function once per environment belonging to every active site."
+  @spec each_active_environment(:all | :live, (-> result)) :: [result] when result: var
+  def each_active_environment(scope, fun)
+      when scope in [:all, :live] and is_function(fun, 0) do
+    if Tenant.enabled?() do
+      Registry.list_sites()
+      |> Enum.filter(&(&1.status == :active))
+      |> Enum.flat_map(fn site ->
+        site.environments
+        |> select_environments(scope)
+        |> Enum.map(fn environment ->
+          site
+          |> Tenant.prefix(environment)
+          |> Tenant.with_prefix(fun)
+        end)
+      end)
+    else
+      [fun.()]
+    end
+  end
+
+  @doc "Returns the current job-argument fragment used to scope shared Oban queries."
+  @spec context_fragment() :: map()
+  def context_fragment do
+    %{}
+    |> attach()
+    |> Map.take([@prefix_key])
+  end
+
+  defp prefix_from(args), do: Map.get(args, @prefix_key) || Map.get(args, :tenant_prefix)
+  defp select_environments(environments, :all), do: environments
+  defp select_environments(environments, :live), do: Enum.filter(environments, & &1.live)
+end

--- a/lib/brando/tenant/live_view.ex
+++ b/lib/brando/tenant/live_view.ex
@@ -14,7 +14,7 @@ defmodule Brando.Tenant.LiveView do
   alias Brando.Tenant.AdminContext
 
   def on_mount(:default, params, session, socket) do
-    case resolve_context(params, session) do
+    case resolve_context(params, session, socket.assigns[:current_user]) do
       {site, environment} ->
         prefix = Tenant.prefix(site, environment)
         Tenant.put_prefix(prefix)
@@ -43,7 +43,9 @@ defmodule Brando.Tenant.LiveView do
   end
 
   @doc false
-  defdelegate resolve_context(params, session), to: AdminContext, as: :resolve
+  def resolve_context(params, session, current_user \\ nil) do
+    AdminContext.resolve(params, session, current_user)
+  end
 
   defp attach_context_hooks(socket) do
     socket

--- a/lib/brando/tenant/lock.ex
+++ b/lib/brando/tenant/lock.ex
@@ -1,0 +1,31 @@
+defmodule Brando.Tenant.Lock do
+  @moduledoc false
+
+  alias Brando.Repo
+
+  @spec with(String.t(), (-> result)) :: result when result: var
+  def with(key, fun) when is_binary(key) and is_function(fun, 0) do
+    repo = Repo.repo()
+
+    repo.checkout(
+      fn ->
+        Ecto.Adapters.SQL.query!(
+          repo,
+          "SELECT pg_advisory_lock(hashtextextended($1, 0))",
+          [key]
+        )
+
+        try do
+          fun.()
+        after
+          Ecto.Adapters.SQL.query!(
+            repo,
+            "SELECT pg_advisory_unlock(hashtextextended($1, 0))",
+            [key]
+          )
+        end
+      end,
+      timeout: :infinity
+    )
+  end
+end

--- a/lib/brando/tenant/migration.ex
+++ b/lib/brando/tenant/migration.ex
@@ -1,0 +1,63 @@
+defmodule Brando.Tenant.Migration do
+  @moduledoc "Migrates an existing public-schema installation into a new site."
+
+  alias Brando.Environments
+  alias Brando.Sites.Site
+  alias Brando.Tenant
+  alias Brando.Tenant.Registry
+  alias Brando.Tenant.Setup
+  alias Brando.Users.User
+
+  @production %{name: "Production", key: "production", live: true}
+  @staging %{name: "Staging", key: "staging", live: false}
+
+  @spec migrate_public(map(), User.t(), keyword()) :: {:ok, Site.t()} | {:error, term()}
+  def migrate_public(attrs, %User{} = creator, opts \\ []) do
+    setup_opts = [environments: [@production], seed: false]
+
+    with {:ok, site} <- Setup.create_site(attrs, creator, setup_opts) do
+      case migrate_and_create_staging(site, creator, opts) do
+        {:ok, migrated_site} ->
+          {:ok, migrated_site}
+
+        {:error, reason} ->
+          cleanup = cleanup_failed_site(site)
+          {:error, {:public_migration_failed, reason, cleanup}}
+      end
+    end
+  end
+
+  defp migrate_and_create_staging(site, creator, opts) do
+    production = Registry.get_environment_by_key(site, "production")
+    prefix = Tenant.prefix(site, production)
+    migrator = Keyword.get(opts, :public_data_migrator, configured_migrator())
+    media_migrator = Keyword.get(opts, :public_media_migrator, configured_media_migrator())
+
+    with :ok <- migrator.migrate("public", prefix),
+         :ok <- media_migrator.migrate(site),
+         {:ok, staging} <- Environments.create_environment(site, @staging, creator: creator),
+         {:ok, _copy} <-
+           Environments.copy_environment(production, staging,
+             creator: creator,
+             keep_archives: 0,
+             note: "Initial public-schema migration"
+           ) do
+      {:ok, Registry.get_site(site.id)}
+    end
+  end
+
+  defp cleanup_failed_site(site) do
+    with {:ok, archived} <- Setup.archive_site(site),
+         {:ok, _deleted} <- Setup.delete_site(archived, force: true) do
+      :ok
+    end
+  end
+
+  defp configured_migrator do
+    Brando.config(:tenant_public_data_migrator) || Brando.Tenant.PublicDataMigrator
+  end
+
+  defp configured_media_migrator do
+    Brando.config(:tenant_public_media_migrator) || Brando.Tenant.PublicMediaMigrator
+  end
+end

--- a/lib/brando/tenant/public_data_migrator.ex
+++ b/lib/brando/tenant/public_data_migrator.ex
@@ -1,0 +1,13 @@
+defmodule Brando.Tenant.PublicDataMigrator do
+  @moduledoc "Copies legacy public-schema content into a migrated tenant schema."
+
+  @callback migrate(source_prefix :: String.t(), target_prefix :: String.t()) ::
+              :ok | {:error, term()}
+
+  @behaviour __MODULE__
+
+  @impl true
+  def migrate(source_prefix, target_prefix) do
+    Brando.Tenant.PublicDataMigrator.Postgres.migrate(source_prefix, target_prefix)
+  end
+end

--- a/lib/brando/tenant/public_data_migrator/postgres.ex
+++ b/lib/brando/tenant/public_data_migrator/postgres.ex
@@ -1,0 +1,69 @@
+defmodule Brando.Tenant.PublicDataMigrator.Postgres do
+  @moduledoc false
+
+  @behaviour Brando.Tenant.PublicDataMigrator
+
+  alias Brando.Environments.SchemaCloner.Postgres, as: SchemaCloner
+
+  @shared_tables ~w(
+    environments
+    environment_operation_logs
+    oban_jobs
+    schema_migrations
+    site_asset_sets
+    sites
+    sites_previews
+    uploads_pending_intents
+    user_sites
+    user_tokens
+    users
+    users_tokens
+  )
+
+  @safe_table ~r/^[a-z0-9_]+$/
+
+  @impl true
+  def migrate(source_prefix, target_prefix) do
+    with {:ok, tables} <- copyable_tables(source_prefix, target_prefix),
+         true <- tables != [],
+         {:ok, dump} <- SchemaCloner.dump_schema(source_prefix, dump_args(source_prefix, tables)),
+         {:ok, rewritten_dump} <- SchemaCloner.rewrite_schema(dump, source_prefix, target_prefix),
+         :ok <- SchemaCloner.restore_dump(rewritten_dump) do
+      :ok
+    else
+      false -> {:error, :no_copyable_public_tables}
+      {:error, _reason} = error -> error
+    end
+  end
+
+  defp copyable_tables(source_prefix, target_prefix) do
+    sql = """
+    SELECT target.tablename
+    FROM pg_tables AS target
+    INNER JOIN pg_tables AS source
+      ON source.tablename = target.tablename
+     AND source.schemaname = $1
+    WHERE target.schemaname = $2
+    ORDER BY target.tablename
+    """
+
+    case Ecto.Adapters.SQL.query(Brando.Repo.repo(), sql, [source_prefix, target_prefix]) do
+      {:ok, %{rows: rows}} ->
+        tables =
+          rows
+          |> Enum.map(&List.first/1)
+          |> Enum.reject(&(&1 in @shared_tables))
+
+        if Enum.all?(tables, &Regex.match?(@safe_table, &1)),
+          do: {:ok, tables},
+          else: {:error, :unsafe_public_table_name}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp dump_args(source_prefix, tables) do
+    ["--data-only"] ++ Enum.map(tables, &"--table=#{source_prefix}.#{&1}")
+  end
+end

--- a/lib/brando/tenant/public_media_migrator.ex
+++ b/lib/brando/tenant/public_media_migrator.ex
@@ -1,0 +1,82 @@
+defmodule Brando.Tenant.PublicMediaMigrator do
+  @moduledoc """
+  Copies classic local media into a new multi-tenant site's media root.
+
+  The legacy tree is left untouched for rollback. Existing per-site roots are
+  excluded, and symlinks or special files abort the migration rather than
+  crossing an isolation boundary.
+  """
+
+  alias Brando.Sites.Site
+  alias Brando.Tenant
+  alias Brando.Tenant.Registry
+  alias Brando.Tenant.Storage
+
+  @callback migrate(Site.t()) :: :ok | {:error, term()}
+
+  @behaviour __MODULE__
+
+  @impl true
+  def migrate(%Site{} = site) do
+    if Tenant.mode() == :multi do
+      source_root = Brando.config(:media_path) |> Path.expand()
+      target_root = site |> Storage.media_root() |> Path.expand()
+
+      excluded_names =
+        Registry.list_sites()
+        |> Enum.map(& &1.key)
+        |> MapSet.new()
+
+      with {:ok, entries} <- File.ls(source_root),
+           entries <- Enum.reject(entries, &MapSet.member?(excluded_names, &1)),
+           :ok <- validate_entries(source_root, entries),
+           :ok <- copy_entries(source_root, target_root, entries) do
+        :ok
+      else
+        {:error, reason} -> {:error, {:media_migration_failed, reason}}
+      end
+    else
+      :ok
+    end
+  end
+
+  defp validate_entries(root, entries) do
+    Enum.reduce_while(entries, :ok, fn entry, :ok ->
+      case validate_path(Path.join(root, entry)) do
+        :ok -> {:cont, :ok}
+        {:error, reason} -> {:halt, {:error, reason}}
+      end
+    end)
+  end
+
+  defp validate_path(path) do
+    case File.lstat(path) do
+      {:ok, %{type: :regular}} ->
+        :ok
+
+      {:ok, %{type: :directory}} ->
+        case File.ls(path) do
+          {:ok, entries} -> validate_entries(path, entries)
+          {:error, reason} -> {:error, {:media_directory_read_failed, path, reason}}
+        end
+
+      {:ok, _symlink_or_special} ->
+        {:error, {:unsupported_media_file, path}}
+
+      {:error, reason} ->
+        {:error, {:media_file_stat_failed, path, reason}}
+    end
+  end
+
+  defp copy_entries(source_root, target_root, entries) do
+    Enum.reduce_while(entries, :ok, fn entry, :ok ->
+      source = Path.join(source_root, entry)
+      target = Path.join(target_root, entry)
+
+      case File.cp_r(source, target) do
+        {:ok, _copied} -> {:cont, :ok}
+        {:error, reason, path} -> {:halt, {:error, {:media_copy_failed, path, reason}}}
+      end
+    end)
+  end
+end

--- a/lib/brando/tenant/seeder.ex
+++ b/lib/brando/tenant/seeder.ex
@@ -1,0 +1,30 @@
+defmodule Brando.Tenant.Seeder do
+  @moduledoc """
+  Default initial-content seeder for a newly provisioned site.
+
+  Brando can create the shared identity and SEO records for every configured
+  language. Applications that also need a schema-specific home page or other
+  initial content can configure a module implementing `c:seed/3` as
+  `config :brando, tenant_seeder: MyApp.TenantSeeder`.
+  """
+
+  alias Brando.Environments.Environment
+  alias Brando.Sites.Site
+  alias Brando.Users.User
+
+  @callback seed(Site.t(), Environment.t(), User.t()) :: :ok | {:error, term()}
+
+  @behaviour __MODULE__
+
+  @impl true
+  def seed(%Site{} = site, %Environment{}, %User{}) do
+    Enum.each(site.languages, fn language ->
+      Brando.Sites.create_default_identity(language)
+      Brando.Sites.create_default_seo(language)
+    end)
+
+    :ok
+  rescue
+    exception -> {:error, exception}
+  end
+end

--- a/lib/brando/tenant/setup.ex
+++ b/lib/brando/tenant/setup.ex
@@ -1,0 +1,210 @@
+defmodule Brando.Tenant.Setup do
+  @moduledoc """
+  Compensated site provisioning and destructive site lifecycle operations.
+
+  A site is not returned until its live and staging environments, tenant
+  schemas, initial content, storage directories, and creator assignment all
+  exist. Any provisioning failure removes the partial site. Permanent deletion
+  is intentionally a second step after archival and a configurable retention
+  period.
+  """
+
+  alias Brando.Environments
+  alias Brando.Environments.Schema
+  alias Brando.Repo
+  alias Brando.Sites.Site
+  alias Brando.Tenant
+  alias Brando.Tenant.Access
+  alias Brando.Tenant.Lock
+  alias Brando.Tenant.Registry
+  alias Brando.Tenant.Storage
+  alias Brando.Users.User
+
+  @default_retention_days 30
+  @default_environments [
+    %{name: "Production", key: "production", live: true},
+    %{name: "Staging", key: "staging", live: false}
+  ]
+
+  @spec create_site(map(), User.t(), keyword()) :: {:ok, Site.t()} | {:error, term()}
+  def create_site(attrs, %User{} = creator, opts \\ []) do
+    case site_key(attrs) do
+      key when is_binary(key) ->
+        Lock.with(lifecycle_lock_key(key), fn -> create_under_lock(attrs, creator, opts) end)
+
+      _missing_key ->
+        Registry.create_site(attrs)
+    end
+  end
+
+  @spec suspend_site(Site.t()) :: {:ok, Site.t()} | {:error, term()}
+  def suspend_site(%Site{} = site), do: update_status(site, :suspended)
+
+  @spec activate_site(Site.t()) :: {:ok, Site.t()} | {:error, term()}
+  def activate_site(%Site{} = site), do: update_status(site, :active)
+
+  @spec archive_site(Site.t(), keyword()) :: {:ok, Site.t()} | {:error, term()}
+  def archive_site(%Site{} = site, opts \\ []) do
+    now = Keyword.get_lazy(opts, :now, &DateTime.utc_now/0)
+
+    Lock.with(lifecycle_lock_key(site.key), fn ->
+      with %Site{} = current_site <- Registry.get_site(site.id) do
+        Registry.update_site(current_site, %{status: :archived, archived_at: now})
+      else
+        nil -> {:error, :site_not_found}
+      end
+    end)
+  end
+
+  @spec delete_site(Site.t(), keyword()) :: {:ok, Site.t()} | {:error, term()}
+  def delete_site(%Site{} = site, opts \\ []) do
+    Lock.with(lifecycle_lock_key(site.key), fn -> delete_under_lock(site, opts) end)
+  end
+
+  defp create_under_lock(attrs, creator, opts) do
+    with {:ok, site} <- Registry.create_site(attrs) do
+      case provision(site, creator, opts) do
+        {:ok, provisioned_site} ->
+          {:ok, provisioned_site}
+
+        {:error, reason} ->
+          compensation = compensate(site)
+          {:error, {:site_setup_failed, reason, compensation}}
+      end
+    end
+  end
+
+  defp provision(site, creator, opts) do
+    environments = Keyword.get(opts, :environments, @default_environments)
+
+    with :ok <- validate_environments(environments),
+         :ok <- Storage.create(site),
+         [live_attrs | remaining_attrs] <- order_live_first(environments),
+         {:ok, live_environment} <- Environments.create_environment(site, live_attrs, creator: creator),
+         :ok <- seed(site, live_environment, creator),
+         {:ok, _environments} <- create_copies(site, live_environment, remaining_attrs, creator),
+         {:ok, _assignment} <- Access.grant(creator, site, :admin) do
+      {:ok, Registry.get_site(site.id)}
+    else
+      [] -> {:error, :missing_live_environment}
+      {:error, _reason} = error -> error
+    end
+  end
+
+  defp create_copies(site, live_environment, environment_attrs, creator) do
+    Enum.reduce_while(environment_attrs, {:ok, [live_environment]}, fn attrs, {:ok, environments} ->
+      with {:ok, environment} <- Environments.create_environment(site, attrs, creator: creator),
+           {:ok, _copy} <-
+             Environments.copy_environment(live_environment, environment,
+               creator: creator,
+               keep_archives: 0,
+               note: "Initial site provisioning"
+             ) do
+        {:cont, {:ok, environments ++ [environment]}}
+      else
+        {:error, reason} -> {:halt, {:error, reason}}
+      end
+    end)
+  end
+
+  defp seed(site, environment, creator) do
+    prefix = Tenant.prefix(site, environment)
+    seeder = Brando.config(:tenant_seeder) || Brando.Tenant.Seeder
+
+    Tenant.with_prefix(prefix, fn -> seeder.seed(site, environment, creator) end)
+  rescue
+    exception -> {:error, {:seeding_failed, exception}}
+  end
+
+  defp validate_environments(environments) when is_list(environments) do
+    if Enum.count(environments, &live?/1) == 1,
+      do: :ok,
+      else: {:error, :exactly_one_live_environment_required}
+  end
+
+  defp validate_environments(_environments), do: {:error, :invalid_environments}
+
+  defp order_live_first(environments) do
+    {live, other} = Enum.split_with(environments, &live?/1)
+    live ++ other
+  end
+
+  defp live?(attrs), do: Map.get(attrs, :live, Map.get(attrs, "live", false)) == true
+
+  defp update_status(site, status) do
+    Lock.with(lifecycle_lock_key(site.key), fn ->
+      with %Site{} = current_site <- Registry.get_site(site.id) do
+        Registry.update_site(current_site, %{status: status, archived_at: nil})
+      else
+        nil -> {:error, :site_not_found}
+      end
+    end)
+  end
+
+  defp delete_under_lock(site, opts) do
+    with %Site{} = current_site <- Registry.get_site(site.id),
+         :ok <- deletable?(current_site, opts),
+         {:ok, deleted_site} <- delete_registry_and_schemas(current_site),
+         :ok <- Storage.delete(current_site) do
+      {:ok, deleted_site}
+    else
+      nil -> {:error, :site_not_found}
+      {:error, _reason} = error -> error
+    end
+  end
+
+  defp deletable?(%Site{status: :archived, archived_at: %DateTime{} = archived_at}, opts) do
+    now = Keyword.get_lazy(opts, :now, &DateTime.utc_now/0)
+
+    retention_days =
+      Keyword.get(opts, :retention_days, Brando.config(:site_delete_retention_days) || @default_retention_days)
+
+    if Keyword.get(opts, :force, false) or DateTime.diff(now, archived_at, :day) >= retention_days,
+      do: :ok,
+      else: {:error, {:retention_period, retention_days}}
+  end
+
+  defp deletable?(%Site{}, _opts), do: {:error, :site_must_be_archived}
+
+  defp delete_registry_and_schemas(site) do
+    case Repo.transaction(fn ->
+           Enum.each(site_schema_prefixes(site), fn prefix ->
+             case Schema.drop(prefix) do
+               :ok -> :ok
+               {:error, reason} -> Repo.rollback({:schema_drop_failed, prefix, reason})
+             end
+           end)
+
+           case Registry.delete_site(site) do
+             {:ok, deleted_site} -> deleted_site
+             {:error, reason} -> Repo.rollback(reason)
+           end
+         end) do
+      {:ok, deleted_site} -> {:ok, deleted_site}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp compensate(site) do
+    Enum.each(site_schema_prefixes(site), &Schema.drop/1)
+    Storage.delete(site)
+
+    case Registry.get_site(site.id) do
+      nil -> :ok
+      current_site -> Registry.delete_site(current_site)
+    end
+  end
+
+  defp site_schema_prefixes(site) do
+    environment_prefixes =
+      site
+      |> Registry.list_environments()
+      |> Enum.map(&Tenant.prefix(site, &1))
+
+    archive_prefixes = Enum.map(Environments.list_archives(site), & &1.schema)
+    Enum.uniq(environment_prefixes ++ archive_prefixes)
+  end
+
+  defp site_key(attrs), do: Map.get(attrs, :key, Map.get(attrs, "key"))
+  defp lifecycle_lock_key(site_key), do: "brando:site-lifecycle:#{site_key}"
+end

--- a/lib/brando/tenant/setup.ex
+++ b/lib/brando/tenant/setup.ex
@@ -67,6 +67,10 @@ defmodule Brando.Tenant.Setup do
         {:ok, provisioned_site} ->
           {:ok, provisioned_site}
 
+        {:error, {:storage_not_created, reason}} ->
+          compensation = compensate(site, delete_storage: false)
+          {:error, {:site_setup_failed, reason, compensation}}
+
         {:error, reason} ->
           compensation = compensate(site)
           {:error, {:site_setup_failed, reason, compensation}}
@@ -77,11 +81,11 @@ defmodule Brando.Tenant.Setup do
   defp provision(site, creator, opts) do
     environments = Keyword.get(opts, :environments, @default_environments)
 
-    with :ok <- validate_environments(environments),
-         :ok <- Storage.create(site),
+    with :ok <- create_storage(site),
+         :ok <- validate_environments(environments),
          [live_attrs | remaining_attrs] <- order_live_first(environments),
          {:ok, live_environment} <- Environments.create_environment(site, live_attrs, creator: creator),
-         :ok <- seed(site, live_environment, creator),
+         :ok <- seed(site, live_environment, creator, opts),
          {:ok, _environments} <- create_copies(site, live_environment, remaining_attrs, creator),
          {:ok, _assignment} <- Access.grant(creator, site, :admin) do
       {:ok, Registry.get_site(site.id)}
@@ -107,13 +111,24 @@ defmodule Brando.Tenant.Setup do
     end)
   end
 
-  defp seed(site, environment, creator) do
-    prefix = Tenant.prefix(site, environment)
-    seeder = Brando.config(:tenant_seeder) || Brando.Tenant.Seeder
+  defp seed(site, environment, creator, opts) do
+    if Keyword.get(opts, :seed, true) do
+      prefix = Tenant.prefix(site, environment)
+      seeder = Brando.config(:tenant_seeder) || Brando.Tenant.Seeder
 
-    Tenant.with_prefix(prefix, fn -> seeder.seed(site, environment, creator) end)
+      Tenant.with_prefix(prefix, fn -> seeder.seed(site, environment, creator) end)
+    else
+      :ok
+    end
   rescue
     exception -> {:error, {:seeding_failed, exception}}
+  end
+
+  defp create_storage(site) do
+    case Storage.create(site) do
+      :ok -> :ok
+      {:error, reason} -> {:error, {:storage_not_created, reason}}
+    end
   end
 
   defp validate_environments(environments) when is_list(environments) do
@@ -185,9 +200,10 @@ defmodule Brando.Tenant.Setup do
     end
   end
 
-  defp compensate(site) do
+  defp compensate(site, opts \\ []) do
     Enum.each(site_schema_prefixes(site), &Schema.drop/1)
-    Storage.delete(site)
+
+    if Keyword.get(opts, :delete_storage, true), do: Storage.delete(site)
 
     case Registry.get_site(site.id) do
       nil -> :ok

--- a/lib/brando/tenant/storage.ex
+++ b/lib/brando/tenant/storage.ex
@@ -1,0 +1,57 @@
+defmodule Brando.Tenant.Storage do
+  @moduledoc "Filesystem locations owned by one site."
+
+  alias Brando.Sites.Site
+
+  @spec create(Site.t()) :: :ok | {:error, term()}
+  def create(%Site{} = site) do
+    [media_root(site), assets_root(site)]
+    |> Enum.reduce_while(:ok, fn path, :ok ->
+      case File.mkdir_p(path) do
+        :ok -> {:cont, :ok}
+        {:error, reason} -> {:halt, {:error, {:create_directory_failed, path, reason}}}
+      end
+    end)
+  end
+
+  @spec delete(Site.t()) :: :ok | {:error, term()}
+  def delete(%Site{} = site) do
+    [media_root(site), site_root(site)]
+    |> Enum.reduce_while(:ok, fn path, :ok ->
+      case File.rm_rf(path) do
+        {:ok, _removed} -> {:cont, :ok}
+        {:error, reason, failed_path} -> {:halt, {:error, {:delete_directory_failed, failed_path, reason}}}
+      end
+    end)
+  end
+
+  @spec media_root(Site.t()) :: String.t()
+  def media_root(%Site{key: site_key}), do: Path.join(Brando.config(:media_path), site_key)
+
+  @doc "Returns the filesystem media root for the current tenant context."
+  @spec current_media_root() :: String.t()
+  def current_media_root do
+    case Brando.Tenant.mode() do
+      :multi ->
+        case Brando.Tenant.current_site_key() do
+          nil -> raise "multi-tenant media access requires a current tenant prefix"
+          site_key -> Path.join(Brando.config(:media_path), site_key)
+        end
+
+      _single_or_none ->
+        Brando.config(:media_path)
+    end
+  end
+
+  @spec sites_root() :: String.t()
+  def sites_root do
+    Brando.config(:sites_path) ||
+      Brando.config(:media_path) |> Path.expand() |> Path.dirname() |> Path.join("sites")
+  end
+
+  @spec site_root(Site.t()) :: String.t()
+  def site_root(%Site{key: site_key}), do: Path.join(sites_root(), site_key)
+
+  @spec assets_root(Site.t()) :: String.t()
+  def assets_root(%Site{} = site), do: Path.join(site_root(site), "assets")
+end

--- a/lib/brando/tenant/storage.ex
+++ b/lib/brando/tenant/storage.ex
@@ -5,13 +5,12 @@ defmodule Brando.Tenant.Storage do
 
   @spec create(Site.t()) :: :ok | {:error, term()}
   def create(%Site{} = site) do
-    [media_root(site), assets_root(site)]
-    |> Enum.reduce_while(:ok, fn path, :ok ->
-      case File.mkdir_p(path) do
-        :ok -> {:cont, :ok}
-        {:error, reason} -> {:halt, {:error, {:create_directory_failed, path, reason}}}
-      end
-    end)
+    roots = [media_root(site), site_root(site)]
+
+    case Enum.find(roots, &File.exists?/1) do
+      nil -> create_new_directories(roots ++ [assets_root(site)])
+      path -> {:error, {:site_storage_already_exists, path}}
+    end
   end
 
   @spec delete(Site.t()) :: :ok | {:error, term()}
@@ -54,4 +53,22 @@ defmodule Brando.Tenant.Storage do
 
   @spec assets_root(Site.t()) :: String.t()
   def assets_root(%Site{} = site), do: Path.join(site_root(site), "assets")
+
+  defp create_new_directories(paths) do
+    paths
+    |> Enum.reduce_while({:ok, []}, fn path, {:ok, created} ->
+      case File.mkdir_p(path) do
+        :ok -> {:cont, {:ok, [path | created]}}
+        {:error, reason} -> {:halt, {:error, {:create_directory_failed, path, reason}, created}}
+      end
+    end)
+    |> case do
+      {:ok, _created} ->
+        :ok
+
+      {:error, reason, created} ->
+        Enum.each(created, &File.rm_rf/1)
+        {:error, reason}
+    end
+  end
 end

--- a/lib/brando/upload.ex
+++ b/lib/brando/upload.ex
@@ -25,6 +25,7 @@ defmodule Brando.Upload do
   alias Brando.Assets.CompletedCallback
   alias Brando.Files
   alias Brando.Images
+  alias Brando.Tenant.Storage
   alias Brando.Type.FileConfig
   alias Brando.Type.ImageConfig
   alias Brando.Type.VideoConfig
@@ -298,7 +299,7 @@ defmodule Brando.Upload do
   end
 
   defp create_upload_path(%__MODULE__{cfg: cfg} = upload) do
-    upload_path = Path.join(Brando.config(:media_path), Map.get(cfg, :upload_path))
+    upload_path = Path.join(Storage.current_media_root(), Map.get(cfg, :upload_path))
 
     case File.mkdir_p(upload_path) do
       :ok ->

--- a/lib/brando/users/user_site.ex
+++ b/lib/brando/users/user_site.ex
@@ -1,0 +1,42 @@
+defmodule Brando.Users.UserSite do
+  @moduledoc """
+  Grants a global Brando user a role within one site.
+
+  User/site assignments live in `public` because they control which tenant
+  schemas a user may enter. The global `:superuser` role bypasses assignments;
+  all other multi-tenant access is represented here.
+  """
+
+  use Ecto.Schema
+
+  import Ecto.Changeset
+
+  alias Brando.Sites.Site
+  alias Brando.Users.User
+
+  @schema_prefix "public"
+  @timestamps_opts [type: :utc_datetime_usec]
+  @roles [:editor, :admin]
+
+  @type t :: %__MODULE__{}
+
+  schema "user_sites" do
+    belongs_to :user, User
+    belongs_to :site, Site
+    field :role, Ecto.Enum, values: @roles
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(user_site \\ %__MODULE__{}, attrs) do
+    user_site
+    |> cast(attrs, [:user_id, :site_id, :role])
+    |> validate_required([:user_id, :site_id, :role])
+    |> assoc_constraint(:user)
+    |> assoc_constraint(:site)
+    |> unique_constraint([:user_id, :site_id])
+  end
+
+  def roles, do: @roles
+end

--- a/lib/brando/workers/entry_cascade.ex
+++ b/lib/brando/workers/entry_cascade.ex
@@ -9,7 +9,7 @@ defmodule Brando.Worker.EntryCascade do
   use Oban.Worker,
     queue: :default,
     max_attempts: 3,
-    unique: [keys: [:schema, :entry_id], period: 5, states: :incomplete]
+    unique: [keys: [:tenant_prefix, :schema, :entry_id], period: 5, states: :incomplete]
 
   require Logger
 
@@ -17,9 +17,12 @@ defmodule Brando.Worker.EntryCascade do
   alias Brando.Content.Blocks
   alias Brando.Content.RenderQueue
   alias Brando.Datasource.Registry
+  alias Brando.Tenant.Job, as: TenantJob
 
   @impl Oban.Worker
-  def perform(%Oban.Job{args: args}) do
+  def perform(%Oban.Job{} = job), do: TenantJob.run(job, fn -> perform_tenant(job) end)
+
+  defp perform_tenant(%Oban.Job{args: args}) do
     schema = Module.concat([args["schema"]])
     entry_id = args["entry_id"]
     identifier_id = args["identifier_id"]

--- a/lib/brando/workers/entry_publisher.ex
+++ b/lib/brando/workers/entry_publisher.ex
@@ -8,19 +8,22 @@ defmodule Brando.Worker.EntryPublisher do
 
   require Logger
   alias Brando.Revisions
+  alias Brando.Tenant.Job, as: TenantJob
 
   # schedule publishing/depublishing an entry
   @impl Oban.Worker
-  def perform(
-        %Oban.Job{
-          args: %{
-            "schema" => schema,
-            "id" => id,
-            "revision" => revision,
-            "user_id" => user_id
-          }
-        } = job
-      ) do
+  def perform(%Oban.Job{} = job), do: TenantJob.run(job, fn -> perform_tenant(job) end)
+
+  defp perform_tenant(
+         %Oban.Job{
+           args: %{
+             "schema" => schema,
+             "id" => id,
+             "revision" => revision,
+             "user_id" => user_id
+           }
+         } = job
+       ) do
     user = publisher_user(user_id)
     now = DateTime.utc_now()
 
@@ -50,15 +53,14 @@ defmodule Brando.Worker.EntryPublisher do
   end
 
   # schedule publishing/depublishing an entry
-  @impl Oban.Worker
-  def perform(%Oban.Job{
-        args: %{
-          "schema" => schema,
-          "id" => id,
-          "status" => status,
-          "user_id" => user_id
-        }
-      }) do
+  defp perform_tenant(%Oban.Job{
+         args: %{
+           "schema" => schema,
+           "id" => id,
+           "status" => status,
+           "user_id" => user_id
+         }
+       }) do
     user = publisher_user(user_id)
     now = DateTime.utc_now()
 

--- a/lib/brando/workers/entry_renderer.ex
+++ b/lib/brando/workers/entry_renderer.ex
@@ -3,12 +3,16 @@ defmodule Brando.Worker.EntryRenderer do
   use Oban.Worker,
     queue: :default,
     max_attempts: 5,
-    unique: [keys: [:schema, :entry_id], period: 5, states: :incomplete]
+    unique: [keys: [:tenant_prefix, :schema, :entry_id], period: 5, states: :incomplete]
 
   require Logger
 
+  alias Brando.Tenant.Job, as: TenantJob
+
   @impl Oban.Worker
-  def perform(%Oban.Job{args: %{"entry_id" => entry_id, "schema" => schema}}) do
+  def perform(%Oban.Job{} = job), do: TenantJob.run(job, fn -> perform_tenant(job) end)
+
+  defp perform_tenant(%Oban.Job{args: %{"entry_id" => entry_id, "schema" => schema}}) do
     schema = Module.concat([schema])
     Logger.info("==> [CRON] Rendering entry #{entry_id} for schema #{schema}")
     Brando.Content.Blocks.render_entry(schema, entry_id)

--- a/lib/brando/workers/entry_revision.ex
+++ b/lib/brando/workers/entry_revision.ex
@@ -9,8 +9,14 @@ defmodule Brando.Worker.EntryRevision do
 
   require Logger
 
+  alias Brando.Tenant.Job, as: TenantJob
+
   @impl Oban.Worker
-  def perform(%Oban.Job{args: %{"schema" => schema, "entry_id" => entry_id, "user_id" => user_id}}) do
+  def perform(%Oban.Job{} = job), do: TenantJob.run(job, fn -> perform_tenant(job) end)
+
+  defp perform_tenant(%Oban.Job{
+         args: %{"schema" => schema, "entry_id" => entry_id, "user_id" => user_id}
+       }) do
     schema = Module.concat([schema])
     Logger.info("==> [OBAN] Creating revision for #{inspect(schema)} ##{entry_id}")
 

--- a/lib/brando/workers/file_uploader.ex
+++ b/lib/brando/workers/file_uploader.ex
@@ -4,17 +4,20 @@ defmodule Brando.Worker.FileUploader do
 
   alias Brando.CDN
   alias Brando.Files
+  alias Brando.Tenant.Job, as: TenantJob
   alias Brando.Users
 
   @impl Oban.Worker
-  def perform(%Oban.Job{
-        args: %{
-          "file_id" => file_id,
-          "config_target" => config_target,
-          "user_id" => user_id,
-          "field_full_path" => field_full_path
-        }
-      }) do
+  def perform(%Oban.Job{} = job), do: TenantJob.run(job, fn -> perform_tenant(job) end)
+
+  defp perform_tenant(%Oban.Job{
+         args: %{
+           "file_id" => file_id,
+           "config_target" => config_target,
+           "user_id" => user_id,
+           "field_full_path" => field_full_path
+         }
+       }) do
     field_full_path =
       Enum.map(field_full_path, fn
         segment when is_binary(segment) -> String.to_existing_atom(segment)

--- a/lib/brando/workers/image_processor.ex
+++ b/lib/brando/workers/image_processor.ex
@@ -4,22 +4,25 @@ defmodule Brando.Worker.ImageProcessor do
 
   alias Brando.Assets.CompletedCallback
   alias Brando.Images
+  alias Brando.Tenant.Job, as: TenantJob
   alias Brando.Users
 
   require Logger
 
   @impl Oban.Worker
-  def perform(
-        %Oban.Job{
-          args:
-            %{
-              "image_id" => image_id,
-              "config_target" => config_target,
-              "user_id" => user_id,
-              "field_full_path" => field_full_path
-            } = args
-        } = job
-      ) do
+  def perform(%Oban.Job{} = job), do: TenantJob.run(job, fn -> perform_tenant(job) end)
+
+  defp perform_tenant(
+         %Oban.Job{
+           args:
+             %{
+               "image_id" => image_id,
+               "config_target" => config_target,
+               "user_id" => user_id,
+               "field_full_path" => field_full_path
+             } = args
+         } = job
+       ) do
     silent? = Map.get(args, "silent", false)
 
     field_full_path =

--- a/lib/brando/workers/image_uploader.ex
+++ b/lib/brando/workers/image_uploader.ex
@@ -3,20 +3,23 @@ defmodule Brando.Worker.ImageUploader do
   import Ecto.Query
   alias Brando.CDN
   alias Brando.Images
+  alias Brando.Tenant.Job, as: TenantJob
   # alias Brando.Users
 
   @impl Oban.Worker
-  def perform(%Oban.Job{
-        id: job_id,
-        args: %{
-          "image_id" => image_id,
-          "src_key" => src_key,
-          "dest_key" => dest_key,
-          "user_id" => user_id,
-          "config_target" => config_target,
-          "field_full_path" => field_full_path
-        }
-      }) do
+  def perform(%Oban.Job{} = job), do: TenantJob.run(job, fn -> perform_tenant(job) end)
+
+  defp perform_tenant(%Oban.Job{
+         id: job_id,
+         args: %{
+           "image_id" => image_id,
+           "src_key" => src_key,
+           "dest_key" => dest_key,
+           "user_id" => user_id,
+           "config_target" => config_target,
+           "field_full_path" => field_full_path
+         }
+       }) do
     BrandoAdmin.Progress.show(user_id)
 
     field_full_path =
@@ -52,12 +55,15 @@ defmodule Brando.Worker.ImageUploader do
   end
 
   defp any_remaining_jobs?(image_id, job_id) do
+    context = TenantJob.context_fragment()
+
     query =
       from j in Oban.Job,
         select: [j.id],
         where:
           ^"image_upload_#{image_id}" in j.tags and
-            j.state != ^"completed"
+            j.state != ^"completed" and
+            fragment("? @> ?", j.args, ^context)
 
     result = Brando.Repo.all(query)
     result != [[job_id]]

--- a/lib/brando/workers/preview_purger.ex
+++ b/lib/brando/workers/preview_purger.ex
@@ -7,9 +7,12 @@ defmodule Brando.Worker.PreviewPurger do
     max_attempts: 3
 
   alias Brando.Sites
+  alias Brando.Tenant.Job, as: TenantJob
 
   @impl Oban.Worker
-  def perform(%Oban.Job{args: %{"id" => id}}) do
+  def perform(%Oban.Job{} = job), do: TenantJob.run(job, fn -> perform_tenant(job) end)
+
+  defp perform_tenant(%Oban.Job{args: %{"id" => id}}) do
     case Sites.delete_preview(id) do
       {:ok, _} -> :ok
       {:error, _} -> :ok

--- a/lib/brando/workers/revision_purger.ex
+++ b/lib/brando/workers/revision_purger.ex
@@ -4,10 +4,16 @@ defmodule Brando.Worker.RevisionPurger do
 
   require Logger
 
+  alias Brando.Tenant.Job, as: TenantJob
+
   @impl Oban.Worker
   def perform(_) do
     Logger.info("==> [CRON] Cleaning up revisions")
-    {purged_revisions, _} = Brando.Revisions.purge_revisions()
+
+    purged_revisions =
+      TenantJob.each_active_environment(:all, &Brando.Revisions.purge_revisions/0)
+      |> Enum.reduce(0, fn {count, _}, total -> total + count end)
+
     Logger.info("==> [CRON] Deleted #{purged_revisions} unprotected/inactive revisions")
     :ok
   end

--- a/lib/brando/workers/sitemap_generator.ex
+++ b/lib/brando/workers/sitemap_generator.ex
@@ -4,10 +4,12 @@ defmodule Brando.Worker.SitemapGenerator do
 
   require Logger
 
+  alias Brando.Tenant.Job, as: TenantJob
+
   @impl Oban.Worker
   def perform(_) do
     Logger.info("==> [CRON] Generating sitemap...")
-    Brando.Sitemap.generate_sitemap()
+    TenantJob.each_active_environment(:live, &Brando.Sitemap.generate_sitemap/0)
     Logger.info("==> [CRON] Generating sitemap... done")
     :ok
   end

--- a/lib/brando/workers/soft_delete_purger.ex
+++ b/lib/brando/workers/soft_delete_purger.ex
@@ -4,10 +4,12 @@ defmodule Brando.Worker.SoftDeletePurger do
 
   require Logger
 
+  alias Brando.Tenant.Job, as: TenantJob
+
   @impl Oban.Worker
   def perform(_) do
     Logger.info("==> [CRON] Cleaning up soft deleted entries...")
-    Brando.SoftDelete.Query.clean_up_soft_deletions()
+    TenantJob.each_active_environment(:all, &Brando.SoftDelete.Query.clean_up_soft_deletions/0)
     Logger.info("==> [CRON] Cleaning up soft deleted entries... done")
     :ok
   end

--- a/lib/brando/workers/upload_intent_reaper.ex
+++ b/lib/brando/workers/upload_intent_reaper.ex
@@ -24,6 +24,7 @@ defmodule Brando.Worker.UploadIntentReaper do
   use Oban.Worker, queue: :upload_reaping, max_attempts: 2
 
   alias Brando.Uploads
+  alias Brando.Tenant.Job, as: TenantJob
 
   require Logger
 
@@ -40,6 +41,18 @@ defmodule Brando.Worker.UploadIntentReaper do
 
   @impl Oban.Worker
   def perform(_job) do
+    errors =
+      TenantJob.each_active_environment(:all, &reap_current_environment/0)
+      |> Enum.reject(&(&1 == :ok))
+
+    case errors do
+      [] -> :ok
+      [{:error, reason}] -> {:error, reason}
+      multiple -> {:error, multiple}
+    end
+  end
+
+  defp reap_current_environment do
     stale = Uploads.list_stale_pending_intents(@stale_after_hours, @batch_size)
 
     {reaped, failed} = Enum.split_with(stale, &(reap(&1) == :ok))

--- a/lib/brando/workers/video_upload_reaper.ex
+++ b/lib/brando/workers/video_upload_reaper.ex
@@ -21,10 +21,24 @@ defmodule Brando.Worker.VideoUploadReaper do
 
   require Logger
 
+  alias Brando.Tenant.Job, as: TenantJob
+
   @stale_after_hours 24
 
   @impl Oban.Worker
   def perform(_) do
+    count =
+      TenantJob.each_active_environment(:all, &reap_current_environment/0)
+      |> Enum.sum()
+
+    if count > 0 do
+      Logger.info("==> [CRON] Marked #{count} abandoned video upload(s) as errored")
+    end
+
+    :ok
+  end
+
+  defp reap_current_environment do
     now = NaiveDateTime.truncate(NaiveDateTime.utc_now(), :second)
     cutoff = NaiveDateTime.add(now, -@stale_after_hours * 3600, :second)
 
@@ -33,12 +47,7 @@ defmodule Brando.Worker.VideoUploadReaper do
         where: v.status == :uploading and v.inserted_at < ^cutoff and is_nil(v.deleted_at)
 
     {count, _} = Brando.Repo.update_all(query, set: [status: :errored, updated_at: now])
-
-    if count > 0 do
-      Logger.info("==> [CRON] Marked #{count} abandoned video upload(s) as errored")
-    end
-
-    :ok
+    count
   end
 
   @impl Oban.Worker

--- a/lib/brando_admin/components/content/list.ex
+++ b/lib/brando_admin/components/content/list.ex
@@ -104,7 +104,7 @@ defmodule BrandoAdmin.Components.Content.List do
 
     target_path =
       Path.join([
-        Brando.config(:media_path),
+        Brando.Tenant.Storage.current_media_root(),
         exports_path
       ])
 

--- a/lib/brando_admin/controllers/environment_controller.ex
+++ b/lib/brando_admin/controllers/environment_controller.ex
@@ -6,12 +6,14 @@ defmodule BrandoAdmin.EnvironmentController do
   import Plug.Conn, only: [put_session: 3]
 
   alias Brando.Tenant
+  alias Brando.Tenant.Access
   alias Brando.Tenant.Cache
 
   def update(conn, params) do
     with true <- Tenant.enabled?(),
          site_key when is_binary(site_key) <- selected_site_key(params),
          site when not is_nil(site) <- Cache.get_site(site_key),
+         true <- authorized?(conn.assigns[:current_user], site),
          environment when not is_nil(environment) <- selected_environment(site.key, params) do
       conn
       |> put_session("brando_site_key", site.key)
@@ -19,6 +21,13 @@ defmodule BrandoAdmin.EnvironmentController do
       |> redirect(to: safe_return_to(params["return_to"]))
     else
       _ -> redirect(conn, to: "/admin")
+    end
+  end
+
+  defp authorized?(current_user, site) do
+    case Tenant.mode() do
+      :single -> true
+      :multi -> Access.can_access?(current_user, site)
     end
   end
 

--- a/lib/brando_admin/controllers/sitemap_controller.ex
+++ b/lib/brando_admin/controllers/sitemap_controller.ex
@@ -7,7 +7,7 @@ defmodule Brando.SitemapController do
   @doc false
   def show(conn, %{"file" => file}) do
     with {:ok, safe_file} <- Path.safe_relative(file),
-         file_path = Path.join([Brando.config(:media_path), "sitemaps", safe_file]),
+         file_path = Path.join([Brando.Tenant.Storage.current_media_root(), "sitemaps", safe_file]),
          true <- File.exists?(file_path) do
       send_download(conn, {:file, file_path})
     else

--- a/lib/brando_admin/live/config/asset_live.ex
+++ b/lib/brando_admin/live/config/asset_live.ex
@@ -1,0 +1,163 @@
+defmodule BrandoAdmin.Sites.AssetLive do
+  @moduledoc false
+
+  use BrandoAdmin, :live_view
+  use BrandoAdmin.Toast
+  use Gettext, backend: Brando.Gettext
+
+  alias Brando.Assets.SiteAssets
+  alias Brando.Tenant
+  alias BrandoAdmin.Components.Content
+
+  @impl Phoenix.LiveView
+  def mount(_params, _session, socket) do
+    cond do
+      socket.assigns.current_user.role != :superuser ->
+        {:ok, redirect(socket, to: "/admin")}
+
+      connected?(socket) ->
+        {:ok,
+         socket
+         |> assign(:socket_connected, true)
+         |> assign(:scope_site, scope_site(socket))
+         |> refresh()}
+
+      true ->
+        {:ok, assign(socket, :socket_connected, false)}
+    end
+  end
+
+  @impl Phoenix.LiveView
+  def render(%{socket_connected: false} = assigns) do
+    ~H"""
+    """
+  end
+
+  def render(assigns) do
+    ~H"""
+    <Content.header
+      title={gettext("Frontend assets")}
+      subtitle={gettext("Activate or revert persistent frontend builds without deploying a release")}
+    >
+      <button type="button" class="secondary" phx-click="refresh">{gettext("Refresh")}</button>
+    </Content.header>
+
+    <div class="environment-management-live">
+      <section class="environment-panel">
+        <header>
+          <div>
+            <h2>{scope_name(@scope_site)}</h2>
+            <p>{gettext("Florist registers uploaded sets here; registration never activates a build.")}</p>
+          </div>
+          <button
+            type="button"
+            class="danger"
+            disabled={is_nil(@active_set)}
+            phx-click="deactivate"
+            phx-confirm={gettext("Revert to the frontend assets included in the current release?")}
+          >
+            {gettext("Revert to release assets")}
+          </button>
+        </header>
+
+        <div :if={@sets == []} class="environment-notice">
+          {gettext("No uploaded frontend asset sets have been registered.")}
+        </div>
+
+        <div :if={@sets != []} class="environment-table-wrap">
+          <table>
+            <thead>
+              <tr>
+                <th>{gettext("Set")}</th>
+                <th>{gettext("Uploaded")}</th>
+                <th>{gettext("Files")}</th>
+                <th>{gettext("Size")}</th>
+                <th>{gettext("State")}</th>
+                <th>{gettext("Actions")}</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr :for={asset_set <- @sets} id={"asset-set-#{asset_set.id}"}>
+                <td>
+                  <strong>{asset_set.name}</strong>
+                  <code>{asset_set.metadata["revision"] || asset_set.path}</code>
+                </td>
+                <td>{format_datetime(asset_set.uploaded_at)}</td>
+                <td>{asset_set.file_count}</td>
+                <td>{format_size(asset_set.size)}</td>
+                <td>
+                  <span class={["environment-state", asset_set.active && "live"]}>
+                    {if asset_set.active, do: gettext("Active"), else: gettext("Available")}
+                  </span>
+                </td>
+                <td>
+                  <button
+                    :if={!asset_set.active}
+                    type="button"
+                    class="primary small"
+                    phx-click="activate"
+                    phx-value-id={asset_set.id}
+                    phx-confirm={gettext("Activate %{name} immediately?", name: asset_set.name)}
+                  >
+                    {gettext("Activate")}
+                  </button>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+    </div>
+    """
+  end
+
+  @impl Phoenix.LiveView
+  def handle_event("refresh", _params, socket), do: {:noreply, refresh(socket)}
+
+  def handle_event("activate", %{"id" => id}, socket) do
+    with {asset_set_id, ""} <- Integer.parse(id),
+         true <- Enum.any?(socket.assigns.sets, &(&1.id == asset_set_id)),
+         {:ok, asset_set} <- SiteAssets.activate_set(asset_set_id) do
+      send(self(), {:toast, gettext("Activated %{name}", name: asset_set.name)})
+      {:noreply, refresh(socket)}
+    else
+      _error ->
+        send(self(), {:toast, gettext("Could not activate the frontend asset set"), :error})
+        {:noreply, socket}
+    end
+  end
+
+  def handle_event("deactivate", _params, socket) do
+    case SiteAssets.deactivate(socket.assigns.scope_site) do
+      :ok ->
+        send(self(), {:toast, gettext("Reverted to release assets")})
+        {:noreply, refresh(socket)}
+
+      {:error, _reason} ->
+        send(self(), {:toast, gettext("Could not revert the frontend assets"), :error})
+        {:noreply, socket}
+    end
+  end
+
+  defp refresh(socket) do
+    sets = SiteAssets.list_sets(socket.assigns.scope_site)
+
+    socket
+    |> assign(:sets, sets)
+    |> assign(:active_set, Enum.find(sets, & &1.active))
+  end
+
+  defp scope_site(socket) do
+    if Tenant.mode() == :multi, do: socket.assigns[:current_site], else: nil
+  end
+
+  defp scope_name(nil), do: gettext("Standalone frontend")
+  defp scope_name(site), do: site.name
+
+  defp format_datetime(%DateTime{} = datetime),
+    do: Calendar.strftime(datetime, "%Y-%m-%d %H:%M UTC")
+
+  defp format_size(bytes) when bytes < 1_024, do: "#{bytes} B"
+  defp format_size(bytes) when bytes < 1_048_576, do: "#{Float.round(bytes / 1_024, 1)} KB"
+  defp format_size(bytes), do: "#{Float.round(bytes / 1_048_576, 1)} MB"
+end

--- a/lib/brando_admin/live/config/environment_live.ex
+++ b/lib/brando_admin/live/config/environment_live.ex
@@ -8,6 +8,7 @@ defmodule BrandoAdmin.Sites.EnvironmentLive do
   alias Brando.Environments
   alias Brando.Environments.Environment
   alias Brando.Tenant
+  alias Brando.Tenant.Access
   alias Brando.Tenant.Registry
   alias Brando.Worker.EnvironmentCopy
   alias Brando.Worker.EnvironmentSetLive
@@ -18,7 +19,7 @@ defmodule BrandoAdmin.Sites.EnvironmentLive do
   @impl Phoenix.LiveView
   def mount(_params, _session, socket) do
     if connected?(socket) do
-      can_manage? = socket.assigns.current_user.role in @manager_roles
+      can_manage? = can_manage?(socket.assigns.current_user, socket.assigns[:current_site])
 
       {:ok,
        socket
@@ -29,6 +30,13 @@ defmodule BrandoAdmin.Sites.EnvironmentLive do
        |> refresh_data()}
     else
       {:ok, assign(socket, :socket_connected, false)}
+    end
+  end
+
+  defp can_manage?(current_user, current_site) do
+    case Tenant.mode() do
+      :multi -> not is_nil(current_site) and Access.can_manage?(current_user, current_site)
+      _other -> current_user.role in @manager_roles
     end
   end
 

--- a/lib/brando_admin/live/config/site_live.ex
+++ b/lib/brando_admin/live/config/site_live.ex
@@ -1,0 +1,392 @@
+defmodule BrandoAdmin.Sites.SiteLive do
+  @moduledoc false
+
+  use BrandoAdmin, :live_view
+  use BrandoAdmin.Toast
+  use Gettext, backend: Brando.Gettext
+
+  alias Brando.Sites.Site
+  alias Brando.Tenant.Access
+  alias Brando.Tenant.Registry
+  alias Brando.Tenant.Setup
+  alias Brando.Tenant.Storage
+  alias Brando.Users.User
+  alias BrandoAdmin.Components.Content
+
+  @impl Phoenix.LiveView
+  def mount(_params, _session, socket) do
+    cond do
+      Brando.Tenant.mode() != :multi or socket.assigns.current_user.role != :superuser ->
+        {:ok, redirect(socket, to: "/admin")}
+
+      connected?(socket) ->
+        {:ok, socket |> assign(:socket_connected, true) |> refresh()}
+
+      true ->
+        {:ok, assign(socket, :socket_connected, false)}
+    end
+  end
+
+  @impl Phoenix.LiveView
+  def render(%{socket_connected: false} = assigns) do
+    ~H"""
+    """
+  end
+
+  def render(assigns) do
+    ~H"""
+    <Content.header
+      title={gettext("Sites")}
+      subtitle={gettext("Provision isolated sites, control lifecycle, and assign users")}
+    >
+      <button type="button" class="secondary" phx-click="refresh">{gettext("Refresh")}</button>
+    </Content.header>
+
+    <div class="environment-management-live">
+      <section class="environment-panel">
+        <h2>{gettext("Create site")}</h2>
+        <p>{gettext("Creates Production and Staging schemas, seeds initial content, and grants you site admin access.")}</p>
+        <form id="create-site-form" phx-submit="create_site">
+          <div class="environment-grid">
+            <label>
+              <span>{gettext("Name")}</span>
+              <input name="site[name]" required placeholder={gettext("Acme Corporation")} />
+            </label>
+            <label>
+              <span>{gettext("Key")}</span>
+              <input name="site[key]" required pattern="[a-z0-9]+(?:-[a-z0-9]+)*" placeholder="acme" />
+            </label>
+            <label>
+              <span>{gettext("Languages")}</span>
+              <input name="site[languages]" required value="en" placeholder="en,no" />
+            </label>
+            <label>
+              <span>{gettext("Default language")}</span>
+              <input name="site[default_language]" required value="en" />
+            </label>
+            <label>
+              <span>{gettext("Delivery")}</span>
+              <select name="site[delivery_mode]">
+                <option value="dynamic">{gettext("Dynamic")}</option>
+                <option value="static">{gettext("Static")}</option>
+              </select>
+              <small>
+                {gettext("Dynamic is served directly by Phoenix. Static requires a configured SSG build and deploy pipeline.")}
+              </small>
+            </label>
+          </div>
+          <button type="submit" class="primary" phx-disable-with={gettext("Provisioning…")}>
+            {gettext("Create site")}
+          </button>
+        </form>
+      </section>
+
+      <section :for={site <- @sites} class="environment-panel" id={"site-#{site.id}"}>
+        <header>
+          <div>
+            <h2>{site.name}</h2>
+            <p><code>{site.key}</code></p>
+          </div>
+          <span class={["environment-state", site.status == :active && "live"]}>{site.status}</span>
+        </header>
+
+        <dl class="site-stats">
+          <div>
+            <dt>{gettext("Environments")}</dt><dd>{length(site.environments)}</dd>
+          </div>
+          <div>
+            <dt>{gettext("Pages")}</dt><dd>{stat(@stats, site.id, :page_count)}</dd>
+          </div>
+          <div>
+            <dt>{gettext("Media")}</dt><dd>{format_size(stat(@stats, site.id, :media_size))}</dd>
+          </div>
+          <div>
+            <dt>{gettext("Last page edit")}</dt><dd>{format_last_edit(stat(@stats, site.id, :last_edit))}</dd>
+          </div>
+        </dl>
+
+        <div class="environment-actions">
+          <button
+            :if={site.status == :active}
+            type="button"
+            class="secondary"
+            phx-click="suspend"
+            phx-value-id={site.id}
+          >
+            {gettext("Suspend")}
+          </button>
+          <button
+            :if={site.status == :suspended}
+            type="button"
+            class="primary"
+            phx-click="activate_site"
+            phx-value-id={site.id}
+          >
+            {gettext("Activate")}
+          </button>
+          <button
+            :if={site.status != :archived}
+            type="button"
+            class="danger"
+            phx-click="archive"
+            phx-value-id={site.id}
+            phx-confirm={gettext("Archive %{name}? Its domains will stop serving immediately.", name: site.name)}
+          >
+            {gettext("Archive")}
+          </button>
+          <button
+            :if={site.status == :archived}
+            type="button"
+            class="secondary"
+            phx-click="activate_site"
+            phx-value-id={site.id}
+          >
+            {gettext("Restore")}
+          </button>
+          <button
+            :if={site.status == :archived}
+            type="button"
+            class="danger"
+            phx-click="delete"
+            phx-value-id={site.id}
+            phx-confirm={gettext("Permanently delete %{name}, all schemas, media, and uploaded assets?", name: site.name)}
+          >
+            {gettext("Permanently delete")}
+          </button>
+        </div>
+
+        <div class="environment-grid">
+          <section>
+            <h3>{gettext("Site users")}</h3>
+            <p :if={assignments(@assignments, site.id) == []}>{gettext("No explicit user assignments.")}</p>
+            <table :if={assignments(@assignments, site.id) != []}>
+              <tbody>
+                <tr :for={assignment <- assignments(@assignments, site.id)} id={"assignment-#{assignment.id}"}>
+                  <td>{assignment.user.name}<small>{assignment.user.email}</small></td>
+                  <td><span class="badge">{assignment.role}</span></td>
+                  <td>
+                    <button
+                      type="button"
+                      class="danger small"
+                      phx-click="revoke"
+                      phx-value-site-id={site.id}
+                      phx-value-user-id={assignment.user_id}
+                    >
+                      {gettext("Revoke")}
+                    </button>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </section>
+
+          <section>
+            <h3>{gettext("Grant access")}</h3>
+            <form phx-submit="grant" id={"grant-site-#{site.id}"}>
+              <input type="hidden" name="assignment[site_id]" value={site.id} />
+              <label>
+                <span>{gettext("User")}</span>
+                <select name="assignment[user_id]" required>
+                  <option :for={user <- @users} value={user.id}>{user.name} · {user.email}</option>
+                </select>
+              </label>
+              <label>
+                <span>{gettext("Role")}</span>
+                <select name="assignment[role]">
+                  <option value="editor">{gettext("Editor")}</option>
+                  <option value="admin">{gettext("Administrator")}</option>
+                </select>
+              </label>
+              <button type="submit" class="primary">{gettext("Grant access")}</button>
+            </form>
+          </section>
+        </div>
+      </section>
+    </div>
+    """
+  end
+
+  @impl Phoenix.LiveView
+  def handle_event("refresh", _params, socket), do: {:noreply, refresh(socket)}
+
+  def handle_event("create_site", %{"site" => params}, socket) do
+    attrs = %{
+      name: params["name"],
+      key: params["key"],
+      languages: parse_languages(params["languages"]),
+      default_language: params["default_language"],
+      status: :active,
+      delivery_mode: parse_delivery_mode(params["delivery_mode"])
+    }
+
+    case Setup.create_site(attrs, socket.assigns.current_user) do
+      {:ok, site} -> {:noreply, socket |> notify(gettext("Site %{name} created.", name: site.name)) |> refresh()}
+      {:error, reason} -> {:noreply, notify_error(socket, lifecycle_error(reason))}
+    end
+  end
+
+  def handle_event("grant", %{"assignment" => params}, socket) do
+    with {:ok, site} <- site_from_socket(socket, params["site_id"]),
+         {:ok, user} <- user_from_socket(socket, params["user_id"]),
+         {:ok, role} <- parse_role(params["role"]),
+         {:ok, _assignment} <- Access.grant(user, site, role) do
+      {:noreply, socket |> notify(gettext("Site access updated.")) |> refresh()}
+    else
+      {:error, reason} -> {:noreply, notify_error(socket, lifecycle_error(reason))}
+    end
+  end
+
+  def handle_event("revoke", params, socket) do
+    with {:ok, site} <- site_from_socket(socket, params["site-id"]),
+         {:ok, user} <- user_from_socket(socket, params["user-id"]),
+         :ok <- Access.revoke(user, site) do
+      {:noreply, socket |> notify(gettext("Site access revoked.")) |> refresh()}
+    else
+      {:error, reason} -> {:noreply, notify_error(socket, lifecycle_error(reason))}
+    end
+  end
+
+  for {event, operation} <- [
+        {"suspend", :suspend_site},
+        {"activate_site", :activate_site},
+        {"archive", :archive_site},
+        {"delete", :delete_site}
+      ] do
+    def handle_event(unquote(event), %{"id" => id}, socket) do
+      with {:ok, site} <- site_from_socket(socket, id),
+           {:ok, _site} <- apply(Setup, unquote(operation), [site]) do
+        {:noreply, socket |> notify(gettext("Site lifecycle updated.")) |> refresh()}
+      else
+        {:error, reason} -> {:noreply, notify_error(socket, lifecycle_error(reason))}
+      end
+    end
+  end
+
+  defp refresh(socket) do
+    sites = Registry.list_sites() |> Enum.sort_by(&{&1.name, &1.id})
+    {:ok, users} = Brando.Users.list_users(%{order: "asc name"})
+    users = Enum.reject(users, &(&1.role == :superuser))
+
+    socket
+    |> assign(:sites, sites)
+    |> assign(:users, users)
+    |> assign(:assignments, Map.new(sites, &{&1.id, Access.list_assignments(&1)}))
+    |> assign(:stats, Map.new(sites, &{&1.id, site_stats(&1)}))
+  end
+
+  defp site_stats(site) do
+    live_environment = Enum.find(site.environments, & &1.live)
+
+    %{
+      page_count: page_stat(site, live_environment, :count),
+      last_edit: page_stat(site, live_environment, :last_edit),
+      media_size: directory_size(Storage.media_root(site))
+    }
+  end
+
+  defp page_stat(_site, nil, _stat), do: "—"
+
+  defp page_stat(site, environment, stat) do
+    prefix = Brando.Tenant.prefix(site, environment)
+    table = Brando.Pages.Page.__schema__(:source)
+
+    sql =
+      case stat do
+        :count -> ~s|SELECT count(*) FROM "#{prefix}"."#{table}"|
+        :last_edit -> ~s|SELECT max(updated_at) FROM "#{prefix}"."#{table}"|
+      end
+
+    case Ecto.Adapters.SQL.query(Brando.Repo.repo(), sql, []) do
+      {:ok, %{rows: [[value]]}} -> value || "—"
+      {:error, _reason} -> "—"
+    end
+  end
+
+  defp directory_size(path) do
+    case File.ls(path) do
+      {:ok, entries} ->
+        Enum.reduce(entries, 0, fn entry, total ->
+          child = Path.join(path, entry)
+
+          case File.lstat(child) do
+            {:ok, %{type: :regular, size: size}} -> total + size
+            {:ok, %{type: :directory}} -> total + directory_size(child)
+            _symlink_or_error -> total
+          end
+        end)
+
+      {:error, _reason} ->
+        0
+    end
+  end
+
+  defp site_from_socket(socket, id) do
+    with {site_id, ""} <- Integer.parse(to_string(id)),
+         %Site{} = site <- Enum.find(socket.assigns.sites, &(&1.id == site_id)) do
+      {:ok, site}
+    else
+      _ -> {:error, :site_not_found}
+    end
+  end
+
+  defp user_from_socket(socket, id) do
+    with {user_id, ""} <- Integer.parse(to_string(id)),
+         %User{} = user <- Enum.find(socket.assigns.users, &(&1.id == user_id)) do
+      {:ok, user}
+    else
+      _ -> {:error, :user_not_found}
+    end
+  end
+
+  defp parse_languages(languages) do
+    languages
+    |> to_string()
+    |> String.split(",")
+    |> Enum.map(&String.trim/1)
+    |> Enum.reject(&(&1 == ""))
+    |> Enum.uniq()
+  end
+
+  defp parse_delivery_mode("static"), do: :static
+  defp parse_delivery_mode(_dynamic), do: :dynamic
+
+  defp parse_role("editor"), do: {:ok, :editor}
+  defp parse_role("admin"), do: {:ok, :admin}
+  defp parse_role(_role), do: {:error, :invalid_role}
+
+  defp assignments(assignments, site_id), do: Map.get(assignments, site_id, [])
+  defp stat(stats, site_id, key), do: stats |> Map.get(site_id, %{}) |> Map.get(key, "—")
+
+  defp format_size("—"), do: "—"
+  defp format_size(bytes) when bytes < 1_024, do: "#{bytes} B"
+  defp format_size(bytes) when bytes < 1_048_576, do: "#{Float.round(bytes / 1_024, 1)} KB"
+  defp format_size(bytes), do: "#{Float.round(bytes / 1_048_576, 1)} MB"
+
+  defp format_last_edit(%NaiveDateTime{} = datetime), do: Calendar.strftime(datetime, "%Y-%m-%d %H:%M")
+  defp format_last_edit(%DateTime{} = datetime), do: Calendar.strftime(datetime, "%Y-%m-%d %H:%M")
+  defp format_last_edit(value), do: value
+
+  defp notify(socket, message) do
+    send(self(), {:toast, message})
+    socket
+  end
+
+  defp notify_error(socket, message) do
+    BrandoAdmin.Toast.send_to(socket.assigns.current_user, message, %{level: :error, type: :notification})
+    socket
+  end
+
+  defp lifecycle_error({:retention_period, days}),
+    do: gettext("This site must remain archived for %{days} days before permanent deletion.", days: days)
+
+  defp lifecycle_error(%Ecto.Changeset{} = changeset) do
+    changeset
+    |> Ecto.Changeset.traverse_errors(fn {message, _opts} -> message end)
+    |> Enum.flat_map(fn {field, messages} -> Enum.map(messages, &"#{field} #{&1}") end)
+    |> Enum.join(", ")
+  end
+
+  defp lifecycle_error({:site_setup_failed, reason, _compensation}), do: lifecycle_error(reason)
+  defp lifecycle_error(reason) when is_atom(reason), do: reason |> Atom.to_string() |> String.replace("_", " ")
+  defp lifecycle_error(reason), do: inspect(reason)
+end

--- a/lib/brando_admin/live/config/utils_live.ex
+++ b/lib/brando_admin/live/config/utils_live.ex
@@ -24,7 +24,7 @@ defmodule BrandoAdmin.Sites.UtilsLive do
   end
 
   defp assign_sitemap(socket) do
-    sitemap_path = Path.join([Brando.config(:media_path), "sitemaps", "sitemap.xml.gz"])
+    sitemap_path = Path.join([Brando.Tenant.Storage.current_media_root(), "sitemaps", "sitemap.xml.gz"])
 
     sitemap_last_updated =
       if File.exists?(sitemap_path) do

--- a/lib/brando_admin/live/nav.ex
+++ b/lib/brando_admin/live/nav.ex
@@ -3,6 +3,8 @@ defmodule BrandoAdmin.Nav do
   use BrandoAdmin, :child_live_view
   use Gettext, backend: Brando.Gettext
 
+  alias Brando.Tenant
+  alias Brando.Tenant.Access
   alias BrandoAdmin.Components.Content
 
   on_mount {BrandoAdmin.UserAuth, :mount_current_user}
@@ -16,7 +18,7 @@ defmodule BrandoAdmin.Nav do
       |> assign(:current_url, url)
       |> put_locale()
       |> assign_tenant_options()
-      |> assign(:menu_sections, BrandoAdmin.Menu.get_menu())
+      |> assign(:menu_sections, BrandoAdmin.Menu.get_menu(socket.assigns.current_user))
       |> then(&{:ok, &1})
     else
       socket
@@ -55,7 +57,7 @@ defmodule BrandoAdmin.Nav do
   end
 
   defp assign_tenant_options(socket) do
-    sites = if Brando.Tenant.enabled?(), do: Brando.Tenant.Cache.list_sites(), else: []
+    sites = tenant_sites(socket.assigns[:current_user], socket.assigns[:current_site])
 
     environments =
       case socket.assigns.current_site do
@@ -66,6 +68,15 @@ defmodule BrandoAdmin.Nav do
     socket
     |> assign(:tenant_sites, sites)
     |> assign(:tenant_environments, environments)
+    |> assign(:tenant_mode, Tenant.mode())
+  end
+
+  defp tenant_sites(current_user, current_site) do
+    case Tenant.mode() do
+      :none -> []
+      :single -> if current_site, do: [current_site], else: []
+      :multi -> Access.list_sites(current_user)
+    end
   end
 
   def render(assigns) do
@@ -129,7 +140,7 @@ defmodule BrandoAdmin.Nav do
             >
               <input type="hidden" name="_csrf_token" value={Plug.CSRFProtection.get_csrf_token()} />
               <input type="hidden" name="return_to" value={@current_url || "/admin"} />
-              <label :if={Brando.Tenant.mode() == :multi}>
+              <label :if={@tenant_mode == :multi}>
                 <span>{gettext("Site")}</span>
                 <select name="site_key">
                   <option
@@ -141,7 +152,7 @@ defmodule BrandoAdmin.Nav do
                   </option>
                 </select>
               </label>
-              <input :if={Brando.Tenant.mode() == :single} type="hidden" name="site_key" value={@current_site.key} />
+              <input :if={@tenant_mode == :single} type="hidden" name="site_key" value={@current_site.key} />
               <label>
                 <span>{gettext("Environment")}</span>
                 <select name="environment_key">

--- a/lib/brando_admin/live_view/listing/hooks.ex
+++ b/lib/brando_admin/live_view/listing/hooks.ex
@@ -255,37 +255,39 @@ defmodule BrandoAdmin.LiveView.Listing.Hooks do
             # Spawn translation Task
             lv_pid = self()
 
-            Task.start(fn ->
-              progress_fn = fn step ->
-                send(lv_pid, {:translation_progress, schema, %{step: step, entry_url: entry_url}})
-              end
+            Task.start(
+              Brando.Tenant.capture_context(fn ->
+                progress_fn = fn step ->
+                  send(lv_pid, {:translation_progress, schema, %{step: step, entry_url: entry_url}})
+                end
 
-              case Brando.AI.Translation.translate_entry(
-                     schema,
-                     duped_entry.id,
-                     source_lang,
-                     language,
-                     progress_fn
-                   ) do
-                {:ok, _} ->
-                  send(
-                    lv_pid,
-                    {:translation_progress, schema, %{step: :complete, entry_url: entry_url, language: language}}
-                  )
+                case Brando.AI.Translation.translate_entry(
+                       schema,
+                       duped_entry.id,
+                       source_lang,
+                       language,
+                       progress_fn
+                     ) do
+                  {:ok, _} ->
+                    send(
+                      lv_pid,
+                      {:translation_progress, schema, %{step: :complete, entry_url: entry_url, language: language}}
+                    )
 
-                  update_list_entries(schema)
+                    update_list_entries(schema)
 
-                {:error, reason} ->
-                  # Roll back: delete the duplicated entry
-                  apply(context, :"delete_#{singular}", [duped_entry.id, user])
-                  update_list_entries(schema)
+                  {:error, reason} ->
+                    # Roll back: delete the duplicated entry
+                    apply(context, :"delete_#{singular}", [duped_entry.id, user])
+                    update_list_entries(schema)
 
-                  send(
-                    lv_pid,
-                    {:translation_progress, schema, %{step: {:error, inspect(reason)}, entry_url: nil}}
-                  )
-              end
-            end)
+                    send(
+                      lv_pid,
+                      {:translation_progress, schema, %{step: {:error, inspect(reason)}, entry_url: nil}}
+                    )
+                end
+              end)
+            )
 
             {:halt, socket}
 

--- a/lib/brando_admin/menu.ex
+++ b/lib/brando_admin/menu.ex
@@ -249,108 +249,115 @@ defmodule BrandoAdmin.Menu do
     [
       %{
         name: gettext("System"),
-        items: [
-          %{
-            name: gettext("Dashboard"),
-            url: "/admin"
-          },
-          %{
-            name: gettext("Configuration"),
-            url: nil,
-            items:
-              [
-                %{
-                  name: gettext("Navigation"),
-                  url: "/admin/config/navigation/menus"
-                },
-                %{
-                  name: gettext("Identity"),
-                  url: "/admin/config/identity"
-                },
-                %{
-                  name: gettext("SEO"),
-                  url: "/admin/config/seo"
-                },
-                %{
-                  name: gettext("Globals"),
-                  url: "/admin/config/global_sets"
-                },
-                %{
-                  name: gettext("Scheduled publishing"),
-                  url: "/admin/config/scheduled_publishing"
-                },
-                Brando.Tenant.enabled?() &&
+        items:
+          [
+            %{
+              name: gettext("Dashboard"),
+              url: "/admin"
+            },
+            Brando.Tenant.mode() == :multi && current_user && current_user.role == :superuser &&
+              %{
+                name: gettext("Sites"),
+                url: "/admin/sites"
+              },
+            %{
+              name: gettext("Configuration"),
+              url: nil,
+              items:
+                [
                   %{
-                    name: gettext("Environments"),
-                    url: "/admin/config/environments"
+                    name: gettext("Navigation"),
+                    url: "/admin/config/navigation/menus"
                   },
-                current_user && current_user.role == :superuser &&
                   %{
-                    name: gettext("Frontend assets"),
-                    url: "/admin/config/assets"
+                    name: gettext("Identity"),
+                    url: "/admin/config/identity"
                   },
+                  %{
+                    name: gettext("SEO"),
+                    url: "/admin/config/seo"
+                  },
+                  %{
+                    name: gettext("Globals"),
+                    url: "/admin/config/global_sets"
+                  },
+                  %{
+                    name: gettext("Scheduled publishing"),
+                    url: "/admin/config/scheduled_publishing"
+                  },
+                  Brando.Tenant.enabled?() &&
+                    %{
+                      name: gettext("Environments"),
+                      url: "/admin/config/environments"
+                    },
+                  current_user && current_user.role == :superuser &&
+                    %{
+                      name: gettext("Frontend assets"),
+                      url: "/admin/config/assets"
+                    },
+                  %{
+                    name: gettext("Cache"),
+                    url: "/admin/config/cache"
+                  },
+                  %{
+                    name: gettext("Utilities"),
+                    url: "/admin/config/utils"
+                  },
+                  %{
+                    name: gettext("Block modules"),
+                    url: "/admin/config/content/modules"
+                  },
+                  %{
+                    name: gettext("Block module sets"),
+                    url: "/admin/config/content/module_sets"
+                  },
+                  %{
+                    name: gettext("Containers"),
+                    url: "/admin/config/content/containers"
+                  },
+                  %{
+                    name: gettext("Table Templates"),
+                    url: "/admin/config/content/table_templates"
+                  },
+                  %{
+                    name: gettext("Templates"),
+                    url: "/admin/config/content/templates"
+                  },
+                  %{
+                    name: gettext("Palettes"),
+                    url: "/admin/config/content/palettes"
+                  }
+                ]
+                |> Enum.reject(&(&1 in [false, nil]))
+            },
+            %{
+              name: gettext("Assets"),
+              url: nil,
+              items: [
                 %{
-                  name: gettext("Cache"),
-                  url: "/admin/config/cache"
+                  name: gettext("Images"),
+                  url: "/admin/assets/images"
                 },
                 %{
-                  name: gettext("Utilities"),
-                  url: "/admin/config/utils"
+                  name: gettext("Files"),
+                  url: "/admin/assets/files"
                 },
                 %{
-                  name: gettext("Block modules"),
-                  url: "/admin/config/content/modules"
+                  name: gettext("Videos"),
+                  url: "/admin/assets/videos"
                 },
                 %{
-                  name: gettext("Block module sets"),
-                  url: "/admin/config/content/module_sets"
-                },
-                %{
-                  name: gettext("Containers"),
-                  url: "/admin/config/content/containers"
-                },
-                %{
-                  name: gettext("Table Templates"),
-                  url: "/admin/config/content/table_templates"
-                },
-                %{
-                  name: gettext("Templates"),
-                  url: "/admin/config/content/templates"
-                },
-                %{
-                  name: gettext("Palettes"),
-                  url: "/admin/config/content/palettes"
+                  name: gettext("Galleries"),
+                  url: "/admin/assets/galleries"
                 }
               ]
-              |> Enum.reject(&(&1 in [false, nil]))
-          },
-          %{
-            name: gettext("Assets"),
-            url: nil,
-            items: [
-              %{
-                name: gettext("Images"),
-                url: "/admin/assets/images"
-              },
-              %{
-                name: gettext("Files"),
-                url: "/admin/assets/files"
-              },
-              %{
-                name: gettext("Videos"),
-                url: "/admin/assets/videos"
-              },
-              %{
-                name: gettext("Galleries"),
-                url: "/admin/assets/galleries"
-              }
-            ]
-          },
-          %{
-            name: gettext("Users"),
-            url: "/admin/users"
-          }
-        ]
+            },
+            %{
+              name: gettext("Users"),
+              url: "/admin/users"
+            }
+          ]
+          |> Enum.reject(&(&1 in [false, nil]))
       },
       %{
         name: gettext("Content"),

--- a/lib/brando_admin/menu.ex
+++ b/lib/brando_admin/menu.ex
@@ -243,7 +243,7 @@ defmodule BrandoAdmin.Menu do
     end
   end
 
-  def get_menu do
+  def get_menu(current_user \\ nil) do
     content_menus = Brando.admin_module(Menus).__menus__()
 
     [
@@ -284,6 +284,11 @@ defmodule BrandoAdmin.Menu do
                     name: gettext("Environments"),
                     url: "/admin/config/environments"
                   },
+                current_user && current_user.role == :superuser &&
+                  %{
+                    name: gettext("Frontend assets"),
+                    url: "/admin/config/assets"
+                  },
                 %{
                   name: gettext("Cache"),
                   url: "/admin/config/cache"
@@ -317,7 +322,7 @@ defmodule BrandoAdmin.Menu do
                   url: "/admin/config/content/palettes"
                 }
               ]
-              |> Enum.reject(&(&1 == false))
+              |> Enum.reject(&(&1 in [false, nil]))
           },
           %{
             name: gettext("Assets"),

--- a/lib/mix/tasks/brando.migrate_to_tenant.ex
+++ b/lib/mix/tasks/brando.migrate_to_tenant.ex
@@ -1,0 +1,91 @@
+defmodule Mix.Tasks.Brando.MigrateToTenant do
+  @shortdoc "Copies an existing public-schema installation into a new tenant site"
+
+  @moduledoc """
+  Migrates existing public content into a new site's Production schema, then
+  creates Staging as a complete copy.
+
+      mix brando.migrate_to_tenant --site-key=my-site
+      mix brando.migrate_to_tenant --site-key=my-site --name="My Site" --creator-email=admin@example.com
+
+  Global users, sessions, tenant registry rows, Oban jobs, and asset-set
+  metadata remain in `public` and are never copied into the tenant schema.
+  """
+
+  use Mix.Task
+
+  import Ecto.Query, only: [from: 2]
+
+  alias Brando.Users.User
+
+  @switches [site_key: :string, name: :string, creator_email: :string]
+
+  @impl Mix.Task
+  def run(args) do
+    Mix.Task.run("app.start")
+    {opts, _remaining, invalid} = OptionParser.parse(args, strict: @switches)
+
+    if invalid != [], do: Mix.raise("Invalid options: #{inspect(invalid)}")
+
+    site_key = opts[:site_key] || Mix.raise("--site-key is required")
+    name = opts[:name] || site_key |> String.replace("-", " ") |> String.capitalize()
+    creator = creator!(opts[:creator_email])
+    languages = configured_languages()
+    default_language = Brando.config(:default_language) |> to_string()
+
+    attrs = %{
+      name: name,
+      key: site_key,
+      languages: languages,
+      default_language: default_language,
+      status: :active,
+      delivery_mode: :dynamic
+    }
+
+    case Brando.Tenant.Migration.migrate_public(attrs, creator) do
+      {:ok, site} ->
+        Mix.shell().info("Migrated public content into site #{site.key} with Production and Staging environments")
+
+      {:error, reason} ->
+        Mix.raise("Tenant migration failed: #{inspect(reason)}")
+    end
+  end
+
+  defp creator!(nil) do
+    from(user in User,
+      where: user.role == :superuser and user.active,
+      order_by: [asc: user.id],
+      limit: 1
+    )
+    |> Brando.Repo.one(prefix: "public")
+    |> case do
+      %User{} = user -> user
+      nil -> Mix.raise("No active superuser exists; pass --creator-email")
+    end
+  end
+
+  defp creator!(email) do
+    from(user in User, where: user.email == ^email and user.active)
+    |> Brando.Repo.one(prefix: "public")
+    |> case do
+      %User{} = user -> user
+      nil -> Mix.raise("No active user found for --creator-email=#{email}")
+    end
+  end
+
+  defp configured_languages do
+    Brando.config(:languages)
+    |> List.wrap()
+    |> Enum.map(fn
+      options when is_list(options) -> options[:value]
+      %{value: value} -> value
+      language -> language
+    end)
+    |> Enum.map(&to_string/1)
+    |> Enum.uniq()
+    |> case do
+      [] -> [Brando.config(:default_language) |> to_string()]
+      languages -> languages
+    end
+  end
+end

--- a/lib/mix/tasks/brando.ssg.ex
+++ b/lib/mix/tasks/brando.ssg.ex
@@ -6,17 +6,19 @@ defmodule Mix.Tasks.Brando.Ssg do
 
       mix brando.ssg
       mix brando.ssg --force
+      mix brando.ssg --site acme --force
 
   Options:
 
     * `--force` - Skip all prompts and run all steps
+    * `--site` - Site key to export in multi-site mode
 
   """
   use Mix.Task
 
   @default_host "http://localhost:4000"
   def run(args) do
-    {opts, _} = OptionParser.parse!(args, strict: [force: :boolean])
+    {opts, _} = OptionParser.parse!(args, strict: [force: :boolean, site: :string])
     force? = Keyword.get(opts, :force, false)
     Application.put_env(:phoenix, :serve_endpoints, true)
     Application.put_env(:logger, :level, :error)
@@ -30,6 +32,7 @@ defmodule Mix.Tasks.Brando.Ssg do
 
     Mix.Tasks.Run.run([])
     :inets.start()
+    site = select_tenant!(opts[:site])
 
     ssg_path = Brando.SSG.get_root_path()
     File.mkdir_p!(ssg_path)
@@ -39,42 +42,10 @@ defmodule Mix.Tasks.Brando.Ssg do
     Application.put_env(Brando.config(:otp_app), :hmr, false)
     Application.put_env(Brando.config(:otp_app), :show_breakpoint_debug, false)
 
-    if force? or Mix.shell().yes?("\nGenerate static files? (cleans priv/static first)") do
-      # delete static
-      static_path = Path.join([File.cwd!(), "priv", "static"])
+    uploaded_assets_path = Brando.Assets.SiteAssets.current_root()
 
-      IO.write([
-        IO.ANSI.blue(),
-        "* ",
-        IO.ANSI.reset(),
-        "Deleting static files... "
-      ])
-
-      File.rm_rf!(static_path)
-      IO.write([IO.ANSI.green(), "done!\n", IO.ANSI.reset()])
-      # generate static files
-      assets_path = Path.join([File.cwd!(), "assets", "frontend"])
-      vite_path = Path.join([File.cwd!(), "assets", "frontend", "node_modules", ".bin", "vite"])
-
-      IO.write([
-        IO.ANSI.blue(),
-        "* ",
-        IO.ANSI.reset(),
-        "Building static files... "
-      ])
-
-      System.cmd(vite_path, ["build"], cd: assets_path)
-      IO.write([IO.ANSI.green(), "done!\n", IO.ANSI.reset()])
-
-      IO.write([
-        IO.ANSI.blue(),
-        "* ",
-        IO.ANSI.reset(),
-        "Copying static files... "
-      ])
-
-      File.cp_r!(static_path, ssg_path)
-      IO.write([IO.ANSI.green(), "done!\n", IO.ANSI.reset()])
+    if force? or Mix.shell().yes?("\nGenerate static files?") do
+      copy_or_build_assets(uploaded_assets_path, ssg_path)
     end
 
     if force? or Mix.shell().yes?("\nGenerate HTML?") do
@@ -90,10 +61,89 @@ defmodule Mix.Tasks.Brando.Ssg do
     Application.put_env(:brando, :ssg_run, :media)
 
     if force? or Mix.shell().yes?("\nCopy media directory?") do
-      media_path = Path.join([File.cwd!(), "media"])
+      media_path = media_path(site)
       File.cp_r!(media_path, Path.join([ssg_path, "media"]))
     end
 
     Application.put_env(:brando, :ssg_run, :normal)
+  end
+
+  defp copy_or_build_assets(nil, ssg_path) do
+    static_path = Path.join([File.cwd!(), "priv", "static"])
+
+    IO.write([
+      IO.ANSI.blue(),
+      "* ",
+      IO.ANSI.reset(),
+      "Deleting static files... "
+    ])
+
+    File.rm_rf!(static_path)
+    IO.write([IO.ANSI.green(), "done!\n", IO.ANSI.reset()])
+    # generate static files
+    assets_path = Path.join([File.cwd!(), "assets", "frontend"])
+    vite_path = Path.join([File.cwd!(), "assets", "frontend", "node_modules", ".bin", "vite"])
+
+    IO.write([
+      IO.ANSI.blue(),
+      "* ",
+      IO.ANSI.reset(),
+      "Building static files... "
+    ])
+
+    System.cmd(vite_path, ["build"], cd: assets_path)
+    IO.write([IO.ANSI.green(), "done!\n", IO.ANSI.reset()])
+
+    IO.write([
+      IO.ANSI.blue(),
+      "* ",
+      IO.ANSI.reset(),
+      "Copying static files... "
+    ])
+
+    File.cp_r!(static_path, ssg_path)
+    IO.write([IO.ANSI.green(), "done!\n", IO.ANSI.reset()])
+  end
+
+  defp copy_or_build_assets(uploaded_assets_path, ssg_path) do
+    IO.write([
+      IO.ANSI.blue(),
+      "* ",
+      IO.ANSI.reset(),
+      "Copying active uploaded asset set... "
+    ])
+
+    File.cp_r!(uploaded_assets_path, ssg_path)
+    IO.write([IO.ANSI.green(), "done!\n", IO.ANSI.reset()])
+  end
+
+  defp select_tenant!(requested_site_key) do
+    case Brando.Tenant.mode() do
+      :none ->
+        nil
+
+      mode when mode in [:single, :multi] ->
+        site_key =
+          if mode == :single,
+            do: Brando.config(:site_key),
+            else: requested_site_key || Mix.raise("--site is required in multi-site mode")
+
+        with %Brando.Sites.Site{} = site <- Brando.Tenant.Registry.get_site_by_key(site_key),
+             %Brando.Environments.Environment{} = environment <-
+               Brando.Tenant.Cache.get_live_env(site.key) do
+          Brando.Tenant.put_prefix(Brando.Tenant.prefix(site, environment))
+          site
+        else
+          _ -> Mix.raise("Could not resolve an active site and live environment for #{inspect(site_key)}")
+        end
+    end
+  end
+
+  defp media_path(nil), do: Brando.config(:media_path)
+
+  defp media_path(site) do
+    if Brando.Tenant.mode() == :multi,
+      do: Brando.Tenant.Storage.media_root(site),
+      else: Brando.config(:media_path)
   end
 end

--- a/priv/repo/migrations/20260816002000_add_user_sites.exs
+++ b/priv/repo/migrations/20260816002000_add_user_sites.exs
@@ -1,0 +1,24 @@
+defmodule Brando.Repo.Migrations.AddUserSites do
+  use Ecto.Migration
+
+  @moduledoc """
+  Test/e2e mirror of `priv/templates/brando.upgrade/migrations/brando_160_*`.
+  """
+
+  def change do
+    create table(:user_sites, prefix: "public") do
+      add :user_id, references(:users, prefix: "public", on_delete: :delete_all), null: false
+      add :site_id, references(:sites, prefix: "public", on_delete: :delete_all), null: false
+      add :role, :text, null: false
+      timestamps(type: :utc_datetime_usec)
+    end
+
+    create unique_index(:user_sites, [:user_id, :site_id], prefix: "public")
+    create index(:user_sites, [:site_id, :role], prefix: "public")
+
+    create constraint(:user_sites, :user_sites_valid_role,
+             prefix: "public",
+             check: "role IN ('editor', 'admin')"
+           )
+  end
+end

--- a/priv/repo/migrations/20260816002100_add_site_archival.exs
+++ b/priv/repo/migrations/20260816002100_add_site_archival.exs
@@ -1,0 +1,11 @@
+defmodule BrandoIntegration.Repo.Migrations.AddSiteArchival do
+  use Ecto.Migration
+
+  def change do
+    alter table(:sites, prefix: "public") do
+      add :archived_at, :utc_datetime_usec
+    end
+
+    create index(:sites, [:status, :archived_at], prefix: "public")
+  end
+end

--- a/priv/repo/migrations/20260816002200_add_site_asset_sets.exs
+++ b/priv/repo/migrations/20260816002200_add_site_asset_sets.exs
@@ -1,0 +1,44 @@
+defmodule BrandoIntegration.Repo.Migrations.AddSiteAssetSets do
+  use Ecto.Migration
+
+  def change do
+    create table(:site_asset_sets, prefix: "public") do
+      add :site_id, references(:sites, prefix: "public", on_delete: :delete_all)
+      add :name, :text, null: false
+      add :path, :text, null: false
+      add :active, :boolean, null: false, default: false
+      add :uploaded_at, :utc_datetime_usec, null: false
+      add :size, :bigint, null: false, default: 0
+      add :file_count, :integer, null: false, default: 0
+      add :metadata, :map, null: false, default: %{}
+
+      timestamps(type: :utc_datetime_usec)
+    end
+
+    create unique_index(:site_asset_sets, [:name],
+             prefix: "public",
+             where: "site_id IS NULL",
+             name: :site_asset_sets_standalone_name_index
+           )
+
+    create unique_index(:site_asset_sets, [:site_id, :name],
+             prefix: "public",
+             where: "site_id IS NOT NULL",
+             name: :site_asset_sets_site_name_index
+           )
+
+    create unique_index(:site_asset_sets, [:active],
+             prefix: "public",
+             where: "site_id IS NULL AND active",
+             name: :site_asset_sets_one_standalone_active_index
+           )
+
+    create unique_index(:site_asset_sets, [:site_id],
+             prefix: "public",
+             where: "site_id IS NOT NULL AND active",
+             name: :site_asset_sets_one_site_active_index
+           )
+
+    create index(:site_asset_sets, [:site_id, :uploaded_at], prefix: "public")
+  end
+end

--- a/priv/templates/brando.install/lib/application_name_web/endpoint.ex
+++ b/priv/templates/brando.install/lib/application_name_web/endpoint.ex
@@ -23,6 +23,8 @@ defmodule <%= application_module %>Web.Endpoint do
   #
   # You should set gzip to true if you are running phoenix.digest
   # when deploying your static files in production.
+  plug Brando.Plug.SiteAssets
+
   plug Plug.Static,
     at: "/",
     from: :<%= application_name %>,

--- a/priv/templates/brando.upgrade/migrations/brando_160_add_user_sites.exs
+++ b/priv/templates/brando.upgrade/migrations/brando_160_add_user_sites.exs
@@ -1,4 +1,4 @@
-defmodule <%= application_module %>.Repo.Migrations.Brando160AddUserSites do
+defmodule Brando.Repo.Migrations.Brando160AddUserSites do
   use Ecto.Migration
 
   def change do

--- a/priv/templates/brando.upgrade/migrations/brando_160_add_user_sites.exs
+++ b/priv/templates/brando.upgrade/migrations/brando_160_add_user_sites.exs
@@ -1,0 +1,20 @@
+defmodule <%= application_module %>.Repo.Migrations.Brando160AddUserSites do
+  use Ecto.Migration
+
+  def change do
+    create table(:user_sites, prefix: "public") do
+      add :user_id, references(:users, prefix: "public", on_delete: :delete_all), null: false
+      add :site_id, references(:sites, prefix: "public", on_delete: :delete_all), null: false
+      add :role, :text, null: false
+      timestamps(type: :utc_datetime_usec)
+    end
+
+    create unique_index(:user_sites, [:user_id, :site_id], prefix: "public")
+    create index(:user_sites, [:site_id, :role], prefix: "public")
+
+    create constraint(:user_sites, :user_sites_valid_role,
+             prefix: "public",
+             check: "role IN ('editor', 'admin')"
+           )
+  end
+end

--- a/priv/templates/brando.upgrade/migrations/brando_161_add_site_archival.exs
+++ b/priv/templates/brando.upgrade/migrations/brando_161_add_site_archival.exs
@@ -1,0 +1,11 @@
+defmodule Brando.Repo.Migrations.Brando161AddSiteArchival do
+  use Ecto.Migration
+
+  def change do
+    alter table(:sites, prefix: "public") do
+      add :archived_at, :utc_datetime_usec
+    end
+
+    create index(:sites, [:status, :archived_at], prefix: "public")
+  end
+end

--- a/priv/templates/brando.upgrade/migrations/brando_162_add_site_asset_sets.exs
+++ b/priv/templates/brando.upgrade/migrations/brando_162_add_site_asset_sets.exs
@@ -1,0 +1,44 @@
+defmodule Brando.Repo.Migrations.Brando162AddSiteAssetSets do
+  use Ecto.Migration
+
+  def change do
+    create table(:site_asset_sets, prefix: "public") do
+      add :site_id, references(:sites, prefix: "public", on_delete: :delete_all)
+      add :name, :text, null: false
+      add :path, :text, null: false
+      add :active, :boolean, null: false, default: false
+      add :uploaded_at, :utc_datetime_usec, null: false
+      add :size, :bigint, null: false, default: 0
+      add :file_count, :integer, null: false, default: 0
+      add :metadata, :map, null: false, default: %{}
+
+      timestamps(type: :utc_datetime_usec)
+    end
+
+    create unique_index(:site_asset_sets, [:name],
+             prefix: "public",
+             where: "site_id IS NULL",
+             name: :site_asset_sets_standalone_name_index
+           )
+
+    create unique_index(:site_asset_sets, [:site_id, :name],
+             prefix: "public",
+             where: "site_id IS NOT NULL",
+             name: :site_asset_sets_site_name_index
+           )
+
+    create unique_index(:site_asset_sets, [:active],
+             prefix: "public",
+             where: "site_id IS NULL AND active",
+             name: :site_asset_sets_one_standalone_active_index
+           )
+
+    create unique_index(:site_asset_sets, [:site_id],
+             prefix: "public",
+             where: "site_id IS NOT NULL AND active",
+             name: :site_asset_sets_one_site_active_index
+           )
+
+    create index(:site_asset_sets, [:site_id, :uploaded_at], prefix: "public")
+  end
+end

--- a/test/brando/assets/site_assets_test.exs
+++ b/test/brando/assets/site_assets_test.exs
@@ -1,0 +1,166 @@
+defmodule Brando.Assets.SiteAssetsTest do
+  use ExUnit.Case, async: false
+  use Brando.ConnCase
+
+  alias Brando.Assets.SiteAssets
+  alias Brando.Assets.Vite.Manifest
+  alias Brando.Tenant
+  alias Brando.Tenant.Registry
+
+  setup do
+    root = Path.join(System.tmp_dir!(), "brando-site-assets-#{System.unique_integer([:positive])}")
+    media_path = Path.join(root, "media")
+    sites_path = Path.join(root, "sites")
+    site_assets_path = Path.join(root, "site_assets")
+
+    put_test_env(:tenancy_mode, :none)
+    put_test_env(:media_path, media_path)
+    put_test_env(:sites_path, sites_path)
+    put_test_env(:site_assets_path, site_assets_path)
+    SiteAssets.invalidate_cache()
+
+    on_exit(fn ->
+      File.rm_rf(root)
+      Tenant.put_prefix(nil)
+      SiteAssets.invalidate_cache()
+      Brando.Tenant.Cache.clear()
+      :persistent_term.erase({:vite, "cache_manifest"})
+      :persistent_term.erase({:vite, "critical_css"})
+    end)
+
+    %{root: root}
+  end
+
+  test "registers, activates, serves, and reverts a standalone set" do
+    set_path = create_set(nil, "20260816_abc123", "standalone", "standalone.css")
+
+    assert {:ok, registered} =
+             SiteAssets.register_set(set_path, %{
+               uploaded_at: "2026-08-16T12:30:00Z",
+               revision: "abc123"
+             })
+
+    refute registered.active
+    assert registered.file_count == 3
+    assert registered.size > 0
+    assert registered.metadata["revision"] == "abc123"
+    assert SiteAssets.cached() == nil
+    refute Brando.Plug.SiteAssets.call(conn("assets/20260816_abc123.js"), []).halted
+
+    assert {:ok, active} = SiteAssets.activate_set(registered.id)
+    assert active.active
+
+    assert %{files: files, manifest: manifest} = SiteAssets.cached()
+    assert MapSet.member?(files, "assets/20260816_abc123.js")
+    assert manifest["src/main.js"]["file"] == "assets/20260816_abc123.js"
+
+    served = Brando.Plug.SiteAssets.call(conn("assets/20260816_abc123.js"), [])
+    assert served.halted
+    assert served.status == 200
+    assert served.resp_body == "standalone"
+
+    parsed_manifest = Manifest.read(:app)
+    assert parsed_manifest.entries.files == ["/assets/20260816_abc123.js"]
+    assert parsed_manifest.entries.css_files == ["/assets/standalone.css"]
+
+    assert :ok = SiteAssets.deactivate()
+    assert SiteAssets.cached() == nil
+    refute Brando.Plug.SiteAssets.call(conn("assets/20260816_abc123.js"), []).halted
+  end
+
+  test "activation validates manifests before replacing the current set" do
+    first_path = create_set(nil, "first", "first", "first.css")
+    assert {:ok, first} = SiteAssets.register_set(first_path)
+    assert {:ok, _active} = SiteAssets.activate_set(first.id)
+
+    invalid_path = Path.join(SiteAssets.sets_root(nil), "invalid")
+    File.mkdir_p!(invalid_path)
+    File.write!(Path.join(invalid_path, "manifest.json"), "not-json")
+
+    assert {:ok, invalid} = SiteAssets.register_set(invalid_path)
+    assert {:error, {:invalid_asset_manifest, _, _}} = SiteAssets.activate_set(invalid.id)
+    assert SiteAssets.active_set().id == first.id
+  end
+
+  test "rejects registration outside the managed sets directory", %{root: root} do
+    outside = Path.join(root, "outside")
+    File.mkdir_p!(outside)
+
+    assert {:error, {:invalid_asset_set_path, _, _}} = SiteAssets.register_set(outside)
+  end
+
+  test "isolates active files and manifests per site host" do
+    put_test_env(:tenancy_mode, :multi)
+    Brando.Tenant.Cache.clear()
+
+    {:ok, acme} = create_site("Asset Acme", "asset-acme", "assets.acme.test")
+    {:ok, beta} = create_site("Asset Beta", "asset-beta", "assets.beta.test")
+
+    acme_path = create_set(acme, "acme-set", "acme-js", "acme.css")
+    beta_path = create_set(beta, "beta-set", "beta-js", "beta.css")
+
+    assert {:ok, acme_set} = SiteAssets.register_set(acme, acme_path, %{revision: "acme"})
+    assert {:ok, beta_set} = SiteAssets.register_set(beta.key, beta_path, %{revision: "beta"})
+    assert {:ok, _active} = SiteAssets.activate_set(acme_set.id)
+    assert {:ok, _active} = SiteAssets.activate_set(beta_set.id)
+
+    acme_conn = Brando.Plug.SiteAssets.call(conn("assets/acme-set.js", "assets.acme.test"), [])
+    beta_conn = Brando.Plug.SiteAssets.call(conn("assets/beta-set.js", "assets.beta.test"), [])
+
+    assert acme_conn.resp_body == "acme-js"
+    assert beta_conn.resp_body == "beta-js"
+    refute Brando.Plug.SiteAssets.call(conn("assets/acme-set.js", "assets.beta.test"), []).halted
+
+    Tenant.put_prefix(Tenant.prefix(acme.key, "production"))
+    assert Manifest.read(:app).entries.files == ["/assets/acme-set.js"]
+
+    Tenant.put_prefix(Tenant.prefix(beta.key, "production"))
+    assert Manifest.read(:app).entries.files == ["/assets/beta-set.js"]
+  end
+
+  defp create_set(site, name, js_content, css_file) do
+    path = Path.join(SiteAssets.sets_root(site), name)
+    File.mkdir_p!(Path.join(path, "assets"))
+    File.write!(Path.join([path, "assets", "#{name}.js"]), js_content)
+    File.write!(Path.join([path, "assets", css_file]), "body{}")
+
+    manifest = %{
+      "src/main.js" => %{
+        "isEntry" => true,
+        "file" => "assets/#{name}.js",
+        "css" => ["assets/#{css_file}"]
+      }
+    }
+
+    File.write!(Path.join(path, "manifest.json"), Jason.encode!(manifest))
+    path
+  end
+
+  defp create_site(name, key, domain) do
+    {:ok, site} =
+      Registry.create_site(%{
+        name: name,
+        key: key,
+        languages: ["en"],
+        default_language: "en",
+        status: :active,
+        delivery_mode: :dynamic
+      })
+
+    {:ok, _environment} =
+      Registry.create_environment(site, %{
+        name: "Production",
+        key: "production",
+        live: true,
+        domain: domain
+      })
+
+    {:ok, Registry.get_site(site.id)}
+  end
+
+  defp conn(relative_path, host \\ "standalone.test") do
+    :get
+    |> Plug.Test.conn("https://#{host}/#{relative_path}")
+    |> Map.put(:host, host)
+  end
+end

--- a/test/brando/plug/admin_tenant_test.exs
+++ b/test/brando/plug/admin_tenant_test.exs
@@ -41,12 +41,24 @@ defmodule Brando.Plug.AdminTenantTest do
       })
 
     conn =
-      init_test_session(conn, %{
+      conn
+      |> init_test_session(%{
         "brando_site_key" => "acme",
         "brando_environment_key" => "preview"
       })
+      |> Plug.Conn.assign(:current_user, Brando.Factory.insert(:random_user, role: :superuser))
 
     %{conn: conn, site: site, production: production, preview: preview}
+  end
+
+  test "does not restore an unassigned site for a regular user", context do
+    user = Brando.Factory.insert(:random_user, role: :admin)
+    conn = Plug.Conn.assign(context.conn, :current_user, user)
+
+    conn = AdminTenant.call(conn, [])
+
+    refute conn.assigns[:current_site]
+    assert Tenant.current_prefix() == nil
   end
 
   test "restores the signed-session environment for controller requests", context do

--- a/test/brando/plug/tenant_test.exs
+++ b/test/brando/plug/tenant_test.exs
@@ -76,6 +76,23 @@ defmodule Brando.Plug.TenantTest do
       |> Brando.Plug.Tenant.call([])
 
     refute conn.assigns[:current_site]
+    assert conn.halted
+    assert conn.status == 404
+    assert Tenant.current_prefix() == nil
+  end
+
+  test "suspended sites are no longer served by their domains", context do
+    assert {:ok, _site} = Registry.update_site(context.site, %{status: :suspended})
+
+    conn =
+      :get
+      |> Plug.Test.conn("https://www.acme.test/")
+      |> Map.put(:host, "www.acme.test")
+      |> Brando.Plug.Tenant.call([])
+
+    assert conn.halted
+    assert conn.status == 404
+    refute conn.assigns[:current_site]
     assert Tenant.current_prefix() == nil
   end
 

--- a/test/brando/tenant_access_test.exs
+++ b/test/brando/tenant_access_test.exs
@@ -1,0 +1,69 @@
+defmodule Brando.TenantAccessTest do
+  use ExUnit.Case, async: false
+  use Brando.ConnCase
+
+  alias Brando.Tenant.Access
+  alias Brando.Tenant.Cache
+  alias Brando.Tenant.Registry
+
+  setup do
+    put_test_env(:tenancy_mode, :multi)
+    Cache.clear()
+
+    on_exit(&Cache.clear/0)
+
+    {:ok, acme} = create_site("Acme", "access-acme")
+    {:ok, beta} = create_site("Beta", "access-beta")
+    {:ok, suspended} = create_site("Suspended", "access-suspended", :suspended)
+
+    superuser = Brando.Factory.insert(:random_user, role: :superuser)
+    admin = Brando.Factory.insert(:random_user, role: :admin)
+    editor = Brando.Factory.insert(:random_user, role: :editor)
+
+    %{admin: admin, acme: acme, beta: beta, editor: editor, superuser: superuser, suspended: suspended}
+  end
+
+  test "superusers bypass assignments for active sites", context do
+    assert Enum.map(Access.list_sites(context.superuser), & &1.id) == [context.acme.id, context.beta.id]
+    assert Access.role_for(context.superuser, context.acme) == :superuser
+    assert Access.can_manage?(context.superuser, context.beta)
+    refute Access.can_access?(context.superuser, context.suspended)
+  end
+
+  test "regular users see only assigned active sites with their per-site role", context do
+    assert {:ok, _assignment} = Access.grant(context.admin, context.acme, :admin)
+    assert {:ok, _assignment} = Access.grant(context.admin, context.beta, :editor)
+    assert {:ok, _assignment} = Access.grant(context.admin, context.suspended, :admin)
+
+    assert Enum.map(Access.list_sites(context.admin), & &1.id) == [context.acme.id, context.beta.id]
+    assert Access.role_for(context.admin, context.acme) == :admin
+    assert Access.role_for(context.admin, context.beta) == :editor
+    assert Access.can_manage?(context.admin, context.acme)
+    refute Access.can_manage?(context.admin, context.beta)
+    refute Access.can_access?(context.admin, context.suspended)
+  end
+
+  test "grant updates an assignment and revoke removes access", context do
+    assert {:ok, assignment} = Access.grant(context.editor, context.acme, :editor)
+    assert assignment.role == :editor
+
+    assert {:ok, updated} = Access.grant(context.editor, context.acme, :admin)
+    assert updated.id == assignment.id
+    assert updated.role == :admin
+
+    assert :ok = Access.revoke(context.editor, context.acme)
+    assert :ok = Access.revoke(context.editor, context.acme)
+    refute Access.can_access?(context.editor, context.acme)
+  end
+
+  defp create_site(name, key, status \\ :active) do
+    Registry.create_site(%{
+      name: name,
+      key: key,
+      languages: ["en"],
+      default_language: "en",
+      status: status,
+      delivery_mode: :dynamic
+    })
+  end
+end

--- a/test/brando/tenant_cache_key_test.exs
+++ b/test/brando/tenant_cache_key_test.exs
@@ -5,15 +5,17 @@ defmodule Brando.TenantCacheKeyTest do
   alias Brando.Cache.Query
   alias Brando.Tenant
 
+  @prefixes ~w(tenant_cache-a_production tenant_cache-a_preview tenant_cache-b_production)
+
   setup do
+    previous_identity = Cachex.get(:cache, :identity)
     put_test_env(:tenancy_mode, :multi)
-    Cachex.clear(:cache)
-    Cachex.clear(:query)
+    cleanup_tenant_entries()
 
     on_exit(fn ->
       Tenant.put_prefix(nil)
-      Cachex.clear(:cache)
-      Cachex.clear(:query)
+      cleanup_tenant_entries()
+      restore_cache_entry(:cache, :identity, previous_identity)
     end)
 
     :ok
@@ -60,4 +62,20 @@ defmodule Brando.TenantCacheKeyTest do
     assert {:ok, %{name: "Legacy"}} = Cachex.get(:cache, :identity)
     assert {:list, "pages", _hash} = Query.hash_query({:list, "pages", %{}})
   end
+
+  defp cleanup_tenant_entries do
+    Enum.each([:cache, :query], fn cache ->
+      {:ok, keys} = Cachex.keys(cache)
+
+      keys
+      |> Enum.filter(&tenant_test_key?/1)
+      |> Enum.each(&Cachex.del(cache, &1))
+    end)
+  end
+
+  defp tenant_test_key?({:tenant, prefix, _key}), do: prefix in @prefixes
+  defp tenant_test_key?(_key), do: false
+
+  defp restore_cache_entry(cache, key, {:ok, nil}), do: Cachex.del(cache, key)
+  defp restore_cache_entry(cache, key, {:ok, value}), do: Cachex.put(cache, key, value)
 end

--- a/test/brando/tenant_cache_key_test.exs
+++ b/test/brando/tenant_cache_key_test.exs
@@ -1,0 +1,63 @@
+defmodule Brando.TenantCacheKeyTest do
+  use ExUnit.Case, async: false
+  use Brando.ConnCase
+
+  alias Brando.Cache.Query
+  alias Brando.Tenant
+
+  setup do
+    put_test_env(:tenancy_mode, :multi)
+    Cachex.clear(:cache)
+    Cachex.clear(:query)
+
+    on_exit(fn ->
+      Tenant.put_prefix(nil)
+      Cachex.clear(:cache)
+      Cachex.clear(:query)
+    end)
+
+    :ok
+  end
+
+  test "application cache entries are isolated by the complete tenant prefix" do
+    Tenant.put_prefix("tenant_cache-a_production")
+    assert {:ok, true} = Brando.Cache.put(:navigation, %{site: "a"}, :infinite)
+
+    Tenant.put_prefix("tenant_cache-b_production")
+    assert Brando.Cache.get(:navigation) == nil
+    assert {:ok, true} = Brando.Cache.put(:navigation, %{site: "b"}, :infinite)
+
+    Tenant.put_prefix("tenant_cache-a_production")
+    assert Brando.Cache.get(:navigation) == %{site: "a"}
+
+    assert {:ok, keys} = Cachex.keys(:cache)
+    assert {:tenant, "tenant_cache-a_production", :navigation} in keys
+    assert {:tenant, "tenant_cache-b_production", :navigation} in keys
+  end
+
+  test "query cache misses and hits independently for each environment" do
+    query_key = {:list, "pages", %{status: :published}}
+
+    Tenant.put_prefix("tenant_cache-a_production")
+    assert {:miss, cache_key_a, _ttl} = Query.try_cache(query_key, true)
+    assert {:ok, true} = Query.put(cache_key_a, [:site_a], :timer.minutes(1))
+    assert {:hit, [:site_a]} = Query.try_cache(query_key, true)
+
+    Tenant.put_prefix("tenant_cache-a_preview")
+    assert {:miss, cache_key_preview, _ttl} = Query.try_cache(query_key, true)
+    refute cache_key_a == cache_key_preview
+
+    Tenant.put_prefix("tenant_cache-b_production")
+    assert {:miss, cache_key_b, _ttl} = Query.try_cache(query_key, true)
+    refute cache_key_a == cache_key_b
+  end
+
+  test "tenancy mode none preserves legacy cache keys" do
+    put_test_env(:tenancy_mode, :none)
+    Tenant.put_prefix(nil)
+
+    assert {:ok, true} = Brando.Cache.put(:identity, %{name: "Legacy"}, :infinite)
+    assert {:ok, %{name: "Legacy"}} = Cachex.get(:cache, :identity)
+    assert {:list, "pages", _hash} = Query.hash_query({:list, "pages", %{}})
+  end
+end

--- a/test/brando/tenant_job_test.exs
+++ b/test/brando/tenant_job_test.exs
@@ -1,0 +1,96 @@
+defmodule Brando.TenantJobTest do
+  use ExUnit.Case, async: false
+  use Brando.ConnCase
+
+  alias Brando.Tenant
+  alias Brando.Tenant.Job
+  alias Brando.Tenant.Registry
+
+  setup do
+    put_test_env(:tenancy_mode, :multi)
+    Tenant.put_prefix(nil)
+
+    on_exit(fn -> Tenant.put_prefix(nil) end)
+
+    :ok
+  end
+
+  test "attaches and restores tenant context across a job boundary" do
+    Tenant.put_prefix("tenant_acme_production")
+
+    assert %{"tenant_prefix" => "tenant_acme_production", image_id: 42} =
+             Job.attach(%{image_id: 42})
+
+    Tenant.put_prefix("tenant_beta_staging")
+
+    assert Job.run(%{"tenant_prefix" => "tenant_acme_production"}, fn ->
+             Tenant.current_prefix()
+           end) == "tenant_acme_production"
+
+    assert Tenant.current_prefix() == "tenant_beta_staging"
+  end
+
+  test "cancels tenant jobs whose context is missing or invalid" do
+    assert_raise ArgumentError, ~r/require a current tenant prefix/, fn -> Job.attach(%{}) end
+
+    assert Job.run(%{}, fn -> flunk("must not run") end) ==
+             {:cancel, :missing_tenant_prefix}
+
+    assert Job.run(%{"tenant_prefix" => "public"}, fn -> flunk("must not run") end) ==
+             {:cancel, :invalid_tenant_prefix}
+  end
+
+  test "runs maintenance in every environment of active sites" do
+    active = create_site("acme", :active)
+    suspended = create_site("beta", :suspended)
+
+    create_environment(active, "production", true)
+    create_environment(active, "staging", false)
+    create_environment(suspended, "production", true)
+
+    assert Job.each_active_environment(:all, fn -> Tenant.current_prefix() end) |> Enum.sort() ==
+             ["tenant_acme_production", "tenant_acme_staging"]
+
+    assert Job.each_active_environment(:live, fn -> Tenant.current_prefix() end) ==
+             ["tenant_acme_production"]
+  end
+
+  test "keeps legacy public-schema behavior when tenancy is disabled" do
+    put_test_env(:tenancy_mode, :none)
+    Tenant.put_prefix(nil)
+
+    assert Job.attach(%{id: 1}) == %{id: 1}
+    assert Job.run(%{}, fn -> :public end) == :public
+    assert Job.each_active_environment(:all, fn -> :public end) == [:public]
+  end
+
+  test "Oban jobs remain pinned to public while a tenant prefix is active" do
+    Tenant.put_prefix("tenant_missing_production")
+    assert Brando.Repo.all(Oban.Job) == []
+  end
+
+  defp create_site(key, status) do
+    {:ok, site} =
+      Registry.create_site(%{
+        name: String.capitalize(key),
+        key: key,
+        languages: ["en"],
+        default_language: "en",
+        status: status,
+        delivery_mode: :dynamic
+      })
+
+    site
+  end
+
+  defp create_environment(site, key, live) do
+    {:ok, environment} =
+      Registry.create_environment(site, %{
+        name: String.capitalize(key),
+        key: key,
+        live: live
+      })
+
+    environment
+  end
+end

--- a/test/brando/tenant_live_view_test.exs
+++ b/test/brando/tenant_live_view_test.exs
@@ -3,6 +3,7 @@ defmodule Brando.TenantLiveViewTest do
   use Brando.ConnCase
 
   alias Brando.Tenant
+  alias Brando.Tenant.Access
   alias Brando.Tenant.Cache
   alias Brando.Tenant.LiveView
   alias Brando.Tenant.Registry
@@ -40,32 +41,44 @@ defmodule Brando.TenantLiveViewTest do
         live: false
       })
 
-    %{site: site, production: production, preview: preview}
+    superuser = Brando.Factory.insert(:random_user, role: :superuser)
+    editor = Brando.Factory.insert(:random_user, role: :editor)
+    {:ok, _assignment} = Access.grant(editor, site, :editor)
+
+    %{editor: editor, site: site, production: production, preview: preview, superuser: superuser}
   end
 
   test "resolves the selected site and environment from signed session", context do
     assert {site, environment} =
-             LiveView.resolve_context(%{}, %{
-               "brando_site_key" => "acme",
-               "brando_environment_key" => "preview"
-             })
+             LiveView.resolve_context(
+               %{},
+               %{
+                 "brando_site_key" => "acme",
+                 "brando_environment_key" => "preview"
+               },
+               context.superuser
+             )
 
     assert site.id == context.site.id
     assert environment.id == context.preview.id
   end
 
   test "falls back to the live environment when the selection is missing", context do
-    assert {_site, environment} = LiveView.resolve_context(%{}, %{})
+    assert {_site, environment} = LiveView.resolve_context(%{}, %{}, context.editor)
 
     assert environment.id == context.production.id
   end
 
   test "resolves child LiveViews that are not mounted at the router", context do
     assert {site, environment} =
-             LiveView.resolve_context(:not_mounted_at_router, %{
-               "brando_site_key" => "acme",
-               "brando_environment_key" => "preview"
-             })
+             LiveView.resolve_context(
+               :not_mounted_at_router,
+               %{
+                 "brando_site_key" => "acme",
+                 "brando_environment_key" => "preview"
+               },
+               context.superuser
+             )
 
     assert site.id == context.site.id
     assert environment.id == context.preview.id
@@ -78,6 +91,15 @@ defmodule Brando.TenantLiveViewTest do
     assert {site, environment} = LiveView.resolve_context(%{}, %{})
     assert site.id == context.site.id
     assert environment.id == context.production.id
+  end
+
+  test "multi mode does not resolve a site without an authorized user" do
+    assert LiveView.resolve_context(%{}, %{}) == nil
+  end
+
+  test "multi mode does not resolve a site for an unassigned user" do
+    unassigned = Brando.Factory.insert(:random_user, role: :admin)
+    assert LiveView.resolve_context(%{}, %{}, unassigned) == nil
   end
 
   test "none mode has no LiveView tenant context" do

--- a/test/brando/tenant_media_test.exs
+++ b/test/brando/tenant_media_test.exs
@@ -1,0 +1,91 @@
+defmodule Brando.TenantMediaTest do
+  use ExUnit.Case, async: false
+  use Brando.ConnCase
+
+  alias Brando.Tenant
+  alias Brando.Tenant.Registry
+  alias Brando.Tenant.Storage
+
+  setup do
+    media_path =
+      Path.join(System.tmp_dir!(), "brando-tenant-media-#{System.unique_integer([:positive])}")
+
+    put_test_env(:tenancy_mode, :multi)
+    put_test_env(:media_path, media_path)
+    Brando.Tenant.Cache.clear()
+
+    on_exit(fn ->
+      File.rm_rf(media_path)
+      Tenant.put_prefix(nil)
+      Brando.Tenant.Cache.clear()
+    end)
+
+    {:ok, acme} = create_site("Acme", "media-acme")
+    {:ok, beta} = create_site("Beta", "media-beta")
+    {:ok, _environment} = create_environment(acme, "acme.media.test")
+    {:ok, _environment} = create_environment(beta, "beta.media.test")
+
+    for {site, content} <- [{acme, "acme logo"}, {beta, "beta logo"}] do
+      path = Path.join([Storage.media_root(site), "images", "logo.txt"])
+      File.mkdir_p!(Path.dirname(path))
+      File.write!(path, content)
+    end
+
+    %{acme: acme, beta: beta, media_path: media_path}
+  end
+
+  test "serves the same relative media path from the request host's site" do
+    assert serve("acme.media.test", "/media/images/logo.txt").resp_body == "acme logo"
+    assert serve("beta.media.test", "/media/images/logo.txt").resp_body == "beta logo"
+  end
+
+  test "does not fall through to another site or the shared media root", %{media_path: media_path} do
+    shared_path = Path.join([media_path, "images", "logo.txt"])
+    File.mkdir_p!(Path.dirname(shared_path))
+    File.write!(shared_path, "shared logo")
+
+    conn = serve("unknown.media.test", "/media/images/logo.txt")
+
+    assert conn.halted
+    assert conn.status == 404
+    refute conn.resp_body =~ "shared logo"
+  end
+
+  test "filesystem helpers use the current tenant prefix", %{acme: acme} do
+    Tenant.put_prefix(Tenant.prefix(acme.key, "production"))
+
+    assert Storage.current_media_root() == Storage.media_root(acme)
+
+    assert Brando.Images.Utils.media_path("images/logo.txt") ==
+             Path.join(Storage.media_root(acme), "images/logo.txt")
+  end
+
+  defp serve(host, path) do
+    opts = Brando.Plug.Media.init(at: "/media")
+
+    :get
+    |> Plug.Test.conn("https://#{host}#{path}")
+    |> Map.put(:host, host)
+    |> Brando.Plug.Media.call(opts)
+  end
+
+  defp create_site(name, key) do
+    Registry.create_site(%{
+      name: name,
+      key: key,
+      languages: ["en"],
+      default_language: "en",
+      status: :active,
+      delivery_mode: :dynamic
+    })
+  end
+
+  defp create_environment(site, domain) do
+    Registry.create_environment(site, %{
+      name: "Production",
+      key: "production",
+      live: true,
+      domain: domain
+    })
+  end
+end

--- a/test/brando/tenant_migration_test.exs
+++ b/test/brando/tenant_migration_test.exs
@@ -1,0 +1,124 @@
+defmodule Brando.TenantMigrationTest do
+  use ExUnit.Case, async: false
+  use Brando.ConnCase
+
+  alias Brando.Environments.Schema
+  alias Brando.Tenant.Migration
+  alias Brando.Tenant.Registry
+
+  defmodule Migrator do
+    @behaviour Brando.Environments.Migrator
+
+    @impl true
+    def migrate(_site, _environment), do: {:ok, [20_260_816_000_001]}
+  end
+
+  defmodule SchemaCloner do
+    @behaviour Brando.Environments.SchemaCloner
+
+    @impl true
+    def clone_schema(_source_prefix, target_prefix), do: Schema.create(target_prefix)
+  end
+
+  defmodule PublicMigrator do
+    @behaviour Brando.Tenant.PublicDataMigrator
+
+    @impl true
+    def migrate(source_prefix, target_prefix) do
+      send(self(), {:public_data_migrated, source_prefix, target_prefix})
+      :ok
+    end
+  end
+
+  defmodule FailingPublicMigrator do
+    @behaviour Brando.Tenant.PublicDataMigrator
+
+    @impl true
+    def migrate(_source_prefix, _target_prefix), do: {:error, :public_copy_failed}
+  end
+
+  defmodule FailingMediaMigrator do
+    @behaviour Brando.Tenant.PublicMediaMigrator
+
+    @impl true
+    def migrate(_site), do: {:error, :media_copy_failed}
+  end
+
+  setup do
+    root = Path.join(System.tmp_dir!(), "brando-tenant-migration-#{System.unique_integer([:positive])}")
+    put_test_env(:tenancy_mode, :multi)
+    put_test_env(:tenant_migrator, Migrator)
+    put_test_env(:environment_schema_cloner, SchemaCloner)
+    put_test_env(:media_path, Path.join(root, "media"))
+    put_test_env(:sites_path, Path.join(root, "sites"))
+    Brando.Tenant.Cache.clear()
+
+    on_exit(fn ->
+      File.rm_rf(root)
+      Brando.Tenant.put_prefix(nil)
+      Brando.Tenant.Cache.clear()
+    end)
+
+    creator = Brando.Factory.insert(:random_user, role: :superuser)
+    %{creator: creator}
+  end
+
+  test "copies public content into Production before creating Staging", %{creator: creator} do
+    legacy_file = Path.join([Brando.config(:media_path), "images", "legacy.txt"])
+    File.mkdir_p!(Path.dirname(legacy_file))
+    File.write!(legacy_file, "legacy media")
+
+    assert {:ok, site} =
+             Migration.migrate_public(site_attrs("legacy-migration"), creator, public_data_migrator: PublicMigrator)
+
+    assert_received {:public_data_migrated, "public", "tenant_legacy-migration_production"}
+
+    assert Enum.map(site.environments, &{&1.key, &1.live}) |> Enum.sort() ==
+             [{"production", true}, {"staging", false}]
+
+    assert Schema.exists?("tenant_legacy-migration_production")
+    assert Schema.exists?("tenant_legacy-migration_staging")
+
+    assert File.read!(Path.join([Brando.config(:media_path), site.key, "images", "legacy.txt"])) ==
+             "legacy media"
+
+    assert File.read!(legacy_file) == "legacy media"
+  end
+
+  test "removes the partial site when public data copying fails", %{creator: creator} do
+    assert {:error, {:public_migration_failed, :public_copy_failed, :ok}} =
+             Migration.migrate_public(site_attrs("failed-legacy-migration"), creator,
+               public_data_migrator: FailingPublicMigrator
+             )
+
+    refute Registry.get_site_by_key("failed-legacy-migration")
+    refute Schema.exists?("tenant_failed-legacy-migration_production")
+  end
+
+  test "removes the partial tenant but preserves legacy media when media copying fails", %{creator: creator} do
+    legacy_file = Path.join([Brando.config(:media_path), "files", "legacy.txt"])
+    File.mkdir_p!(Path.dirname(legacy_file))
+    File.write!(legacy_file, "keep me")
+
+    assert {:error, {:public_migration_failed, :media_copy_failed, :ok}} =
+             Migration.migrate_public(site_attrs("failed-media-migration"), creator,
+               public_data_migrator: PublicMigrator,
+               public_media_migrator: FailingMediaMigrator
+             )
+
+    refute Registry.get_site_by_key("failed-media-migration")
+    assert File.read!(legacy_file) == "keep me"
+    refute File.exists?(Path.join(Brando.config(:media_path), "failed-media-migration"))
+  end
+
+  defp site_attrs(key) do
+    %{
+      name: "Legacy",
+      key: key,
+      languages: ["en"],
+      default_language: "en",
+      status: :active,
+      delivery_mode: :dynamic
+    }
+  end
+end

--- a/test/brando/tenant_public_data_migrator_postgres_test.exs
+++ b/test/brando/tenant_public_data_migrator_postgres_test.exs
@@ -1,0 +1,77 @@
+defmodule Brando.TenantPublicDataMigratorPostgresTest do
+  use ExUnit.Case, async: false
+
+  alias Brando.Tenant.PublicDataMigrator.Postgres
+
+  defmodule Repo do
+    use Ecto.Repo,
+      otp_app: :brando,
+      adapter: Ecto.Adapters.Postgres
+  end
+
+  setup_all do
+    integration_config = BrandoIntegration.Repo.config()
+
+    repo_options =
+      integration_config
+      |> Keyword.take([:database, :hostname, :password, :port, :socket_options, :ssl, :username])
+      |> Keyword.merge(pool: DBConnection.ConnectionPool, pool_size: 3)
+
+    previous_repo_config = Application.fetch_env(:brando, Repo)
+    Application.put_env(:brando, Repo, repo_options)
+    {:ok, repo} = Repo.start_link()
+
+    on_exit(fn ->
+      try do
+        GenServer.stop(repo)
+      catch
+        :exit, _ -> :ok
+      end
+
+      restore_env(Repo, previous_repo_config)
+    end)
+
+    :ok
+  end
+
+  setup do
+    previous_repo = Application.fetch_env(:brando, :repo_module)
+    Application.put_env(:brando, :repo_module, Repo)
+
+    unique = System.unique_integer([:positive])
+    table = "migration_records_#{unique}"
+    target = "tenant_publicmigration#{unique}_production"
+
+    Ecto.Adapters.SQL.query!(Repo, ~s|CREATE TABLE public."#{table}" (id serial PRIMARY KEY, name text NOT NULL)|, [])
+    Ecto.Adapters.SQL.query!(Repo, ~s|INSERT INTO public."#{table}" (name) VALUES ('legacy-one'), ('legacy-two')|, [])
+    Ecto.Adapters.SQL.query!(Repo, ~s|CREATE SCHEMA "#{target}"|, [])
+
+    Ecto.Adapters.SQL.query!(
+      Repo,
+      ~s|CREATE TABLE "#{target}"."#{table}" (id serial PRIMARY KEY, name text NOT NULL)|,
+      []
+    )
+
+    on_exit(fn ->
+      Ecto.Adapters.SQL.query!(Repo, ~s|DROP SCHEMA IF EXISTS "#{target}" CASCADE|, [])
+      Ecto.Adapters.SQL.query!(Repo, ~s|DROP TABLE IF EXISTS public."#{table}" CASCADE|, [])
+      restore_env(:repo_module, previous_repo)
+    end)
+
+    %{table: table, target: target}
+  end
+
+  test "copies data only for tables present in the migrated tenant schema", context do
+    assert :ok = Postgres.migrate("public", context.target)
+
+    assert %{rows: [["legacy-one"], ["legacy-two"]]} =
+             Ecto.Adapters.SQL.query!(
+               Repo,
+               ~s|SELECT name FROM "#{context.target}"."#{context.table}" ORDER BY id|,
+               []
+             )
+  end
+
+  defp restore_env(key, {:ok, value}), do: Application.put_env(:brando, key, value)
+  defp restore_env(key, :error), do: Application.delete_env(:brando, key)
+end

--- a/test/brando/tenant_setup_test.exs
+++ b/test/brando/tenant_setup_test.exs
@@ -1,0 +1,140 @@
+defmodule Brando.Tenant.SetupTest do
+  use ExUnit.Case, async: false
+  use Brando.ConnCase
+
+  alias Brando.Environments.Schema
+  alias Brando.Tenant
+  alias Brando.Tenant.Access
+  alias Brando.Tenant.Registry
+  alias Brando.Tenant.Setup
+  alias Brando.Tenant.Storage
+
+  defmodule Migrator do
+    @behaviour Brando.Environments.Migrator
+
+    @impl true
+    def migrate(site, environment) do
+      send(self(), {:migrated, site.key, environment.key})
+      {:ok, [20_260_816_000_001]}
+    end
+  end
+
+  defmodule SchemaCloner do
+    @behaviour Brando.Environments.SchemaCloner
+
+    @impl true
+    def clone_schema(source_prefix, target_prefix) do
+      send(self(), {:cloned, source_prefix, target_prefix})
+      Schema.create(target_prefix)
+    end
+  end
+
+  defmodule Seeder do
+    @behaviour Brando.Tenant.Seeder
+
+    @impl true
+    def seed(site, environment, creator) do
+      send(self(), {:seeded, site.key, environment.key, creator.id})
+      :ok
+    end
+  end
+
+  defmodule FailingSeeder do
+    @behaviour Brando.Tenant.Seeder
+
+    @impl true
+    def seed(_site, _environment, _creator), do: {:error, :seed_failed}
+  end
+
+  setup do
+    root = Path.join(System.tmp_dir!(), "brando-tenant-setup-#{System.unique_integer([:positive])}")
+    media_path = Path.join(root, "media")
+    sites_path = Path.join(root, "sites")
+
+    put_test_env(:tenancy_mode, :multi)
+    put_test_env(:tenant_migrator, Migrator)
+    put_test_env(:environment_schema_cloner, SchemaCloner)
+    put_test_env(:tenant_seeder, Seeder)
+    put_test_env(:media_path, media_path)
+    put_test_env(:sites_path, sites_path)
+
+    on_exit(fn ->
+      File.rm_rf(root)
+      Tenant.put_prefix(nil)
+      Brando.Tenant.Cache.clear()
+    end)
+
+    creator = Brando.Factory.insert(:random_user, role: :admin)
+    %{creator: creator, root: root}
+  end
+
+  test "creates, seeds, copies, and assigns a complete site", %{creator: creator} do
+    assert {:ok, site} = Setup.create_site(site_attrs("provisioned-site"), creator)
+
+    assert Enum.map(site.environments, &{&1.key, &1.live}) |> Enum.sort() ==
+             [{"production", true}, {"staging", false}]
+
+    assert_received {:migrated, "provisioned-site", "production"}
+    assert_received {:migrated, "provisioned-site", "staging"}
+    assert_received {:seeded, "provisioned-site", "production", creator_id}
+    assert creator_id == creator.id
+    assert_received {:cloned, "tenant_provisioned-site_production", "tenant_provisioned-site_staging"}
+
+    assert Schema.exists?("tenant_provisioned-site_production")
+    assert Schema.exists?("tenant_provisioned-site_staging")
+    assert File.dir?(Storage.media_root(site))
+    assert File.dir?(Storage.assets_root(site))
+    assert Access.role_for(creator, site) == :admin
+  end
+
+  test "compensates all persisted resources when provisioning fails", %{creator: creator} do
+    put_test_env(:tenant_seeder, FailingSeeder)
+
+    assert {:error, {:site_setup_failed, :seed_failed, _compensation}} =
+             Setup.create_site(site_attrs("broken-site"), creator)
+
+    refute Registry.get_site_by_key("broken-site")
+    refute Schema.exists?("tenant_broken-site_production")
+    refute File.exists?(Path.join(Brando.config(:media_path), "broken-site"))
+    refute File.exists?(Path.join(Brando.config(:sites_path), "broken-site"))
+  end
+
+  test "suspends, archives, and only permanently deletes after retention", %{creator: creator} do
+    assert {:ok, site} = Setup.create_site(site_attrs("retained-site"), creator)
+    assert {:ok, suspended} = Setup.suspend_site(site)
+    assert suspended.status == :suspended
+    refute Brando.Tenant.Cache.get_live_env(site.key)
+
+    archived_at = DateTime.utc_now()
+    assert {:ok, archived} = Setup.archive_site(suspended, now: archived_at)
+    assert archived.status == :archived
+    assert archived.archived_at == archived_at
+
+    assert {:error, {:retention_period, 30}} =
+             Setup.delete_site(archived, now: DateTime.add(archived_at, 29, :day))
+
+    assert Registry.get_site(archived.id)
+    assert Schema.exists?("tenant_retained-site_production")
+
+    assert {:ok, deleted} =
+             Setup.delete_site(archived, now: DateTime.add(archived_at, 30, :day))
+
+    assert deleted.id == archived.id
+    refute Registry.get_site(archived.id)
+    refute Schema.exists?("tenant_retained-site_production")
+    refute Schema.exists?("tenant_retained-site_staging")
+    refute File.exists?(Storage.media_root(archived))
+    refute File.exists?(Storage.site_root(archived))
+  end
+
+  defp site_attrs(key) do
+    %{
+      name: "Tenant #{key}",
+      key: key,
+      languages: ["en"],
+      default_language: "en",
+      status: :active,
+      delivery_mode: :dynamic
+    }
+  end
+end

--- a/test/brando/tenant_setup_test.exs
+++ b/test/brando/tenant_setup_test.exs
@@ -99,6 +99,19 @@ defmodule Brando.Tenant.SetupTest do
     refute File.exists?(Path.join(Brando.config(:sites_path), "broken-site"))
   end
 
+  test "never deletes storage that existed before provisioning", %{creator: creator} do
+    existing_root = Path.join(Brando.config(:media_path), "existing-site")
+    existing_file = Path.join(existing_root, "keep.txt")
+    File.mkdir_p!(existing_root)
+    File.write!(existing_file, "legacy")
+
+    assert {:error, {:site_setup_failed, {:site_storage_already_exists, ^existing_root}, _compensation}} =
+             Setup.create_site(site_attrs("existing-site"), creator)
+
+    refute Registry.get_site_by_key("existing-site")
+    assert File.read!(existing_file) == "legacy"
+  end
+
   test "suspends, archives, and only permanently deletes after retention", %{creator: creator} do
     assert {:ok, site} = Setup.create_site(site_attrs("retained-site"), creator)
     assert {:ok, suspended} = Setup.suspend_site(site)

--- a/test/brando/tenant_test.exs
+++ b/test/brando/tenant_test.exs
@@ -85,6 +85,19 @@ defmodule Brando.TenantTest do
     assert Tenant.current_prefix() == "tenant_acme_production"
   end
 
+  test "tenant context can be captured for zero- and one-arity task functions" do
+    put_test_env(:tenancy_mode, :multi)
+    Tenant.put_prefix("tenant_acme_production")
+
+    zero_arity = Tenant.capture_context(fn -> Tenant.current_prefix() end)
+    one_arity = Tenant.capture_context(fn value -> {Tenant.current_prefix(), value} end)
+
+    assert Task.async(zero_arity) |> Task.await() == "tenant_acme_production"
+
+    assert Task.async(fn -> one_arity.(:value) end) |> Task.await() ==
+             {"tenant_acme_production", :value}
+  end
+
   test "arbitrary schema names cannot enter the process context" do
     assert_raise ArgumentError, ~r/invalid tenant prefix/, fn ->
       Tenant.put_prefix("public; DROP SCHEMA public")

--- a/test/brando_admin/controllers/environment_controller_test.exs
+++ b/test/brando_admin/controllers/environment_controller_test.exs
@@ -3,6 +3,7 @@ defmodule BrandoAdmin.EnvironmentControllerTest do
   use Brando.ConnCase
 
   alias Brando.Tenant
+  alias Brando.Tenant.Access
   alias Brando.Tenant.Cache
   alias Brando.Tenant.Registry
 
@@ -39,7 +40,14 @@ defmodule BrandoAdmin.EnvironmentControllerTest do
         live: false
       })
 
-    %{conn: init_test_session(conn, %{}), site: site, production: production, preview: preview}
+    superuser = Brando.Factory.insert(:random_user, role: :superuser)
+
+    conn =
+      conn
+      |> init_test_session(%{})
+      |> Plug.Conn.assign(:current_user, superuser)
+
+    %{conn: conn, site: site, production: production, preview: preview}
   end
 
   test "stores a valid site and environment selection", context do
@@ -76,5 +84,32 @@ defmodule BrandoAdmin.EnvironmentControllerTest do
       })
 
     assert redirected_to(conn) == "/admin"
+  end
+
+  test "rejects a site selection the current user cannot access", context do
+    editor = Brando.Factory.insert(:random_user, role: :editor)
+    conn = Plug.Conn.assign(context.conn, :current_user, editor)
+
+    conn =
+      BrandoAdmin.EnvironmentController.update(conn, %{
+        "site_key" => "acme",
+        "environment_key" => "preview"
+      })
+
+    refute get_session(conn, "brando_site_key")
+    refute get_session(conn, "brando_environment_key")
+    assert redirected_to(conn) == "/admin"
+
+    assert {:ok, _assignment} = Access.grant(editor, context.site, :editor)
+
+    authorized_conn =
+      context.conn
+      |> Plug.Conn.assign(:current_user, editor)
+      |> BrandoAdmin.EnvironmentController.update(%{
+        "site_key" => "acme",
+        "environment_key" => "preview"
+      })
+
+    assert get_session(authorized_conn, "brando_site_key") == "acme"
   end
 end

--- a/test/brando_admin/live/asset_live_test.exs
+++ b/test/brando_admin/live/asset_live_test.exs
@@ -1,0 +1,60 @@
+defmodule BrandoAdmin.Sites.AssetLiveTest do
+  use Brando.LiveCase
+
+  alias Brando.Assets.SiteAssets
+
+  setup do
+    root = Path.join(System.tmp_dir!(), "brando-asset-live-#{System.unique_integer([:positive])}")
+    put_test_env(:tenancy_mode, :none)
+    put_test_env(:media_path, Path.join(root, "media"))
+    put_test_env(:site_assets_path, Path.join(root, "site_assets"))
+    SiteAssets.invalidate_cache()
+
+    on_exit(fn ->
+      File.rm_rf(root)
+      SiteAssets.invalidate_cache()
+    end)
+
+    set_path = Path.join(SiteAssets.sets_root(nil), "20260816_admin")
+    File.mkdir_p!(Path.join(set_path, "assets"))
+    File.write!(Path.join([set_path, "assets", "main.js"]), "console.log('active')")
+    File.write!(Path.join(set_path, "manifest.json"), "{}")
+    {:ok, asset_set} = SiteAssets.register_set(set_path, %{revision: "admin-test"})
+
+    %{asset_set: asset_set}
+  end
+
+  test "superusers activate and revert registered asset sets", %{conn: conn, asset_set: asset_set} do
+    {:ok, view, html} = live(conn, "/admin/config/assets")
+
+    assert html =~ "Frontend assets"
+    assert has_element?(view, "#asset-set-#{asset_set.id}", asset_set.name)
+    assert has_element?(view, "#asset-set-#{asset_set.id} button", "Activate")
+
+    view
+    |> element("#asset-set-#{asset_set.id} button", "Activate")
+    |> render_click()
+
+    assert SiteAssets.active_set().id == asset_set.id
+    assert has_element?(view, "#asset-set-#{asset_set.id}", "Active")
+
+    view
+    |> element("button", "Revert to release assets")
+    |> render_click()
+
+    refute SiteAssets.active_set()
+    assert has_element?(view, "#asset-set-#{asset_set.id}", "Available")
+  end
+
+  test "non-superusers are redirected", %{asset_set: _asset_set} do
+    editor =
+      Brando.Factory.insert(:random_user,
+        role: :editor,
+        config: %Brando.Users.UserConfig{}
+      )
+
+    conn = log_in_user(Phoenix.ConnTest.build_conn(), editor)
+
+    assert {:error, {:redirect, %{to: "/admin"}}} = live(conn, "/admin/config/assets")
+  end
+end

--- a/test/brando_admin/live/environment_live_test.exs
+++ b/test/brando_admin/live/environment_live_test.exs
@@ -5,6 +5,7 @@ defmodule BrandoAdmin.Sites.EnvironmentLiveTest do
   alias Brando.Environments.OperationLog
   alias Brando.Environments.Schema
   alias Brando.Tenant
+  alias Brando.Tenant.Access
   alias Brando.Tenant.Cache
   alias Brando.Tenant.Registry
 
@@ -140,6 +141,8 @@ defmodule BrandoAdmin.Sites.EnvironmentLiveTest do
         role: :editor,
         config: %Brando.Users.UserConfig{}
       )
+
+    assert {:ok, _assignment} = Access.grant(editor, site, :editor)
 
     conn = log_in_user(Phoenix.ConnTest.build_conn(), editor)
     {:ok, view, _html} = live(conn, "/admin/config/environments")

--- a/test/brando_admin/live/site_live_test.exs
+++ b/test/brando_admin/live/site_live_test.exs
@@ -1,0 +1,142 @@
+defmodule BrandoAdmin.Sites.SiteLiveTest do
+  use Brando.LiveCase
+
+  alias Brando.Environments.Schema
+  alias Brando.Tenant.Access
+  alias Brando.Tenant.Registry
+
+  defmodule Migrator do
+    @behaviour Brando.Environments.Migrator
+
+    @impl true
+    def migrate(_site, _environment), do: {:ok, [20_260_816_000_001]}
+  end
+
+  defmodule SchemaCloner do
+    @behaviour Brando.Environments.SchemaCloner
+
+    @impl true
+    def clone_schema(_source_prefix, target_prefix), do: Schema.create(target_prefix)
+  end
+
+  defmodule Seeder do
+    @behaviour Brando.Tenant.Seeder
+
+    @impl true
+    def seed(_site, _environment, _creator), do: :ok
+  end
+
+  setup do
+    root = Path.join(System.tmp_dir!(), "brando-site-live-#{System.unique_integer([:positive])}")
+
+    put_test_env(:tenancy_mode, :multi)
+    put_test_env(:tenant_migrator, Migrator)
+    put_test_env(:environment_schema_cloner, SchemaCloner)
+    put_test_env(:tenant_seeder, Seeder)
+    put_test_env(:media_path, Path.join(root, "media"))
+    put_test_env(:sites_path, Path.join(root, "sites"))
+    Brando.Tenant.Cache.clear()
+
+    on_exit(fn ->
+      File.rm_rf(root)
+      Brando.Tenant.put_prefix(nil)
+      Brando.Tenant.Cache.clear()
+    end)
+
+    {:ok, site} =
+      Registry.create_site(%{
+        name: "Existing Site",
+        key: "existing-site-dashboard",
+        languages: ["en"],
+        default_language: "en",
+        status: :active,
+        delivery_mode: :dynamic
+      })
+
+    {:ok, _environment} =
+      Registry.create_environment(site, %{
+        name: "Production",
+        key: "production",
+        live: true,
+        domain: "existing.dashboard.test"
+      })
+
+    editor =
+      Brando.Factory.insert(:random_user,
+        role: :editor,
+        config: %Brando.Users.UserConfig{}
+      )
+
+    %{editor: editor, site: Registry.get_site(site.id)}
+  end
+
+  test "superusers provision sites and manage per-site assignments", %{conn: conn, editor: editor} do
+    {:ok, view, html} = live(conn, "/admin/sites")
+
+    assert html =~ "Existing Site"
+
+    view
+    |> form("#create-site-form",
+      site: %{
+        name: "New Client",
+        key: "new-client-dashboard",
+        languages: "en,no",
+        default_language: "en",
+        delivery_mode: "dynamic"
+      }
+    )
+    |> render_submit()
+
+    created = Registry.get_site_by_key("new-client-dashboard")
+    assert created
+    assert Enum.map(created.environments, & &1.key) |> Enum.sort() == ["production", "staging"]
+    assert has_element?(view, "#site-#{created.id}", "New Client")
+
+    view
+    |> form("#grant-site-#{created.id}",
+      assignment: %{site_id: created.id, user_id: editor.id, role: "admin"}
+    )
+    |> render_submit()
+
+    assert Access.role_for(editor, created) == :admin
+    assert has_element?(view, "#site-#{created.id}", editor.email)
+
+    view
+    |> element("#site-#{created.id} button[phx-click=revoke][phx-value-user-id=\"#{editor.id}\"]")
+    |> render_click()
+
+    refute Access.can_access?(editor, created)
+  end
+
+  test "site lifecycle actions immediately update status", %{conn: conn, site: site} do
+    {:ok, view, _html} = live(conn, "/admin/sites")
+
+    view
+    |> element("#site-#{site.id} button", "Suspend")
+    |> render_click()
+
+    assert Registry.get_site(site.id).status == :suspended
+    assert has_element?(view, "#site-#{site.id}", "suspended")
+
+    view
+    |> element("#site-#{site.id} button", "Archive")
+    |> render_click()
+
+    archived = Registry.get_site(site.id)
+    assert archived.status == :archived
+    assert archived.archived_at
+
+    view
+    |> element("#site-#{site.id} button", "Permanently delete")
+    |> render_click()
+
+    assert Registry.get_site(site.id)
+  end
+
+  test "non-superusers are redirected", %{editor: editor, site: site} do
+    assert {:ok, _assignment} = Access.grant(editor, site, :admin)
+    conn = log_in_user(Phoenix.ConnTest.build_conn(), editor)
+
+    assert {:error, {:redirect, %{to: "/admin"}}} = live(conn, "/admin/sites")
+  end
+end

--- a/test/mix/tasks/brando_migrate_to_tenant_test.exs
+++ b/test/mix/tasks/brando_migrate_to_tenant_test.exs
@@ -1,0 +1,11 @@
+defmodule Mix.Tasks.BrandoMigrateToTenantTest do
+  use ExUnit.Case, async: false
+
+  test "requires a site key" do
+    Mix.Task.reenable("brando.migrate_to_tenant")
+
+    assert_raise Mix.Error, ~r/--site-key is required/, fn ->
+      Mix.Tasks.Brando.MigrateToTenant.run([])
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- completes the Brando Phase 3 multi-site surface: per-site roles, strict admin/frontend isolation, compensated lifecycle, per-site media, cache scoping, and the superuser Sites dashboard
- implements the Brando side of uploadable/versioned frontend asset sets, including registration, activation/rollback, persistent-term file and manifest caches, serving fallback, admin UI, and tenant-aware SSG input
- carries tenant context across Oban and Task process boundaries and fans maintenance jobs out across active tenant environments
- adds the existing-installation migration command with real pg_dump/psql data copying, non-destructive legacy media copying, and failure compensation
- expands the operating guide, including delivery_mode semantics and migration/cutover constraints

## Stacking

This PR targets codex/multitenancy-phase-2 and is intended to follow #2739. Reviewing it against that branch keeps the Phase 3 diff isolated.

## Validation

- strict test-environment compile with warnings as errors
- 1,658 checks passing: 1,523 tests plus 135 doctests
- real PostgreSQL schema-copy integration
- ExDoc build with warnings as errors
- E2E consumer Vite build

Tracks #2684 and the Brando deliverables in #2689. Florist upload/pruning/bootstrap work remains in its own repository, and the versioned automatic SSG build/deploy pipeline remains Phase 5 (#2686).