### PR TITLE
Add shared content library with tenant overrides

### DIFF
--- a/guides/tenancy_and_environments.md
+++ b/guides/tenancy_and_environments.md
@@ -12,7 +12,9 @@ environments backed by PostgreSQL schemas.
 > strict host and admin authorization, compensated site provisioning,
 > retention-aware site deletion, per-site media, tenant-scoped caches,
 > uploadable frontend asset sets, and the existing-installation migration task
-> are also available.
+> are also available. Multi-site installations can curate a shared module,
+> container, and palette library with per-site access and per-environment
+> overrides.
 > Before enabling tenancy for an application, you must provide tenant migrations
 > for every table the application queries as tenant content.
 
@@ -299,6 +301,61 @@ In `:multi`, a suspended, archived, or unknown frontend host receives `404`
 before content plugs run. A stale or forged admin site selection is checked
 against `public.user_sites`; it can never restore another tenant's schema
 prefix.
+
+## Shared modules, containers, and palettes
+
+In `:multi` mode, global superusers can manage reusable block building blocks
+at `/admin/config/content/shared_library`. Shared modules, containers, and
+palettes live in `public`; custom entries and customizations live in the
+selected environment schema.
+
+Access is opt-in and site-wide. Enabling an entry makes it available in every
+environment's picker for that site. It does not copy the entry into those
+schemas. A site can therefore use only custom entries, only an approved subset
+of the shared library, or a mixture of both. The dashboard supports saving an
+exact allowlist as well as enabling or disabling all entries of one kind.
+
+Blocks store both an integer ID and an explicit `local` or `shared` origin for
+their module, container, and palette references. The origin is significant:
+`local:42` and `shared:42` are different references even when PostgreSQL has
+assigned the same integer in both schemas. Existing local blocks are migrated
+with `local`, preserving pre-tenancy behavior.
+
+Resolution has two paths:
+
+- pickers return all non-deleted local entries plus the enabled shared entries;
+- rendering resolves the block's stored origin and may load a shared entry even
+  after picker access was revoked.
+
+The second rule is deliberate. Disabling a shared entry prevents adding new
+references but never breaks published or draft blocks that already use it.
+Deleting a shared entry is blocked while it is enabled, customized, or
+referenced in any environment. The dashboard shows those sites and
+environments before an edit or deletion.
+
+Choosing **Customize** copies the shared entry into the selected environment
+and records its source ID and source version. Blocks keep their shared identity,
+so they immediately resolve to that environment's customization without a
+content rewrite. Other environments and sites are unaffected. **Reset to
+shared** removes only the customization.
+
+Publishing a shared edit increments its version and records a changelog note.
+Sites without a customization use the new version immediately, and Brando
+queues affected entries for rendering in each environment. A customization
+continues using its local version and receives an **Update available** badge.
+The administrator can inspect a field-level diff, replace the customization
+with the current shared version, or dismiss that version's notification.
+
+The allowlist is cached per site. Mutations update the cache immediately; no
+application restart is required. When upgrading an existing application, run
+both public and tenant migrations so the public access tables, source/version
+columns, and origin-qualified block fields are present:
+
+```bash
+mix brando.upgrade
+mix brando.migrate
+mix brando.migrate --tenants
+```
 
 ## Per-site roles and lifecycle
 

--- a/lib/brando/content.ex
+++ b/lib/brando/content.ex
@@ -203,9 +203,9 @@ defmodule Brando.Content do
   @doc """
   Find module with `id` in `modules`
   """
-  def find_module(modules, id) do
+  def find_module(modules, id, origin \\ :local) do
     modules
-    |> Enum.find(&(&1.id == id))
+    |> Enum.find(&(&1.id == id and library_origin(&1) == normalize_library_origin(origin)))
     |> case do
       nil -> {:error, {:module, :not_found, id}}
       mod -> {:ok, mod}
@@ -215,9 +215,9 @@ defmodule Brando.Content do
   @doc """
   Find container with `id` in `containers`
   """
-  def find_container(containers, id) do
+  def find_container(containers, id, origin \\ :local) do
     containers
-    |> Enum.find(&(&1.id == id))
+    |> Enum.find(&(&1.id == id and library_origin(&1) == normalize_library_origin(origin)))
     |> case do
       nil -> {:error, {:container, :not_found, id}}
       mod -> {:ok, mod}
@@ -237,17 +237,29 @@ defmodule Brando.Content do
   @doc """
   Fetch a single module by ID from the cached module list.
   """
-  def fetch_module(id) do
-    {:ok, modules} = list_modules(@module_cache_opts)
-    Enum.find(modules, &(&1.id == id))
+  def fetch_module(id, origin \\ :local)
+
+  def fetch_module(id, origin) do
+    if Brando.Tenant.enabled?() do
+      Brando.Content.SharedLibrary.get_for_current_tenant(:module, id, origin)
+    else
+      {:ok, modules} = list_modules(@module_cache_opts)
+      Enum.find(modules, &(&1.id == id))
+    end
   end
 
   @doc """
   Fetch a single container by ID from the cached container list.
   """
-  def fetch_container(id) do
-    {:ok, containers} = list_containers(@container_cache_opts)
-    Enum.find(containers, &(&1.id == id))
+  def fetch_container(id, origin \\ :local)
+
+  def fetch_container(id, origin) do
+    if Brando.Tenant.enabled?() do
+      Brando.Content.SharedLibrary.get_for_current_tenant(:container, id, origin)
+    else
+      {:ok, containers} = list_containers(@container_cache_opts)
+      Enum.find(containers, &(&1.id == id))
+    end
   end
 
   ## Vars
@@ -373,14 +385,18 @@ defmodule Brando.Content do
   @doc """
   Find palette with `id` in `palettes`
   """
-  def find_palette(palettes, id) do
+  def find_palette(palettes, id, origin \\ :local) do
     palettes
-    |> Enum.find(&(&1.id == id))
+    |> Enum.find(&(&1.id == id and library_origin(&1) == normalize_library_origin(origin)))
     |> case do
       nil -> {:error, {:palette, :not_found, id}}
       palette -> {:ok, palette}
     end
   end
+
+  defp library_origin(entry), do: Map.get(entry, :library_origin) || :local
+  defp normalize_library_origin(origin) when origin in [:shared, "shared"], do: :shared
+  defp normalize_library_origin(_origin), do: :local
 
   @doc """
   Get color from palette by key

--- a/lib/brando/content/block.ex
+++ b/lib/brando/content/block.ex
@@ -25,10 +25,13 @@ defmodule Brando.Content.Block do
     :sequence,
     :parent_id,
     :module_id,
+    :module_origin,
     :container_id,
+    :container_origin,
     :fragment_id,
     :multi,
     :palette_id,
+    :palette_origin,
     :type,
     :source,
     :identifier_metas
@@ -95,6 +98,9 @@ defmodule Brando.Content.Block do
     attribute :rendered_at, :datetime
     attribute :source, Brando.Type.Module
     attribute :identifier_metas, Brando.Type.Json
+    attribute :module_origin, :enum, values: [:local, :shared], default: :local
+    attribute :container_origin, :enum, values: [:local, :shared], default: :local
+    attribute :palette_origin, :enum, values: [:local, :shared], default: :local
   end
 
   relations do

--- a/lib/brando/content/blocks.ex
+++ b/lib/brando/content/blocks.ex
@@ -141,13 +141,27 @@ defmodule Brando.Content.Blocks do
   @doc """
   Return list of all blocks using `palette_id`
   """
-  def list_block_ids_using_palette(palette_id) do
+  def list_block_ids_using_palette(palette_id, origin \\ nil) do
     query =
       from b in Block,
         select: b.id,
         where: b.palette_id == ^palette_id
 
-    Brando.Repo.all(query)
+    query
+    |> maybe_filter_library_origin(:palette_origin, origin)
+    |> Brando.Repo.all()
+  end
+
+  @doc "Return list of all blocks using `container_id`."
+  def list_block_ids_using_container(container_id, origin \\ nil) do
+    query =
+      from b in Block,
+        select: b.id,
+        where: b.container_id == ^container_id
+
+    query
+    |> maybe_filter_library_origin(:container_origin, origin)
+    |> Brando.Repo.all()
   end
 
   @doc """
@@ -194,13 +208,15 @@ defmodule Brando.Content.Blocks do
   @doc """
   Return list of all blocks using `module_id`
   """
-  def list_block_ids_using_module(module_id) do
+  def list_block_ids_using_module(module_id, origin \\ nil) do
     query =
       from b in Block,
         select: b.id,
         where: b.module_id == ^module_id
 
-    Brando.Repo.all(query)
+    query
+    |> maybe_filter_library_origin(:module_origin, origin)
+    |> Brando.Repo.all()
   end
 
   @doc """
@@ -320,10 +336,10 @@ defmodule Brando.Content.Blocks do
   First syncs the module with the block, renders the block,
   then renders all entries using the block.
   """
-  def render_entries_with_module_id(module_id) do
+  def render_entries_with_module_id(module_id, origin \\ :local) do
     module_id
-    |> list_block_ids_using_module()
-    |> sync_and_render_blocks(module_id)
+    |> list_block_ids_using_module(origin)
+    |> sync_and_render_blocks(module_id, origin)
     |> list_entry_ids_for_root_blocks_by_source()
     |> enqueue_entry_map_for_render()
   end
@@ -342,9 +358,18 @@ defmodule Brando.Content.Blocks do
   @doc """
   Render and update all entries with a block using `palette_id`
   """
-  def render_entries_with_palette_id(palette_id) do
+  def render_entries_with_palette_id(palette_id, origin \\ :local) do
     palette_id
-    |> list_block_ids_using_palette()
+    |> list_block_ids_using_palette(origin)
+    |> list_root_block_ids_by_source()
+    |> list_entry_ids_for_root_blocks_by_source()
+    |> enqueue_entry_map_for_render()
+  end
+
+  @doc "Render entries containing a block that uses `container_id`."
+  def render_entries_with_container_id(container_id, origin \\ :local) do
+    container_id
+    |> list_block_ids_using_container(origin)
     |> list_root_block_ids_by_source()
     |> list_entry_ids_for_root_blocks_by_source()
     |> enqueue_entry_map_for_render()
@@ -703,12 +728,24 @@ defmodule Brando.Content.Blocks do
     |> Changeset.put_assoc(:refs, reapplied_refs)
   end
 
-  def sync_and_render_blocks(block_ids, module_id) do
-    {:ok, module} =
-      Content.get_module(%{
-        matches: %{id: module_id},
-        preload: [:vars, refs: Ref.preloads()]
-      })
+  def sync_and_render_blocks(block_ids, module_id, origin \\ :local)
+  def sync_and_render_blocks([], _module_id, _origin), do: %{}
+
+  def sync_and_render_blocks(block_ids, module_id, origin) do
+    module =
+      case normalize_library_origin(origin) do
+        :local ->
+          {:ok, module} =
+            Content.get_module(%{
+              matches: %{id: module_id},
+              preload: [:vars, refs: Ref.preloads()]
+            })
+
+          module
+
+        :shared ->
+          Brando.Content.SharedLibrary.get_for_current_tenant(:module, module_id, :shared)
+      end
 
     {:ok, blocks} =
       Content.list_blocks(%{
@@ -726,6 +763,16 @@ defmodule Brando.Content.Blocks do
     end)
     |> render_blocks()
   end
+
+  defp maybe_filter_library_origin(query, _field, nil), do: query
+
+  defp maybe_filter_library_origin(query, field, origin) do
+    normalized_origin = normalize_library_origin(origin)
+    from entry in query, where: field(entry, ^field) == ^normalized_origin
+  end
+
+  defp normalize_library_origin(origin) when origin in [:shared, "shared"], do: :shared
+  defp normalize_library_origin(_origin), do: :local
 
   def render_blocks(block_ids) do
     source_map = list_root_block_ids_by_source(block_ids)

--- a/lib/brando/content/container.ex
+++ b/lib/brando/content/container.ex
@@ -21,7 +21,11 @@ defmodule Brando.Content.Container do
   identifier "[{{ entry.namespace }}] {{ entry.name}}"
   persist_identifier false
 
-  @derived_fields ~w(id type name sequence namespace help_text code deleted_at)a
+  @derived_fields ~w(
+    id type name sequence namespace help_text code deleted_at version version_note
+    source_container_id source_version acknowledged_version library_origin
+    override_id
+  )a
   @derive {Jason.Encoder, only: @derived_fields}
 
   trait :sequenced
@@ -36,6 +40,14 @@ defmodule Brando.Content.Container do
     attribute :code, :text, required: true
     attribute :allow_custom_palette, :boolean, default: false
     attribute :palette_namespace, :string
+    attribute :version, :integer, default: 1
+    attribute :version_note, :text
+    attribute :source_container_id, :integer
+    attribute :source_version, :integer
+    attribute :acknowledged_version, :integer
+    attribute :library_origin, :enum, values: [:local, :shared], default: :local, virtual: true
+    attribute :update_available, :boolean, default: false, virtual: true
+    attribute :override_id, :integer, virtual: true
   end
 
   relations do

--- a/lib/brando/content/container_resolver.ex
+++ b/lib/brando/content/container_resolver.ex
@@ -1,0 +1,10 @@
+defmodule Brando.Content.ContainerResolver do
+  @moduledoc "Tenant-first resolver for shared and site-specific containers."
+
+  alias Brando.Content.SharedLibrary
+
+  def get_container(id, site, prefix), do: SharedLibrary.get(:container, id, site, prefix)
+  def get_container(id, origin, site, prefix), do: SharedLibrary.get(:container, id, origin, site, prefix)
+  def list_available_containers(site, prefix), do: SharedLibrary.list_available(:container, site, prefix)
+  def list_containers_for_rendering(site, prefix), do: SharedLibrary.list_for_rendering(:container, site, prefix)
+end

--- a/lib/brando/content/module.ex
+++ b/lib/brando/content/module.ex
@@ -50,7 +50,11 @@ defmodule Brando.Content.Module do
   identifier "[{{ entry.namespace | i18n }}] {{ entry.name | i18n }}"
   persist_identifier false
 
-  @derived_fields ~w(id type name sequence namespace help_text multi color class code refs vars svg deleted_at)a
+  @derived_fields ~w(
+    id type name sequence namespace help_text multi color class code refs vars svg deleted_at
+    version version_note source_module_id source_version acknowledged_version library_origin
+    override_id
+  )a
   @derive {Jason.Encoder, only: @derived_fields}
 
   trait :sequenced
@@ -74,6 +78,15 @@ defmodule Brando.Content.Module do
     attribute :datasource_module, :string
     attribute :datasource_type, :enum, values: [:list, :single, :selection]
     attribute :datasource_query, :string
+
+    attribute :version, :integer, default: 1
+    attribute :version_note, :text
+    attribute :source_module_id, :integer
+    attribute :source_version, :integer
+    attribute :acknowledged_version, :integer
+    attribute :library_origin, :enum, values: [:local, :shared], default: :local, virtual: true
+    attribute :update_available, :boolean, default: false, virtual: true
+    attribute :override_id, :integer, virtual: true
   end
 
   relations do

--- a/lib/brando/content/module_resolver.ex
+++ b/lib/brando/content/module_resolver.ex
@@ -1,0 +1,10 @@
+defmodule Brando.Content.ModuleResolver do
+  @moduledoc "Tenant-first resolver for shared and site-specific modules."
+
+  alias Brando.Content.SharedLibrary
+
+  def get_module(id, site, prefix), do: SharedLibrary.get(:module, id, site, prefix)
+  def get_module(id, origin, site, prefix), do: SharedLibrary.get(:module, id, origin, site, prefix)
+  def list_available_modules(site, prefix), do: SharedLibrary.list_available(:module, site, prefix)
+  def list_modules_for_rendering(site, prefix), do: SharedLibrary.list_for_rendering(:module, site, prefix)
+end

--- a/lib/brando/content/palette.ex
+++ b/lib/brando/content/palette.ex
@@ -32,6 +32,14 @@ defmodule Brando.Content.Palette do
     attribute :global, :boolean
     attribute :namespace, :string, default: "site"
     attribute :instructions, :text
+    attribute :version, :integer, default: 1
+    attribute :version_note, :text
+    attribute :source_palette_id, :integer
+    attribute :source_version, :integer
+    attribute :acknowledged_version, :integer
+    attribute :library_origin, :enum, values: [:local, :shared], default: :local, virtual: true
+    attribute :update_available, :boolean, default: false, virtual: true
+    attribute :override_id, :integer, virtual: true
   end
 
   relations do

--- a/lib/brando/content/palette_resolver.ex
+++ b/lib/brando/content/palette_resolver.ex
@@ -1,0 +1,10 @@
+defmodule Brando.Content.PaletteResolver do
+  @moduledoc "Tenant-first resolver for shared and site-specific palettes."
+
+  alias Brando.Content.SharedLibrary
+
+  def get_palette(id, site, prefix), do: SharedLibrary.get(:palette, id, site, prefix)
+  def get_palette(id, origin, site, prefix), do: SharedLibrary.get(:palette, id, origin, site, prefix)
+  def list_available_palettes(site, prefix), do: SharedLibrary.list_available(:palette, site, prefix)
+  def list_palettes_for_rendering(site, prefix), do: SharedLibrary.list_for_rendering(:palette, site, prefix)
+end

--- a/lib/brando/content/shared_library.ex
+++ b/lib/brando/content/shared_library.ex
@@ -1,0 +1,667 @@
+defmodule Brando.Content.SharedLibrary do
+  @moduledoc """
+  Resolves Brando's shared module, container, and palette library.
+
+  Shared entries live in `public`. Site-specific entries and overrides live in
+  the active environment schema. Blocks carry an explicit origin so an integer
+  ID collision between schemas can never change which entry is selected.
+  """
+
+  import Ecto.Query, only: [from: 2]
+
+  alias Brando.Content.Container
+  alias Brando.Content.Block
+  alias Brando.Content.Blocks
+  alias Brando.Content.Module
+  alias Brando.Content.Palette
+  alias Brando.Content.SharedLibrary.Cache
+  alias Brando.Content.SiteEnabledContainer
+  alias Brando.Content.SiteEnabledModule
+  alias Brando.Content.SiteEnabledPalette
+  alias Brando.Repo
+  alias Brando.Sites.Site
+  alias Brando.Tenant
+  alias Brando.Tenant.Registry
+  alias Ecto.Changeset
+
+  @public_opts [prefix: "public"]
+  @kinds [:module, :container, :palette]
+
+  @definitions %{
+    module: %{
+      schema: Module,
+      access_schema: SiteEnabledModule,
+      access_field: :module_id,
+      block_field: :module_id,
+      block_origin_field: :module_origin,
+      source_field: :source_module_id,
+      preloads: [:vars, refs: Brando.Content.Ref.preloads()]
+    },
+    container: %{
+      schema: Container,
+      access_schema: SiteEnabledContainer,
+      access_field: :container_id,
+      block_field: :container_id,
+      block_origin_field: :container_origin,
+      source_field: :source_container_id,
+      preloads: []
+    },
+    palette: %{
+      schema: Palette,
+      access_schema: SiteEnabledPalette,
+      access_field: :palette_id,
+      block_field: :palette_id,
+      block_origin_field: :palette_origin,
+      source_field: :source_palette_id,
+      preloads: []
+    }
+  }
+
+  @doc "Returns the public IDs enabled for `site` and `kind`."
+  def enabled_ids(%Site{id: site_id}, kind) when kind in @kinds do
+    case Cache.get(site_id, kind) do
+      %MapSet{} = ids -> ids
+      nil -> load_enabled_ids(site_id, kind)
+    end
+  end
+
+  @doc "Atomically replaces one site's allowlist for a library kind."
+  def set_enabled(%Site{} = site, kind, ids) when kind in @kinds and is_list(ids) do
+    definition = definition(kind)
+    ids = ids |> Enum.map(&normalize_id!/1) |> Enum.uniq() |> Enum.sort()
+
+    with :ok <- validate_shared_ids(definition.schema, ids),
+         {:ok, _result} <- replace_access_rows(site.id, definition, ids) do
+      Cache.put(site.id, kind, ids)
+      :ok
+    end
+  end
+
+  def enable(%Site{} = site, kind, id) when kind in @kinds do
+    ids = [normalize_id!(id) | MapSet.to_list(enabled_ids(site, kind))]
+    set_enabled(site, kind, ids)
+  end
+
+  def disable(%Site{} = site, kind, id) when kind in @kinds do
+    id = normalize_id!(id)
+    ids = site |> enabled_ids(kind) |> MapSet.delete(id) |> MapSet.to_list()
+    set_enabled(site, kind, ids)
+  end
+
+  def enabled?(%Site{} = site, kind, id) when kind in @kinds do
+    MapSet.member?(enabled_ids(site, kind), normalize_id!(id))
+  end
+
+  @doc "Lists every non-deleted public entry in a shared library."
+  def list_shared(kind) when kind in @kinds do
+    definition = definition(kind)
+
+    definition.schema
+    |> active_query()
+    |> Repo.all(@public_opts)
+    |> Repo.preload(definition.preloads, @public_opts)
+    |> Enum.map(&mark_entry(&1, :shared, false))
+  end
+
+  @doc "Gets one public shared-library entry with its editing associations preloaded."
+  def get_shared(kind, id) when kind in @kinds do
+    kind
+    |> get_public(normalize_id!(id))
+    |> mark_entry_or_nil(:shared, false)
+  end
+
+  @doc "Creates a versioned entry directly in the public shared library."
+  def create_shared(kind, attrs, user \\ :system) when kind in @kinds and is_map(attrs) do
+    definition = definition(kind)
+    schema = definition.schema
+
+    schema
+    |> struct()
+    |> schema.changeset(attrs, user)
+    |> Repo.insert(@public_opts)
+  end
+
+  @doc "Lists site-local entries plus only the shared entries enabled for new content."
+  def list_available(kind, %Site{} = site, prefix) when kind in @kinds do
+    list_effective(kind, site, prefix, :enabled)
+  end
+
+  @doc """
+  Lists all effective entries required to render existing content.
+
+  Disabled shared entries stay in this result so blocks created before access
+  was revoked continue to render; the picker uses `list_available/3` instead.
+  """
+  def list_for_rendering(kind, %Site{} = site, prefix) when kind in @kinds do
+    list_effective(kind, site, prefix, :rendering)
+  end
+
+  def list_for_current_tenant(kind) when kind in @kinds do
+    with prefix when is_binary(prefix) <- Tenant.current_prefix(),
+         site_key when is_binary(site_key) <- Tenant.current_site_key(),
+         %Site{} = site <- Registry.get_site_by_key(site_key) do
+      list_for_rendering(kind, site, prefix)
+    else
+      _no_tenant -> list_local(kind, nil)
+    end
+  end
+
+  @doc """
+  Resolves an origin-qualified reference. Shared reads allow disabled IDs
+  by default for backwards-compatible rendering; pass `require_enabled: true`
+  for new-content workflows.
+  """
+  def get(kind, id, origin, %Site{} = site, prefix, opts \\ []) when kind in @kinds do
+    id = normalize_id!(id)
+
+    case normalize_origin(origin) do
+      :local -> get_local(kind, id, prefix)
+      :shared -> get_shared(kind, id, site, prefix, opts)
+    end
+  end
+
+  @doc "Compatibility resolver matching the Phase 4 tenant-first contract."
+  def get(kind, id, %Site{} = site, prefix) when kind in @kinds do
+    id = normalize_id!(id)
+    get_local(kind, id, prefix) || get_shared(kind, id, site, prefix, require_enabled: true)
+  end
+
+  def get_for_current_tenant(kind, id, origin \\ :local) when kind in @kinds do
+    with prefix when is_binary(prefix) <- Tenant.current_prefix(),
+         site_key when is_binary(site_key) <- Tenant.current_site_key(),
+         %Site{} = site <- Registry.get_site_by_key(site_key) do
+      get(kind, id, origin, site, prefix)
+    else
+      _no_tenant -> get_local(kind, normalize_id!(id), nil)
+    end
+  end
+
+  @doc "Copies a shared entry into the tenant schema as an override."
+  def customize(kind, id, %Site{} = site, prefix, user \\ :system) when kind in @kinds do
+    id = normalize_id!(id)
+
+    cond do
+      not enabled?(site, kind, id) ->
+        {:error, :not_enabled}
+
+      override = get_override(kind, id, prefix) ->
+        {:ok, override}
+
+      shared = get_public(kind, id) ->
+        create_override(kind, shared, prefix, user)
+
+      true ->
+        {:error, :not_found}
+    end
+  end
+
+  @doc "Deletes a tenant override; origin-qualified blocks immediately use shared again."
+  def reset(kind, id, %Site{}, prefix) when kind in @kinds do
+    case get_override(kind, normalize_id!(id), prefix) do
+      nil -> :ok
+      override -> override |> Repo.delete(prefix: prefix) |> result_to_ok()
+    end
+  end
+
+  @doc "Destructively replaces an override with the current shared version."
+  def accept_update(kind, id, %Site{}, prefix, user \\ :system) when kind in @kinds do
+    id = normalize_id!(id)
+
+    with override when not is_nil(override) <- get_override(kind, id, prefix),
+         shared when not is_nil(shared) <- get_public(kind, id) do
+      case Repo.transaction(fn ->
+             with {:ok, _deleted} <- Repo.delete(override, prefix: prefix),
+                  {:ok, replacement} <- create_override(kind, shared, prefix, user) do
+               replacement
+             else
+               {:error, reason} -> Repo.rollback(reason)
+             end
+           end) do
+        {:ok, replacement} -> {:ok, replacement}
+        {:error, reason} -> {:error, reason}
+      end
+    else
+      nil -> {:error, :not_found}
+    end
+  end
+
+  @doc "Acknowledges the current shared version without replacing local changes."
+  def dismiss_update(kind, id, %Site{}, prefix) when kind in @kinds do
+    with override when not is_nil(override) <- get_override(kind, normalize_id!(id), prefix),
+         shared when not is_nil(shared) <- get_public(kind, normalize_id!(id)) do
+      override
+      |> Changeset.change(acknowledged_version: shared.version)
+      |> Repo.update(prefix: prefix)
+    else
+      nil -> {:error, :not_found}
+    end
+  end
+
+  @doc "Updates a public library entry and bumps its meaningful version."
+  def update_shared(kind, id, attrs_or_changeset, user \\ :system)
+
+  def update_shared(kind, id, %Changeset{} = changeset, _user) when kind in @kinds do
+    id = normalize_id!(id)
+
+    if changeset.data.id == id and changeset.data.__struct__ == definition(kind).schema do
+      changeset
+      |> Changeset.put_change(:version, (changeset.data.version || 1) + 1)
+      |> Changeset.validate_required([:version_note])
+      |> Repo.update(@public_opts)
+      |> after_shared_update(kind)
+    else
+      {:error, :invalid_shared_changeset}
+    end
+  end
+
+  def update_shared(kind, id, attrs, user) when kind in @kinds and is_map(attrs) do
+    definition = definition(kind)
+    schema = definition.schema
+
+    with shared when not is_nil(shared) <- get_public(kind, normalize_id!(id)) do
+      attrs =
+        attrs
+        |> Map.put(version_key(attrs), (shared.version || 1) + 1)
+        |> Map.delete(opposite_version_key(attrs))
+
+      result =
+        shared
+        |> schema.changeset(attrs, user)
+        |> Changeset.validate_required([:version_note])
+        |> Repo.update(@public_opts)
+
+      after_shared_update(result, kind)
+    else
+      nil -> {:error, :not_found}
+    end
+  end
+
+  @doc "Returns enabled and overridden sites for impact analysis."
+  def usage(kind, id) when kind in @kinds do
+    id = normalize_id!(id)
+
+    Registry.list_sites()
+    |> Enum.map(fn site ->
+      {overridden, referenced} =
+        Enum.reduce(site.environments, {[], []}, fn environment, {overridden_acc, referenced_acc} ->
+          prefix = Tenant.prefix(site, environment)
+
+          overridden_acc =
+            if get_override(kind, id, prefix), do: [environment.key | overridden_acc], else: overridden_acc
+
+          referenced_acc =
+            if shared_reference_exists?(kind, id, prefix),
+              do: [environment.key | referenced_acc],
+              else: referenced_acc
+
+          {overridden_acc, referenced_acc}
+        end)
+
+      %{
+        site: site,
+        enabled: enabled?(site, kind, id),
+        overridden_environments: Enum.reverse(overridden),
+        referenced_environments: Enum.reverse(referenced)
+      }
+    end)
+    |> Enum.reject(&(!&1.enabled and &1.overridden_environments == [] and &1.referenced_environments == []))
+  end
+
+  @doc "Returns field-level changes between a tenant override and its current shared source."
+  def diff(kind, id, %Site{}, prefix) when kind in @kinds do
+    id = normalize_id!(id)
+
+    with override when not is_nil(override) <- get_override(kind, id, prefix),
+         shared when not is_nil(shared) <- get_public(kind, id) do
+      definition = definition(kind)
+
+      fields =
+        definition.schema.__schema__(:fields) --
+          [
+            :id,
+            :inserted_at,
+            :updated_at,
+            :deleted_at,
+            :version,
+            :version_note,
+            :source_version,
+            :acknowledged_version,
+            definition.source_field
+          ]
+
+      {:ok,
+       fields
+       |> Enum.reduce(%{}, fn field, changes ->
+         shared_value = Map.get(shared, field)
+         override_value = Map.get(override, field)
+
+         if shared_value == override_value do
+           changes
+         else
+           Map.put(changes, field, %{shared: shared_value, override: override_value})
+         end
+       end)}
+    else
+      nil -> {:error, :not_found}
+    end
+  end
+
+  @doc "Prevents deleting a shared entry while any site can still use it."
+  def delete_shared(kind, id) when kind in @kinds do
+    id = normalize_id!(id)
+
+    case usage(kind, id) do
+      [] ->
+        case get_public(kind, id) do
+          nil -> {:error, :not_found}
+          entry -> Repo.delete(entry, @public_opts)
+        end
+
+      usages ->
+        {:error, {:shared_item_in_use, usages}}
+    end
+  end
+
+  def reference(value) when is_binary(value) do
+    case String.split(value, ":", parts: 2) do
+      [origin, id] when origin in ["local", "shared"] ->
+        {normalize_origin(origin), normalize_id!(id)}
+
+      [id] ->
+        {:local, normalize_id!(id)}
+    end
+  end
+
+  def reference(id) when is_integer(id), do: {:local, id}
+  def reference({origin, id}), do: {normalize_origin(origin), normalize_id!(id)}
+  def encode_reference(origin, id), do: "#{normalize_origin(origin)}:#{normalize_id!(id)}"
+
+  defp list_effective(kind, site, prefix, shared_scope) do
+    definition = definition(kind)
+    locals = list_local(kind, prefix)
+    {site_specific, overrides} = Enum.split_with(locals, &is_nil(Map.get(&1, definition.source_field)))
+    overrides_by_source = Map.new(overrides, &{Map.fetch!(&1, definition.source_field), &1})
+
+    shared_ids =
+      case shared_scope do
+        :enabled -> enabled_ids(site, kind)
+        :rendering -> MapSet.union(enabled_ids(site, kind), referenced_shared_ids(kind, prefix))
+      end
+
+    shared =
+      kind
+      |> list_shared()
+      |> maybe_filter_ids(shared_ids)
+      |> Enum.map(fn entry ->
+        case overrides_by_source[entry.id] do
+          nil -> mark_entry(entry, :shared, false)
+          override -> effective_override(override, entry)
+        end
+      end)
+
+    Enum.map(site_specific, &mark_entry(&1, :local, false)) ++ shared
+  end
+
+  defp list_local(kind, prefix) do
+    definition = definition(kind)
+    opts = if is_binary(prefix), do: [prefix: prefix], else: []
+
+    definition.schema
+    |> active_query()
+    |> Repo.all(opts)
+    |> Repo.preload(definition.preloads, opts)
+  end
+
+  defp get_local(kind, id, prefix) do
+    definition = definition(kind)
+    opts = if is_binary(prefix), do: [prefix: prefix], else: []
+
+    definition.schema
+    |> Repo.get(id, opts)
+    |> preload_one(definition.preloads, opts)
+    |> mark_entry_or_nil(:local, false)
+  end
+
+  defp get_shared(kind, id, site, prefix, opts) do
+    if Keyword.get(opts, :require_enabled, false) and not enabled?(site, kind, id) do
+      nil
+    else
+      case {get_override(kind, id, prefix), get_public(kind, id)} do
+        {nil, nil} -> nil
+        {nil, shared} -> mark_entry(shared, :shared, false)
+        {override, nil} -> mark_entry(override, :shared, false)
+        {override, shared} -> effective_override(override, shared)
+      end
+    end
+  end
+
+  defp get_override(kind, source_id, prefix) do
+    definition = definition(kind)
+    opts = [prefix: prefix]
+
+    from(entry in definition.schema,
+      where: field(entry, ^definition.source_field) == ^source_id and is_nil(entry.deleted_at),
+      limit: 1
+    )
+    |> Repo.one(opts)
+    |> preload_one(definition.preloads, opts)
+  end
+
+  defp get_public(kind, id) do
+    definition = definition(kind)
+
+    definition.schema
+    |> Repo.get(id, @public_opts)
+    |> preload_one(definition.preloads, @public_opts)
+  end
+
+  defp shared_reference_exists?(kind, id, prefix) do
+    definition = definition(kind)
+
+    query =
+      from block in Block,
+        where:
+          field(block, ^definition.block_field) == ^id and
+            field(block, ^definition.block_origin_field) == :shared,
+        select: 1,
+        limit: 1
+
+    not is_nil(Repo.one(query, prefix: prefix))
+  end
+
+  defp referenced_shared_ids(kind, prefix) do
+    definition = definition(kind)
+
+    from(block in Block,
+      where:
+        field(block, ^definition.block_origin_field) == :shared and
+          not is_nil(field(block, ^definition.block_field)),
+      select: field(block, ^definition.block_field),
+      distinct: true
+    )
+    |> Repo.all(prefix: prefix)
+    |> MapSet.new()
+  end
+
+  defp rerender_shared(kind, id) do
+    Enum.each(Registry.list_sites(), fn site ->
+      Enum.each(site.environments, fn environment ->
+        prefix = Tenant.prefix(site, environment)
+
+        Tenant.with_prefix(prefix, fn ->
+          case kind do
+            :module -> Blocks.render_entries_with_module_id(id, :shared)
+            :container -> Blocks.render_entries_with_container_id(id, :shared)
+            :palette -> Blocks.render_entries_with_palette_id(id, :shared)
+          end
+        end)
+      end)
+    end)
+  end
+
+  defp after_shared_update({:ok, updated} = result, kind) do
+    rerender_shared(kind, updated.id)
+    result
+  end
+
+  defp after_shared_update(result, _kind), do: result
+
+  defp create_override(kind, shared, prefix, user) do
+    definition = definition(kind)
+    schema = definition.schema
+
+    attrs =
+      shared
+      |> copy_fields(definition)
+      |> Map.put(definition.source_field, shared.id)
+      |> Map.put(:source_version, shared.version || 1)
+      |> Map.put(:acknowledged_version, shared.version || 1)
+      |> Map.put(:version, 1)
+      |> put_copy_associations(kind, shared)
+
+    struct(schema)
+    |> schema.changeset(attrs, user)
+    |> Changeset.unique_constraint(definition.source_field)
+    |> Repo.insert(prefix: prefix)
+  end
+
+  defp copy_fields(shared, definition) do
+    excluded =
+      [
+        :id,
+        :inserted_at,
+        :updated_at,
+        :deleted_at,
+        :version,
+        :version_note,
+        :source_version,
+        :acknowledged_version,
+        definition.source_field
+      ]
+
+    shared
+    |> Map.from_struct()
+    |> Map.take(definition.schema.__schema__(:fields))
+    |> Map.drop(excluded)
+  end
+
+  defp put_copy_associations(attrs, :module, shared) do
+    attrs
+    |> Map.put(:vars, Enum.map(loaded_list(shared.vars), &copy_assoc(&1, [:module_id])))
+    |> Map.put(:refs, Enum.map(loaded_list(shared.refs), &copy_assoc(&1, [:module_id])))
+  end
+
+  defp put_copy_associations(attrs, _kind, _shared), do: attrs
+
+  defp copy_assoc(entry, owner_fields) do
+    entry
+    |> Map.from_struct()
+    |> Map.take(entry.__struct__.__schema__(:fields))
+    |> Map.drop([:id, :inserted_at, :updated_at, :deleted_at, :creator_id] ++ owner_fields)
+    |> Brando.Utils.map_from_struct()
+  end
+
+  defp effective_override(override, shared) do
+    shared_version = shared.version || 1
+
+    update_available =
+      (override.source_version || 0) < shared_version and
+        (override.acknowledged_version || 0) < shared_version
+
+    override
+    |> Map.put(:id, shared.id)
+    |> Map.put(:override_id, override.id)
+    |> mark_entry(:shared, update_available)
+  end
+
+  defp mark_entry(entry, origin, update_available) do
+    entry
+    |> Map.put(:library_origin, origin)
+    |> Map.put(:update_available, update_available)
+  end
+
+  defp mark_entry_or_nil(nil, _origin, _update_available), do: nil
+  defp mark_entry_or_nil(entry, origin, update_available), do: mark_entry(entry, origin, update_available)
+
+  defp active_query(schema), do: from(entry in schema, where: is_nil(entry.deleted_at))
+
+  defp maybe_filter_ids(entries, %MapSet{} = ids), do: Enum.filter(entries, &MapSet.member?(ids, &1.id))
+
+  defp validate_shared_ids(_schema, []), do: :ok
+
+  defp validate_shared_ids(schema, ids) do
+    found =
+      from(entry in schema, where: entry.id in ^ids and is_nil(entry.deleted_at), select: entry.id)
+      |> Repo.all(@public_opts)
+      |> MapSet.new()
+
+    missing = Enum.reject(ids, &MapSet.member?(found, &1))
+    if missing == [], do: :ok, else: {:error, {:shared_items_not_found, missing}}
+  end
+
+  defp replace_access_rows(site_id, definition, ids) do
+    Repo.transaction(fn ->
+      from(access in definition.access_schema, where: access.site_id == ^site_id)
+      |> Repo.delete_all(@public_opts)
+
+      now = DateTime.utc_now()
+
+      rows =
+        Enum.map(ids, fn id ->
+          %{definition.access_field => id, site_id: site_id, inserted_at: now, updated_at: now}
+        end)
+
+      Repo.insert_all(definition.access_schema, rows, @public_opts)
+    end)
+  end
+
+  defp load_enabled_ids(site_id, kind) do
+    definition = definition(kind)
+
+    ids =
+      from(access in definition.access_schema,
+        where: access.site_id == ^site_id,
+        select: field(access, ^definition.access_field)
+      )
+      |> Repo.all(@public_opts)
+
+    Cache.put(site_id, kind, ids)
+    MapSet.new(ids)
+  end
+
+  defp preload_one(nil, _preloads, _opts), do: nil
+  defp preload_one(entry, [], _opts), do: entry
+  defp preload_one(entry, preloads, opts), do: Repo.preload(entry, preloads, opts)
+
+  defp loaded_list(%Ecto.Association.NotLoaded{}), do: []
+  defp loaded_list(nil), do: []
+  defp loaded_list(list), do: list
+
+  defp result_to_ok({:ok, _entry}), do: :ok
+  defp result_to_ok({:error, _changeset} = error), do: error
+
+  defp definition(kind), do: Map.fetch!(@definitions, kind)
+
+  defp normalize_origin(origin) when origin in [:local, "local", nil], do: :local
+  defp normalize_origin(origin) when origin in [:shared, "shared"], do: :shared
+  defp normalize_origin(origin), do: raise(ArgumentError, "invalid library origin: #{inspect(origin)}")
+
+  defp normalize_id!(id) when is_integer(id) and id > 0, do: id
+
+  defp normalize_id!(id) when is_binary(id) do
+    case Integer.parse(id) do
+      {parsed, ""} when parsed > 0 -> parsed
+      _ -> raise ArgumentError, "invalid shared library id: #{inspect(id)}"
+    end
+  end
+
+  defp normalize_id!(id), do: raise(ArgumentError, "invalid shared library id: #{inspect(id)}")
+
+  defp version_key(attrs) do
+    if Enum.all?(Map.keys(attrs), &is_binary/1), do: "version", else: :version
+  end
+
+  defp opposite_version_key(attrs) do
+    if Enum.all?(Map.keys(attrs), &is_binary/1), do: :version, else: "version"
+  end
+end

--- a/lib/brando/content/shared_library/cache.ex
+++ b/lib/brando/content/shared_library/cache.ex
@@ -1,0 +1,34 @@
+defmodule Brando.Content.SharedLibrary.Cache do
+  @moduledoc false
+
+  @keys_key {__MODULE__, :keys}
+
+  def get(site_id, kind) do
+    :persistent_term.get(key(site_id, kind), nil)
+  end
+
+  def put(site_id, kind, ids) do
+    cache_key = key(site_id, kind)
+    :persistent_term.put(cache_key, MapSet.new(ids))
+
+    keys = :persistent_term.get(@keys_key, MapSet.new())
+    :persistent_term.put(@keys_key, MapSet.put(keys, cache_key))
+    :ok
+  end
+
+  def invalidate(site_id, kind) do
+    :persistent_term.erase(key(site_id, kind))
+    :ok
+  end
+
+  def clear do
+    @keys_key
+    |> :persistent_term.get(MapSet.new())
+    |> Enum.each(&:persistent_term.erase/1)
+
+    :persistent_term.erase(@keys_key)
+    :ok
+  end
+
+  defp key(site_id, kind), do: {__MODULE__, site_id, kind}
+end

--- a/lib/brando/content/site_enabled_container.ex
+++ b/lib/brando/content/site_enabled_container.ex
@@ -1,0 +1,22 @@
+defmodule Brando.Content.SiteEnabledContainer do
+  @moduledoc false
+
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  @schema_prefix "public"
+  @timestamps_opts [type: :utc_datetime_usec]
+
+  schema "site_enabled_containers" do
+    field :site_id, :integer
+    field :container_id, :integer
+    timestamps()
+  end
+
+  def changeset(access \\ %__MODULE__{}, attrs) do
+    access
+    |> cast(attrs, [:site_id, :container_id])
+    |> validate_required([:site_id, :container_id])
+    |> unique_constraint([:site_id, :container_id])
+  end
+end

--- a/lib/brando/content/site_enabled_module.ex
+++ b/lib/brando/content/site_enabled_module.ex
@@ -1,0 +1,22 @@
+defmodule Brando.Content.SiteEnabledModule do
+  @moduledoc false
+
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  @schema_prefix "public"
+  @timestamps_opts [type: :utc_datetime_usec]
+
+  schema "site_enabled_modules" do
+    field :site_id, :integer
+    field :module_id, :integer
+    timestamps()
+  end
+
+  def changeset(access \\ %__MODULE__{}, attrs) do
+    access
+    |> cast(attrs, [:site_id, :module_id])
+    |> validate_required([:site_id, :module_id])
+    |> unique_constraint([:site_id, :module_id])
+  end
+end

--- a/lib/brando/content/site_enabled_palette.ex
+++ b/lib/brando/content/site_enabled_palette.ex
@@ -1,0 +1,22 @@
+defmodule Brando.Content.SiteEnabledPalette do
+  @moduledoc false
+
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  @schema_prefix "public"
+  @timestamps_opts [type: :utc_datetime_usec]
+
+  schema "site_enabled_palettes" do
+    field :site_id, :integer
+    field :palette_id, :integer
+    timestamps()
+  end
+
+  def changeset(access \\ %__MODULE__{}, attrs) do
+    access
+    |> cast(attrs, [:site_id, :palette_id])
+    |> validate_required([:site_id, :palette_id])
+    |> unique_constraint([:site_id, :palette_id])
+  end
+end

--- a/lib/brando/router.ex
+++ b/lib/brando/router.ex
@@ -146,6 +146,12 @@ defmodule Brando.Router do
 
             live "/content/modules", BrandoAdmin.Content.ModuleListLive
             live "/content/modules/update/:entry_id", BrandoAdmin.Content.ModuleFormLive, :update
+            live "/content/shared_library", BrandoAdmin.Content.SharedLibraryLive
+
+            live "/content/shared_library/modules/update/:entry_id",
+                 BrandoAdmin.Content.ModuleFormLive,
+                 :shared_update
+
             live "/content/module_sets", BrandoAdmin.Content.ModuleSetListLive
             live "/content/module_sets/create", BrandoAdmin.Content.ModuleSetFormLive, :create
 

--- a/lib/brando/villain/components.ex
+++ b/lib/brando/villain/components.ex
@@ -157,9 +157,9 @@ defmodule Brando.Villain.Components do
   end
 
   defp build_parser_opts(assigns) do
-    {:ok, modules} = Brando.Content.list_modules(cache_opts())
-    {:ok, containers} = Brando.Content.list_containers(cache_opts())
-    {:ok, palettes} = Brando.Content.list_palettes(cache_opts())
+    {:ok, modules} = Brando.Villain.RenderSourceQuery.list_modules(cache_opts())
+    {:ok, containers} = Brando.Villain.RenderSourceQuery.list_containers(cache_opts())
+    {:ok, palettes} = Brando.Villain.RenderSourceQuery.list_palettes(cache_opts())
 
     %{
       context: assigns[:liquex_context] || build_empty_context(),

--- a/lib/brando/villain/parser.ex
+++ b/lib/brando/villain/parser.ex
@@ -288,7 +288,7 @@ defmodule Brando.Villain.Parser do
     modules = opts.modules
     skip_children? = Map.get(opts, :skip_children, false)
 
-    {:ok, module} = Content.find_module(modules, id)
+    {:ok, module} = Content.find_module(modules, id, Map.get(block, :module_origin, :local))
     adapter = adapter_for(module.type)
     opts = Map.put(opts, :parser_module, parser_module(opts))
 
@@ -311,7 +311,13 @@ defmodule Brando.Villain.Parser do
             ""
 
           {child_block, index} ->
-            {:ok, child_module} = Content.find_module(modules, child_block.module_id)
+            {:ok, child_module} =
+              Content.find_module(
+                modules,
+                child_block.module_id,
+                Map.get(child_block, :module_origin, :local)
+              )
+
             child_adapter = adapter_for(child_module.type)
 
             vars = process_vars(child_block.vars)
@@ -363,7 +369,7 @@ defmodule Brando.Villain.Parser do
   def module(%{module_id: id} = block, opts) do
     modules = opts.modules
 
-    case Content.find_module(modules, id) do
+    case Content.find_module(modules, id, Map.get(block, :module_origin, :local)) do
       {:ok, module} ->
         processed_vars = process_vars(block.vars)
         processed_refs = process_refs(block.refs)
@@ -1016,7 +1022,7 @@ defmodule Brando.Villain.Parser do
     target_id =
       (target_id && " id=\"#{target_id}\" data-scrollspy-trigger=\"##{target_id}\"") || ""
 
-    case Content.find_palette(palettes, palette_id) do
+    case Content.find_palette(palettes, palette_id, Map.get(block, :palette_origin, :local)) do
       {:ok, palette} ->
         colors =
           palette.colors |> Enum.map(&"--#{&1.key}: #{&1.hex_value}") |> Enum.intersperse(";")
@@ -1055,7 +1061,9 @@ defmodule Brando.Villain.Parser do
     containers = opts.containers
     # palettes = opts.palettes
     skip_children? = Map.get(opts, :skip_children, false)
-    {:ok, container} = Content.find_container(containers, container_id)
+
+    {:ok, container} =
+      Content.find_container(containers, container_id, Map.get(block, :container_origin, :local))
 
     children_html =
       if skip_children? === true do

--- a/lib/brando/villain/render_source_query.ex
+++ b/lib/brando/villain/render_source_query.ex
@@ -43,6 +43,16 @@ defmodule Brando.Villain.RenderSourceQuery do
   def list_palettes(opts \\ %{}), do: list(@palette_schema, opts)
 
   defp list(schema, opts) when is_map(opts) do
+    kind = tenant_library_kind(schema)
+
+    if kind && Brando.Tenant.enabled?() do
+      {:ok, Brando.Content.SharedLibrary.list_for_current_tenant(kind)}
+    else
+      list_from_current_prefix(schema, opts)
+    end
+  end
+
+  defp list_from_current_prefix(schema, opts) do
     query =
       from entry in schema,
         where: is_nil(entry.deleted_at)
@@ -63,6 +73,11 @@ defmodule Brando.Villain.RenderSourceQuery do
         {:ok, Repo.all(query)}
     end
   end
+
+  defp tenant_library_kind(@module_schema), do: :module
+  defp tenant_library_kind(@container_schema), do: :container
+  defp tenant_library_kind(@palette_schema), do: :palette
+  defp tenant_library_kind(_schema), do: nil
 
   defp maybe_preload(query, nil), do: query
   defp maybe_preload(query, preloads), do: preload(query, ^preloads)

--- a/lib/brando_admin/components/form/block.ex
+++ b/lib/brando_admin/components/form/block.ex
@@ -595,13 +595,13 @@ defmodule BrandoAdmin.Components.Form.Block do
   end
 
   def update(%{event: "insert_block", sequence: sequence, module_id: module_id, type: type}, socket) do
-    module_id = String.to_integer(module_id)
+    module_reference = Brando.Content.SharedLibrary.reference(module_id)
     user_id = socket.assigns.current_user_id
     parent_id = nil
     sequence = (is_binary(sequence) && String.to_integer(sequence)) || sequence
     source = socket.assigns.block_module
 
-    empty_block_cs = BlockField.build_block(module_id, user_id, parent_id, source, type)
+    empty_block_cs = BlockField.build_block(module_reference, user_id, parent_id, source, type)
     uid = Changeset.get_field(empty_block_cs, :uid)
     # insert the new block uid into the block_list
     block_list = socket.assigns.block_list
@@ -936,6 +936,7 @@ defmodule BrandoAdmin.Components.Form.Block do
     end)
     |> assign_new(:parent_id, fn -> Changeset.get_field(block_cs, :parent_id) end)
     |> assign_new(:parent_module_id, fn -> nil end)
+    |> assign_new(:parent_module_origin, fn -> nil end)
     # Both lists come out of an ETS-cached query, and an ETS read copies the
     # whole term onto the reading process's heap — so this was one copy per
     # block component, all inside the single LiveView process. Scope them to the
@@ -952,7 +953,7 @@ defmodule BrandoAdmin.Components.Form.Block do
     # Anything else was carrying a list it had no template for.
     |> assign_new(:containers, fn %{type: type} ->
       if type == :container do
-        Brando.Content.list_containers!(%{
+        library_entries(:container, %{
           order: "desc namespace, asc sequence",
           cache: {:ttl, :infinite}
         })
@@ -972,7 +973,10 @@ defmodule BrandoAdmin.Components.Form.Block do
     end)
     |> assign_new(:collapsed, fn -> Changeset.get_field(changeset, :collapsed) end)
     |> assign_new(:module_id, fn -> Changeset.get_field(block_cs, :module_id) end)
+    |> assign_new(:module_origin, fn -> Changeset.get_field(block_cs, :module_origin) || :local end)
     |> assign_new(:container_id, fn -> Changeset.get_field(block_cs, :container_id) end)
+    |> assign_new(:container_origin, fn -> Changeset.get_field(block_cs, :container_origin) || :local end)
+    |> assign_new(:palette_origin, fn -> Changeset.get_field(block_cs, :palette_origin) || :local end)
     |> assign_new(:fragment_id, fn -> Changeset.get_field(block_cs, :fragment_id) end)
     |> assign_new(:has_children?, fn -> assigns.children !== [] end)
     |> assign_new(:available_identifiers, fn -> [] end)
@@ -1030,6 +1034,9 @@ defmodule BrandoAdmin.Components.Form.Block do
     :anchor,
     :multi,
     :module_id,
+    :module_origin,
+    :container_origin,
+    :palette_origin,
     :parent_id,
     :creator_id,
     :marked_as_deleted
@@ -1303,7 +1310,7 @@ defmodule BrandoAdmin.Components.Form.Block do
   # returning it renders a `<select>` with no options, which submits nothing for
   # `block[palette_id]` and drops an already-set palette on the next validate.
   defp palette_options_for(assigns, opts_fun) do
-    if renders_palette_options?(assigns), do: Brando.Content.list_palettes!(opts_fun.()), else: nil
+    if renders_palette_options?(assigns), do: library_entries(:palette, opts_fun.()), else: nil
   end
 
   defp palette_query_opts(%{palette_namespace: nil}), do: %{cache: {:ttl, :infinite}}
@@ -1320,7 +1327,7 @@ defmodule BrandoAdmin.Components.Form.Block do
   end
 
   def maybe_assign_container(%{assigns: %{container_id: container_id}} = socket) do
-    case get_container(container_id) do
+    case get_container(container_id, Map.get(socket.assigns, :container_origin, :local)) do
       nil ->
         # Still assign both, or `render(%{type: :container})` — which has no
         # `container_not_found` clause of its own until the one in `render.ex`
@@ -1397,7 +1404,7 @@ defmodule BrandoAdmin.Components.Form.Block do
   end
 
   def maybe_assign_module(%{assigns: %{module_id: module_id}} = socket) do
-    case get_module(module_id) do
+    case get_module(module_id, Map.get(socket.assigns, :module_origin, :local)) do
       nil ->
         assign(socket, :module_not_found, true)
 
@@ -1986,8 +1993,8 @@ defmodule BrandoAdmin.Components.Form.Block do
     end
   end
 
-  defdelegate get_container(id), to: Brando.Content, as: :fetch_container
-  defdelegate get_module(id), to: Brando.Content, as: :fetch_module
+  def get_container(id, origin \\ :local), do: Brando.Content.fetch_container(id, origin)
+  def get_module(id, origin \\ :local), do: Brando.Content.fetch_module(id, origin)
 
   # `render_html?: false` skips the Villain render entirely — the output is only
   # consumed by live preview, and both preview-open and save re-render from
@@ -2185,11 +2192,13 @@ defmodule BrandoAdmin.Components.Form.Block do
     |> Enum.reverse()
   end
 
-  def maybe_update_container(socket, [_block_type, "block", "container_id"]) do
+  def maybe_update_container(socket, [_block_type, "block", field])
+      when field in ["container_id", "container_origin"] do
     changeset = socket.assigns.form.source
     block_cs = Changeset.get_assoc(changeset, :block)
     container_id = Changeset.get_field(block_cs, :container_id)
-    container = get_container(container_id)
+    container_origin = Changeset.get_field(block_cs, :container_origin) || :local
+    container = get_container(container_id, container_origin)
 
     # `:palette_options` is derived from the container's `allow_custom_palette`
     # and `palette_namespace`, so it has to move with it. Re-assigning only
@@ -2202,10 +2211,36 @@ defmodule BrandoAdmin.Components.Form.Block do
 
     socket
     |> assign(:container, container)
+    |> assign(:container_origin, container_origin)
     |> assign(:palette_options, palette_options)
   end
 
   def maybe_update_container(socket, _), do: socket
+
+  defp library_entries(kind, fallback_opts) do
+    with prefix when is_binary(prefix) <- Brando.Tenant.current_prefix(),
+         site_key when is_binary(site_key) <- Brando.Tenant.current_site_key(),
+         %Brando.Sites.Site{} = site <- Brando.Tenant.Registry.get_site_by_key(site_key) do
+      kind
+      |> Brando.Content.SharedLibrary.list_available(site, prefix)
+      |> filter_library_entries(Map.get(fallback_opts, :filter, %{}))
+    else
+      _no_tenant ->
+        case kind do
+          :container -> Brando.Content.list_containers!(fallback_opts)
+          :palette -> Brando.Content.list_palettes!(fallback_opts)
+        end
+    end
+  end
+
+  defp filter_library_entries(entries, filter) do
+    Enum.filter(entries, fn entry ->
+      Enum.all?(filter, fn
+        {:namespace, value} -> entry.namespace == value
+        _other -> true
+      end)
+    end)
+  end
 
   def maybe_update_fragment(socket, [_block_type, "block", "fragment_id"]) do
     changeset = socket.assigns.form.source

--- a/lib/brando_admin/components/form/block/events.ex
+++ b/lib/brando_admin/components/form/block/events.ex
@@ -248,7 +248,7 @@ defmodule BrandoAdmin.Components.Form.Block.Events do
     belongs_to = socket.assigns.belongs_to
     module_id = socket.assigns.module_id
     uid = socket.assigns.uid
-    module = Block.get_module(module_id)
+    module = Block.get_module(module_id, Map.get(socket.assigns, :module_origin, :local))
 
     module_refs = module.refs
     module_ref_names = Enum.map(module_refs, & &1.name)
@@ -301,7 +301,7 @@ defmodule BrandoAdmin.Components.Form.Block.Events do
     belongs_to = socket.assigns.belongs_to
     module_id = socket.assigns.module_id
     uid = socket.assigns.uid
-    module = Block.get_module(module_id)
+    module = Block.get_module(module_id, Map.get(socket.assigns, :module_origin, :local))
 
     module_refs = module.refs
 
@@ -359,7 +359,7 @@ defmodule BrandoAdmin.Components.Form.Block.Events do
     belongs_to = socket.assigns.belongs_to
     module_id = socket.assigns.module_id
     uid = socket.assigns.uid
-    module = Block.get_module(module_id)
+    module = Block.get_module(module_id, Map.get(socket.assigns, :module_origin, :local))
 
     module_refs = module.refs
 
@@ -396,7 +396,7 @@ defmodule BrandoAdmin.Components.Form.Block.Events do
     belongs_to = socket.assigns.belongs_to
     module_id = socket.assigns.module_id
     uid = socket.assigns.uid
-    module = Block.get_module(module_id)
+    module = Block.get_module(module_id, Map.get(socket.assigns, :module_origin, :local))
 
     module_vars = module.vars
     module_var_names = Enum.map(module_vars, & &1.key)
@@ -449,7 +449,7 @@ defmodule BrandoAdmin.Components.Form.Block.Events do
     belongs_to = socket.assigns.belongs_to
     module_id = socket.assigns.module_id
     uid = socket.assigns.uid
-    module = Block.get_module(module_id)
+    module = Block.get_module(module_id, Map.get(socket.assigns, :module_origin, :local))
 
     module_vars = module.vars
 
@@ -486,7 +486,7 @@ defmodule BrandoAdmin.Components.Form.Block.Events do
     belongs_to = socket.assigns.belongs_to
     module_id = socket.assigns.module_id
     uid = socket.assigns.uid
-    module = Block.get_module(module_id)
+    module = Block.get_module(module_id, Map.get(socket.assigns, :module_origin, :local))
 
     module_vars = module.vars
 
@@ -618,10 +618,17 @@ defmodule BrandoAdmin.Components.Form.Block.Events do
         socket.assigns.module_id
       end
 
+    module_origin =
+      if socket.assigns.parent_module_id do
+        Map.get(socket.assigns, :parent_module_origin, :local) || :local
+      else
+        Map.get(socket.assigns, :module_origin, :local) || :local
+      end
+
     send_update(ModulePicker,
       id: block_picker_id,
       event: :show_module_picker,
-      filter: %{parent_id: module_id, namespace: "all"},
+      filter: %{parent_id: module_id, parent_origin: module_origin, namespace: "all"},
       module_set: "all",
       type: :module_entry,
       sequence: sequence,

--- a/lib/brando_admin/components/form/block/render.ex
+++ b/lib/brando_admin/components/form/block/render.ex
@@ -137,6 +137,7 @@ defmodule BrandoAdmin.Components.Form.Block.Render do
               parent_uid={@uid}
               parent_path={@path}
               parent_module_id={@module_id}
+              parent_module_origin={@module_origin}
               module_set={@module_set}
               form={child_block_form}
               form_id={@form_id}
@@ -1204,6 +1205,7 @@ defmodule BrandoAdmin.Components.Form.Block.Render do
             module={Input.Select}
             id={"#{@block.id}-container-select"}
             field={@block[:container_id]}
+            origin_field={@block[:container_origin]}
             label={gettext("Container template")}
             opts={[options: @containers, resetable: true]}
             publish
@@ -1213,6 +1215,7 @@ defmodule BrandoAdmin.Components.Form.Block.Render do
               module={Input.Select}
               id={"#{@block.id}-palette-select"}
               field={@block[:palette_id]}
+              origin_field={@block[:palette_origin]}
               label={gettext("Palette")}
               opts={[options: @palette_options]}
               publish

--- a/lib/brando_admin/components/form/block_field.ex
+++ b/lib/brando_admin/components/form/block_field.ex
@@ -297,12 +297,12 @@ defmodule BrandoAdmin.Components.Form.BlockField do
 
   # INSERT ROOT BLOCK
   def update(%{event: "insert_block", sequence: sequence, module_id: module_id}, socket) do
-    module_id = String.to_integer(module_id)
+    {module_origin, module_id} = Brando.Content.SharedLibrary.reference(module_id)
     block_module = socket.assigns.block_module
     user_id = socket.assigns.current_user.id
     parent_id = nil
     source = socket.assigns.block_module
-    empty_block_cs = build_block(module_id, user_id, parent_id, source, :module)
+    empty_block_cs = build_block({module_origin, module_id}, user_id, parent_id, source, :module)
 
     sequence = (is_integer(sequence) && sequence) || String.to_integer(sequence)
 
@@ -329,7 +329,14 @@ defmodule BrandoAdmin.Components.Form.BlockField do
       Phoenix.PubSub.broadcast(
         Brando.pubsub(),
         topic,
-        {:block_added, %{uid: uid, module_id: module_id, sequence: sequence, user_id: socket.assigns.current_user.id}}
+        {:block_added,
+         %{
+           uid: uid,
+           module_id: module_id,
+           module_origin: module_origin,
+           sequence: sequence,
+           user_id: socket.assigns.current_user.id
+         }}
       )
     end
 
@@ -495,7 +502,7 @@ defmodule BrandoAdmin.Components.Form.BlockField do
           module_id: module_id,
           sequence: sequence,
           user_id: remote_user_id
-        },
+        } = msg,
         socket
       ) do
     # Skip if we already have this block (dedup)
@@ -505,7 +512,8 @@ defmodule BrandoAdmin.Components.Form.BlockField do
       block_module = socket.assigns.block_module
       source = socket.assigns.block_module
 
-      empty_block_cs = build_block(module_id, remote_user_id, nil, source, :module)
+      module_origin = Map.get(msg, :module_origin, :local)
+      empty_block_cs = build_block({module_origin, module_id}, remote_user_id, nil, source, :module)
       # Override UID to match the original
       empty_block_cs = Changeset.put_change(empty_block_cs, :uid, remote_uid)
 
@@ -581,10 +589,19 @@ defmodule BrandoAdmin.Components.Form.BlockField do
       |> Enum.each(fn {uid, index} ->
         with :inserted <- ops.statuses[uid],
              module_id when not is_nil(module_id) <- get_in(ops.diffs, [uid, "block", "module_id"]) do
+          module_origin = get_in(ops.diffs, [uid, "block", "module_origin"]) || "local"
+
           Phoenix.PubSub.broadcast(
             Brando.pubsub(),
             topic,
-            {:block_added, %{uid: uid, module_id: module_id, sequence: index, user_id: user_id}}
+            {:block_added,
+             %{
+               uid: uid,
+               module_id: module_id,
+               module_origin: module_origin,
+               sequence: index,
+               user_id: user_id
+             }}
           )
         end
       end)
@@ -1655,8 +1672,9 @@ defmodule BrandoAdmin.Components.Form.BlockField do
     )
   end
 
-  def build_block(module_id, user_id, parent_id, source, type) do
-    module = get_module(module_id)
+  def build_block(module_reference, user_id, parent_id, source, type) do
+    {module_origin, module_id} = Brando.Content.SharedLibrary.reference(module_reference)
+    module = get_module(module_id, module_origin)
     # Generate fresh refs with new UIDs when creating blocks from modules
     fresh_refs =
       (module.refs || [])
@@ -1684,6 +1702,7 @@ defmodule BrandoAdmin.Components.Form.BlockField do
         type: type,
         creator_id: user_id,
         module_id: module_id,
+        module_origin: module_origin,
         parent_id: parent_id,
         multi: module.multi,
         source: source,
@@ -1768,9 +1787,10 @@ defmodule BrandoAdmin.Components.Form.BlockField do
     for {block_uid, form} <- socket.assigns.seed_forms do
       block_cs = Changeset.get_assoc(form.source, :block)
       module_id = Changeset.get_field(block_cs, :module_id)
+      module_origin = Changeset.get_field(block_cs, :module_origin) || :local
 
       if module_id do
-        case Brando.Content.fetch_module(module_id) do
+        case Brando.Content.fetch_module(module_id, module_origin) do
           %{multi: true} ->
             send_update(Block,
               id: "block-#{block_uid}",
@@ -1787,7 +1807,7 @@ defmodule BrandoAdmin.Components.Form.BlockField do
     socket
   end
 
-  defp get_module(module_id), do: Brando.Content.fetch_module(module_id)
+  defp get_module(module_id, origin \\ :local), do: Brando.Content.fetch_module(module_id, origin)
 
   defp assign_module_set(socket) do
     assign_new(socket, :module_set, fn ->

--- a/lib/brando_admin/components/form/block_field/module_picker.ex
+++ b/lib/brando_admin/components/form/block_field/module_picker.ex
@@ -128,13 +128,13 @@ defmodule BrandoAdmin.Components.Form.BlockField.ModulePicker do
                 <div class="module-picker-grid">
                   <button
                     :for={module <- modules}
-                    :key={module.id}
+                    :key={{module.library_origin, module.id}}
                     type="button"
                     class={["module-card", module.svg && "has-preview"]}
                     data-color={module.color}
                     aria-label={translate(module.name)}
                     phx-click={JS.push("insert_module", target: @myself) |> hide_modal("##{@id}")}
-                    phx-value-module-id={module.id}
+                    phx-value-module-id={Brando.Content.SharedLibrary.encode_reference(module.library_origin, module.id)}
                   >
                     <%!-- Only modules that actually ship an SVG get a preview
                           box. Rendering an empty 16:9 placeholder for the rest
@@ -145,6 +145,19 @@ defmodule BrandoAdmin.Components.Form.BlockField.ModulePicker do
                     </figure>
                     <span class="module-card-body">
                       <span class="module-card-name">{translate(module.name)}</span>
+                      <span class="badge">
+                        <%= cond do %>
+                          <% module.library_origin == :shared and module.source_module_id -> %>
+                            {gettext("customized")}
+                          <% module.library_origin == :shared -> %>
+                            {gettext("shared")}
+                          <% true -> %>
+                            {gettext("site")}
+                        <% end %>
+                      </span>
+                      <span :if={module.update_available} class="badge warning">
+                        {gettext("update available")}
+                      </span>
                       <span :if={translate(module.help_text) != ""} class="module-card-help">
                         {translate(module.help_text)}
                       </span>
@@ -209,7 +222,7 @@ defmodule BrandoAdmin.Components.Form.BlockField.ModulePicker do
   end
 
   def maybe_update_modules_by_filter(socket, %{filter: %{parent_id: nil, namespace: _} = filter}) do
-    {:ok, modules} = Brando.Content.list_modules(%{filter: filter})
+    modules = list_picker_modules(filter)
 
     modules_by_namespace =
       modules
@@ -220,7 +233,7 @@ defmodule BrandoAdmin.Components.Form.BlockField.ModulePicker do
   end
 
   def maybe_update_modules_by_filter(socket, %{filter: %{parent_id: parent_id}}) do
-    {:ok, modules} = Brando.Content.list_modules(%{filter: %{parent_id: parent_id}})
+    modules = list_picker_modules(%{parent_id: parent_id})
 
     modules_by_namespace =
       modules
@@ -235,7 +248,7 @@ defmodule BrandoAdmin.Components.Form.BlockField.ModulePicker do
   end
 
   def assign_modules(socket) do
-    {:ok, modules} = Brando.Content.list_modules(%{cache: {:ttl, :infinite}})
+    modules = list_picker_modules(%{})
 
     modules_by_namespace =
       modules
@@ -377,5 +390,48 @@ defmodule BrandoAdmin.Components.Form.BlockField.ModulePicker do
       end
 
     {translated_namespace, namespace, sorted_modules}
+  end
+
+  defp list_picker_modules(filter) do
+    case current_site_and_prefix() do
+      {site, prefix} ->
+        :module
+        |> Brando.Content.SharedLibrary.list_available(site, prefix)
+        |> filter_modules(filter)
+
+      nil ->
+        {:ok, modules} =
+          Brando.Content.list_modules(%{
+            filter: filter,
+            cache: {:ttl, :infinite}
+          })
+
+        modules
+    end
+  end
+
+  defp filter_modules(modules, filter) do
+    Enum.filter(modules, fn module ->
+      Enum.all?(filter, fn
+        {:parent_id, value} -> module.parent_id == value
+        {:parent_origin, value} -> module.library_origin == normalize_origin(value)
+        {:namespace, "all"} -> true
+        {:namespace, value} -> module.namespace == value
+        _other -> true
+      end)
+    end)
+  end
+
+  defp normalize_origin(origin) when origin in [:shared, "shared"], do: :shared
+  defp normalize_origin(_origin), do: :local
+
+  defp current_site_and_prefix do
+    with prefix when is_binary(prefix) <- Brando.Tenant.current_prefix(),
+         site_key when is_binary(site_key) <- Brando.Tenant.current_site_key(),
+         %Brando.Sites.Site{} = site <- Brando.Tenant.Registry.get_site_by_key(site_key) do
+      {site, prefix}
+    else
+      _no_tenant -> nil
+    end
   end
 end

--- a/lib/brando_admin/components/form/block_field/outline.ex
+++ b/lib/brando_admin/components/form/block_field/outline.ex
@@ -144,7 +144,8 @@ defmodule BrandoAdmin.Components.Form.BlockField.Outline do
   reflects live structure, not mount-time seeds.
   """
   def build_outline_item_from_struct(%Brando.Content.Block{} = block) do
-    {module_name, module_color, multi} = resolve_module(block.module_id)
+    {module_name, module_color, multi} =
+      resolve_module(block.module_id, Map.get(block, :module_origin, :local))
 
     children =
       case block.children do
@@ -166,10 +167,10 @@ defmodule BrandoAdmin.Components.Form.BlockField.Outline do
     }
   end
 
-  defp resolve_module(nil), do: {nil, :blue, false}
+  defp resolve_module(nil, _origin), do: {nil, :blue, false}
 
-  defp resolve_module(module_id) do
-    case Brando.Content.fetch_module(module_id) do
+  defp resolve_module(module_id, origin) do
+    case Brando.Content.fetch_module(module_id, origin) do
       nil -> {nil, :blue, false}
       module -> {module.name, module.color || :blue, module.multi || false}
     end

--- a/lib/brando_admin/components/form/input/select.ex
+++ b/lib/brando_admin/components/form/input/select.ex
@@ -47,6 +47,13 @@ defmodule BrandoAdmin.Components.Form.Input.Select do
     <div>
       <Primitives.field_base field={@field} label={@label} instructions={@instructions} class={@class} compact={@compact}>
         <Input.input type={:hidden} field={@field} value={@selected_option} publish={@publish} />
+        <Input.input
+          :if={@origin_field}
+          type={:hidden}
+          field={@origin_field}
+          value={@selected_origin}
+          publish={@publish}
+        />
         <div class="multiselect">
           <div>
             <span class="select-label">
@@ -94,6 +101,7 @@ defmodule BrandoAdmin.Components.Form.Input.Select do
               ]}
               data-label={extract_label(opt)}
               value={extract_value(opt)}
+              phx-value-origin={extract_origin(opt)}
               phx-click={
                 JS.add_class("option-selected")
                 |> JS.push("select_option", target: @myself)
@@ -166,10 +174,11 @@ defmodule BrandoAdmin.Components.Form.Input.Select do
                     type="button"
                     class={[
                       "options-option",
-                      option_value(opt) == @selected_option && "option-selected"
+                      option_selected?(opt, @selected_option, @selected_origin) && "option-selected"
                     ]}
                     data-label={extract_label(opt)}
                     value={extract_value(opt)}
+                    phx-value-origin={extract_origin(opt)}
                     phx-click={
                       JS.add_class("option-selected")
                       |> JS.push("select_option", target: @myself)
@@ -276,6 +285,8 @@ defmodule BrandoAdmin.Components.Form.Input.Select do
 
   def update(assigns, socket) do
     selected_option = get_selected_option(assigns.field)
+    origin_field = Map.get(assigns, :origin_field)
+    selected_origin = if origin_field, do: get_selected_option(origin_field), else: nil
 
     show_filter = Keyword.get(assigns.opts, :filter, true)
     narrow = Keyword.get(assigns.opts, :narrow)
@@ -294,6 +305,8 @@ defmodule BrandoAdmin.Components.Form.Input.Select do
      |> prepare_input_component()
      |> assign_input_options()
      |> assign(:selected_option, selected_option)
+     |> assign(:selected_origin, selected_origin)
+     |> assign(:origin_field, origin_field)
      |> assign_new(:allow_custom, fn -> allow_custom end)
      |> assign_label()
      |> assign_custom_input_value()
@@ -356,7 +369,14 @@ defmodule BrandoAdmin.Components.Form.Input.Select do
   defp precompute_option(%{__struct__: module} = entry) do
     if function_exported?(module, :__identifier__, 2) do
       identifier = module.__identifier__(entry, skip_cover: true)
-      %{value: to_string(entry.id), label: identifier.title, status: identifier.status, entry: entry}
+
+      %{
+        value: to_string(entry.id),
+        label: identifier.title,
+        status: identifier.status,
+        entry: entry,
+        origin: Map.get(entry, :library_origin)
+      }
     else
       entry
     end
@@ -364,7 +384,13 @@ defmodule BrandoAdmin.Components.Form.Input.Select do
 
   defp precompute_option(opt), do: opt
 
-  defp option_value(opt), do: to_string(extract_value(opt))
+  defp option_selected?(opt, selected_value, nil),
+    do: to_string(extract_value(opt)) == selected_value
+
+  defp option_selected?(opt, selected_value, selected_origin) do
+    to_string(extract_value(opt)) == selected_value and
+      to_string(extract_origin(opt) || "local") == selected_origin
+  end
 
   defp ensure_string_values(%{label: _label, value: value} = opt) when not is_binary(value) do
     %{opt | value: to_string(value)}
@@ -378,9 +404,16 @@ defmodule BrandoAdmin.Components.Form.Input.Select do
   defp ensure_string_values(map), do: map
 
   def assign_label(
-        %{assigns: %{input_options: input_options, selected_option: selected_option, allow_custom: allow_custom}} = socket
+        %{
+          assigns: %{
+            input_options: input_options,
+            selected_option: selected_option,
+            selected_origin: selected_origin,
+            allow_custom: allow_custom
+          }
+        } = socket
       ) do
-    assign(socket, :select_label, get_label(input_options, selected_option, allow_custom))
+    assign(socket, :select_label, get_label(input_options, selected_option, selected_origin, allow_custom))
   end
 
   def maybe_assign_select_form(%{assigns: %{entry_form: {target_module, form_name}}} = socket) do
@@ -431,6 +464,9 @@ defmodule BrandoAdmin.Components.Form.Input.Select do
 
   defp extract_value(%{value: value}), do: value
   defp extract_value(%{id: value}), do: value
+  defp extract_origin(%{origin: origin}) when not is_nil(origin), do: origin
+  defp extract_origin(%{library_origin: origin}) when not is_nil(origin), do: origin
+  defp extract_origin(_opt), do: nil
 
   defp get_label(%{opt: %{entry: _, status: _}} = assigns) do
     assigns = assign_new(assigns, :deletable, fn -> false end)
@@ -488,10 +524,9 @@ defmodule BrandoAdmin.Components.Form.Input.Select do
   # Developer-authored `%{label: ...}` options may deliberately contain markup
   # and pass through untouched; entry titles and custom values are user input
   # and must be escaped before they reach `raw`.
-  defp get_label(input_options, selected_option, allow_custom) do
+  defp get_label(input_options, selected_option, selected_origin, allow_custom) do
     case Enum.find(input_options, fn
-           %{value: value} -> value == selected_option
-           %{id: id} -> to_string(id) == selected_option
+           option -> option_selected?(option, selected_option, selected_origin)
          end) do
       nil ->
         if allow_custom && selected_option && selected_option != "" do
@@ -590,7 +625,7 @@ defmodule BrandoAdmin.Components.Form.Input.Select do
     {:noreply, assign(socket, select_changeset: select_changeset)}
   end
 
-  def handle_event("select_option", %{"value" => value}, socket) do
+  def handle_event("select_option", %{"value" => value} = params, socket) do
     update_relation = socket.assigns.update_relation
     value = if value == "", do: nil, else: value
 
@@ -609,6 +644,7 @@ defmodule BrandoAdmin.Components.Form.Input.Select do
 
     socket
     |> assign(:selected_option, value)
+    |> assign(:selected_origin, selected_origin(socket, params, value))
     |> assign_label()
     |> then(&{:noreply, &1})
   end
@@ -617,6 +653,7 @@ defmodule BrandoAdmin.Components.Form.Input.Select do
     {:noreply,
      socket
      |> assign(:selected_option, nil)
+     |> assign(:selected_origin, nil)
      |> assign_label()}
   end
 
@@ -653,6 +690,10 @@ defmodule BrandoAdmin.Components.Form.Input.Select do
       _ -> nil
     end
   end
+
+  defp selected_origin(%{assigns: %{origin_field: nil}}, _params, _value), do: nil
+  defp selected_origin(_socket, _params, nil), do: nil
+  defp selected_origin(_socket, params, _value), do: Map.get(params, "origin", "local")
 
   defp assign_relation_schema(socket, field) do
     assign_new(socket, :relation_schema, fn ->

--- a/lib/brando_admin/live/content/module_form_live.ex
+++ b/lib/brando_admin/live/content/module_form_live.ex
@@ -15,19 +15,32 @@ defmodule BrandoAdmin.Content.ModuleFormLive do
   alias Ecto.Changeset
 
   def mount(%{"entry_id" => entry_id}, %{"user_token" => token}, socket) do
-    if connected?(socket) do
-      {:ok,
-       socket
-       |> assign(:socket_connected, true)
-       |> assign(:save_redirect_target, :listing)
-       |> assign(:open_item_modal, nil)
-       |> assign(:active_tab, :template)
-       |> assign_entry(entry_id)
-       |> assign_current_user(token)
-       |> assign_form()
-       |> set_admin_locale()}
-    else
-      {:ok, assign(socket, :socket_connected, false)}
+    shared_library? = socket.assigns.live_action == :shared_update
+
+    cond do
+      shared_library? and
+          (Brando.Tenant.mode() != :multi or socket.assigns.current_user.role != :superuser) ->
+        {:ok, redirect(socket, to: "/admin")}
+
+      connected?(socket) ->
+        {:ok,
+         socket
+         |> assign(:socket_connected, true)
+         |> assign(:shared_library?, shared_library?)
+         |> assign(:save_redirect_target, :listing)
+         |> assign(:open_item_modal, nil)
+         |> assign(:active_tab, :template)
+         |> assign_entry(entry_id)
+         |> assign_current_user(token)
+         |> assign_form()
+         |> set_admin_locale()
+         |> maybe_use_public_library_context()}
+
+      true ->
+        {:ok,
+         socket
+         |> assign(:socket_connected, false)
+         |> assign(:shared_library?, shared_library?)}
     end
   end
 
@@ -38,13 +51,24 @@ defmodule BrandoAdmin.Content.ModuleFormLive do
 
   def render(assigns) do
     ~H"""
-    <Content.header title={gettext("Content Modules")} subtitle={gettext("Edit module")} />
+    <Content.header
+      title={if @shared_library?, do: gettext("Shared module library"), else: gettext("Content Modules")}
+      subtitle={gettext("Edit module")}
+    />
 
     <div id="module_form-el" phx-hook="Brando.Form" data-skip-keydown>
       <.form for={@form} class="main-form" phx-change="validate" phx-submit="save">
         <input type="hidden" name={"#{@form.name}[#{:__force_change}]"} phx-debounce="0" />
 
         <.tab_bar active_tab={@active_tab} form={@form} />
+
+        <div :if={@shared_library?} class="module-version-note">
+          <Input.text
+            field={@form[:version_note]}
+            label={gettext("Changelog note")}
+            instructions={gettext("Describe what changed for sites with customized versions.")}
+          />
+        </div>
 
         <%!-- Every panel stays in the DOM and is hidden with CSS. Rendering only
               the active one would drop the other panels' inputs from the form
@@ -315,7 +339,12 @@ defmodule BrandoAdmin.Content.ModuleFormLive do
 
   def handle_event("validate", %{"module" => module_params}, socket) do
     %{current_user: current_user, entry: entry} = socket.assigns
-    changeset = Brando.Content.Module.changeset(entry, module_params, current_user)
+
+    changeset =
+      entry
+      |> Brando.Content.Module.changeset(module_params, current_user)
+      |> maybe_require_version_note(socket.assigns.shared_library?)
+
     updated_changeset = %{changeset | action: :update}
 
     updated_form = to_form(updated_changeset, [])
@@ -328,7 +357,12 @@ defmodule BrandoAdmin.Content.ModuleFormLive do
   def handle_event("save", %{"module" => module_params}, socket) do
     user = socket.assigns.current_user
     entry = socket.assigns.entry
-    changeset = Brando.Content.Module.changeset(entry, module_params, user)
+
+    changeset =
+      entry
+      |> Brando.Content.Module.changeset(module_params, user)
+      |> maybe_require_version_note(socket.assigns.shared_library?)
+
     updated_changeset = %{changeset | action: :update}
 
     changeset =
@@ -345,7 +379,7 @@ defmodule BrandoAdmin.Content.ModuleFormLive do
         updated_changeset
       end
 
-    case Brando.Content.update_module(changeset, user) do
+    case persist_module(changeset, user, socket.assigns.shared_library?) do
       {:ok, entry} ->
         send(self(), {:toast, gettext("Module updated")})
 
@@ -354,7 +388,10 @@ defmodule BrandoAdmin.Content.ModuleFormLive do
             :self ->
               socket
               |> assign(:entry, entry)
-              |> assign(:form, to_form(Brando.Content.Module.changeset(entry, %{}, user), []))
+              |> assign(:form, module_form(entry, user, socket.assigns.shared_library?))
+
+            :listing when socket.assigns.shared_library? ->
+              push_navigate(socket, to: "/admin/config/content/shared_library")
 
             :listing ->
               push_navigate(socket, to: "/admin/config/content/modules")
@@ -435,17 +472,47 @@ defmodule BrandoAdmin.Content.ModuleFormLive do
 
   defp assign_entry(socket, entry_id) do
     assign_new(socket, :entry, fn ->
-      Brando.Content.get_module!(%{matches: %{id: entry_id}, preload: [:vars, :refs]})
+      if socket.assigns.shared_library? do
+        Brando.Content.SharedLibrary.get_shared(:module, entry_id) ||
+          raise Ecto.NoResultsError, queryable: Brando.Content.Module
+      else
+        Brando.Content.get_module!(%{matches: %{id: entry_id}, preload: [:vars, :refs]})
+      end
     end)
   end
 
   defp assign_form(%{assigns: %{entry: entry, current_user: current_user}} = socket) do
     assign_new(socket, :form, fn ->
-      entry
-      |> Brando.Content.Module.changeset(%{}, current_user)
-      |> to_form([])
+      module_form(entry, current_user, socket.assigns.shared_library?)
     end)
   end
+
+  defp module_form(entry, current_user, shared_library?) do
+    entry
+    |> Brando.Content.Module.changeset(%{}, current_user)
+    |> then(fn changeset ->
+      if shared_library?, do: Changeset.put_change(changeset, :version_note, ""), else: changeset
+    end)
+    |> to_form([])
+  end
+
+  defp maybe_require_version_note(changeset, true),
+    do: Changeset.validate_required(changeset, [:version_note])
+
+  defp maybe_require_version_note(changeset, false), do: changeset
+
+  defp maybe_use_public_library_context(%{assigns: %{shared_library?: true}} = socket) do
+    Brando.Tenant.put_prefix(nil)
+    assign(socket, :tenant_prefix, nil)
+  end
+
+  defp maybe_use_public_library_context(socket), do: socket
+
+  defp persist_module(changeset, user, true) do
+    Brando.Content.SharedLibrary.update_shared(:module, changeset.data.id, changeset, user)
+  end
+
+  defp persist_module(changeset, user, false), do: Brando.Content.update_module(changeset, user)
 
   defp build_ref_data(TextBlock) do
     struct(TextBlock.Data, %{styles: TextBlock.Data.default_styles()})

--- a/lib/brando_admin/live/content/shared_library_live.ex
+++ b/lib/brando_admin/live/content/shared_library_live.ex
@@ -1,0 +1,737 @@
+defmodule BrandoAdmin.Content.SharedLibraryLive do
+  @moduledoc false
+
+  use BrandoAdmin, :live_view
+  use BrandoAdmin.Toast
+  use Gettext, backend: Brando.Gettext
+
+  alias Brando.Content.SharedLibrary
+  alias Brando.Tenant
+  alias Brando.Tenant.Access
+  alias Brando.Tenant.Registry
+  alias BrandoAdmin.Components.Content
+
+  @kinds [:module, :container, :palette]
+  @global_events ~w(select_site set_access enable_all disable_all create update delete)
+
+  @impl Phoenix.LiveView
+  def mount(_params, _session, socket) do
+    global_manager? = socket.assigns.current_user.role == :superuser
+
+    site_access? =
+      not is_nil(socket.assigns.current_site) and
+        Access.can_access?(socket.assigns.current_user, socket.assigns.current_site)
+
+    cond do
+      Tenant.mode() != :multi or (not global_manager? and not site_access?) ->
+        {:ok, redirect(socket, to: "/admin")}
+
+      connected?(socket) ->
+        {:ok,
+         socket
+         |> assign(:socket_connected, true)
+         |> assign(:global_manager?, global_manager?)
+         |> assign(:selected_site_id, socket.assigns.current_site && socket.assigns.current_site.id)
+         |> assign(
+           :selected_environment_id,
+           socket.assigns.current_environment && socket.assigns.current_environment.id
+         )
+         |> refresh()}
+
+      true ->
+        {:ok,
+         socket
+         |> assign(:socket_connected, false)
+         |> assign(:global_manager?, global_manager?)}
+    end
+  end
+
+  @impl Phoenix.LiveView
+  def render(%{socket_connected: false} = assigns) do
+    ~H"""
+    """
+  end
+
+  def render(assigns) do
+    ~H"""
+    <Content.header
+      title={gettext("Shared content library")}
+      subtitle={gettext("Curate reusable modules, containers, and palettes across sites")}
+    >
+      <button type="button" class="secondary" phx-click="refresh">{gettext("Refresh")}</button>
+    </Content.header>
+
+    <div class="environment-management-live shared-library-live">
+      <section class="environment-panel">
+        <header>
+          <div>
+            <h2>
+              {if @global_manager?, do: gettext("Site access and overrides"), else: gettext("Site library")}
+            </h2>
+            <p>
+              {gettext("Access controls what appears when creating content. Disabling an item never breaks existing blocks.")}
+            </p>
+          </div>
+        </header>
+
+        <div :if={@sites == []} class="empty">{gettext("Create a site before assigning library access.")}</div>
+
+        <div :if={@selected_site} class="environment-grid">
+          <label :if={@global_manager?}>
+            <span>{gettext("Site")}</span>
+            <select name="site_id" phx-change="select_site">
+              <option :for={site <- @sites} value={site.id} selected={site.id == @selected_site.id}>
+                {site.name}
+              </option>
+            </select>
+          </label>
+
+          <div :if={!@global_manager?}>
+            <span>{gettext("Site")}</span>
+            <strong>{@selected_site.name}</strong>
+          </div>
+
+          <label>
+            <span>{gettext("Environment for overrides")}</span>
+            <select name="environment_id" phx-change="select_environment">
+              <option
+                :for={environment <- @selected_site.environments}
+                value={environment.id}
+                selected={@selected_environment && environment.id == @selected_environment.id}
+              >
+                {environment.name}{if environment.live, do: " · live", else: ""}
+              </option>
+            </select>
+          </label>
+        </div>
+
+        <div :if={@selected_site && @global_manager?} class="environment-grid">
+          <.access_form
+            :for={kind <- @kinds}
+            kind={kind}
+            entries={Map.fetch!(@libraries, kind)}
+            enabled={Map.fetch!(@enabled, kind)}
+          />
+        </div>
+      </section>
+
+      <section :for={kind <- @kinds} class="environment-panel" id={"shared-library-#{kind}"}>
+        <header>
+          <div>
+            <h2>{kind_title(kind)}</h2>
+            <p>{kind_description(kind)}</p>
+          </div>
+          <span class="badge">{length(Map.fetch!(@libraries, kind))}</span>
+        </header>
+
+        <.create_form :if={@global_manager?} kind={kind} />
+
+        <div :if={Map.fetch!(@libraries, kind) == []} class="empty">
+          {gettext("No shared entries yet.")}
+        </div>
+
+        <article
+          :for={entry <- Map.fetch!(@libraries, kind)}
+          class="environment-panel shared-library-entry"
+          id={"shared-#{kind}-#{entry.id}"}
+        >
+          <% usage = Map.get(@usage, {kind, entry.id}, []) %>
+          <% effective = Map.get(@effective, {kind, entry.id}) %>
+          <% overridden? = effective && Map.get(effective, source_field(kind)) %>
+
+          <header>
+            <div>
+              <h3>{entry_label(entry)}</h3>
+              <p>
+                <span class="badge">v{entry.version || 1}</span>
+                <span :if={entry.version_note not in [nil, ""]}>{entry.version_note}</span>
+              </p>
+            </div>
+            <div :if={@global_manager?} class="environment-actions">
+              <.link
+                :if={kind == :module}
+                navigate={"/admin/config/content/shared_library/modules/update/#{entry.id}"}
+                class="secondary button"
+              >
+                {gettext("Edit")}
+              </.link>
+              <button
+                type="button"
+                class="danger"
+                phx-click="delete"
+                phx-value-kind={kind}
+                phx-value-id={entry.id}
+                phx-confirm={gettext("Delete this shared entry? This is blocked while any site uses it.")}
+              >
+                {gettext("Delete")}
+              </button>
+            </div>
+          </header>
+
+          <div class="environment-grid">
+            <section :if={@global_manager?}>
+              <h4>{gettext("Impact")}</h4>
+              <p :if={usage == []}>{gettext("No sites currently use this entry.")}</p>
+              <ul :if={usage != []}>
+                <li :for={item <- usage}>
+                  <strong>{item.site.name}</strong>
+                  <span :if={item.enabled}> · {gettext("enabled")}</span>
+                  <span :if={item.overridden_environments != []}>
+                    · {gettext("customized in %{envs}", envs: Enum.join(item.overridden_environments, ", "))}
+                  </span>
+                  <span :if={item.referenced_environments != []}>
+                    · {gettext("used in %{envs}", envs: Enum.join(item.referenced_environments, ", "))}
+                  </span>
+                </li>
+              </ul>
+            </section>
+
+            <section :if={@selected_site && @selected_environment}>
+              <h4>{gettext("Selected environment")}</h4>
+              <p>
+                {@selected_site.name} · {@selected_environment.name}
+                <span :if={overridden?} class="badge">{gettext("customized")}</span>
+                <span :if={effective && effective.update_available} class="badge warning">
+                  {gettext("update available")}
+                </span>
+              </p>
+
+              <div class="environment-actions">
+                <.link
+                  :if={overridden? && @can_customize?}
+                  navigate={override_route(kind, effective, @selected_site, @selected_environment)}
+                  class="secondary button"
+                >
+                  {gettext("Edit customization")}
+                </.link>
+                <button
+                  :if={@can_customize? && enabled?(@enabled, kind, entry.id) && !overridden?}
+                  type="button"
+                  class="secondary"
+                  phx-click="customize"
+                  phx-value-kind={kind}
+                  phx-value-id={entry.id}
+                >
+                  {gettext("Customize")}
+                </button>
+                <button
+                  :if={@can_customize? && overridden?}
+                  type="button"
+                  class="secondary"
+                  phx-click="reset"
+                  phx-value-kind={kind}
+                  phx-value-id={entry.id}
+                  phx-confirm={gettext("Discard this environment's customization and use shared again?")}
+                >
+                  {gettext("Reset to shared")}
+                </button>
+                <button
+                  :if={@can_customize? && effective && effective.update_available}
+                  type="button"
+                  class="primary"
+                  phx-click="accept_update"
+                  phx-value-kind={kind}
+                  phx-value-id={entry.id}
+                  phx-confirm={gettext("Replace the customized version with the current shared version?")}
+                >
+                  {gettext("Accept update")}
+                </button>
+                <button
+                  :if={@can_customize? && effective && effective.update_available}
+                  type="button"
+                  class="secondary"
+                  phx-click="dismiss_update"
+                  phx-value-kind={kind}
+                  phx-value-id={entry.id}
+                >
+                  {gettext("Dismiss")}
+                </button>
+              </div>
+
+              <details :if={Map.has_key?(@diffs, {kind, entry.id})}>
+                <summary>{gettext("View changes")}</summary>
+                <dl>
+                  <div :for={{field, change} <- Map.fetch!(@diffs, {kind, entry.id})}>
+                    <dt>{field}</dt>
+                    <dd>
+                      <small>{gettext("Shared")}</small> {format_value(change.shared)}<br />
+                      <small>{gettext("Customized")}</small> {format_value(change.override)}
+                    </dd>
+                  </div>
+                </dl>
+              </details>
+            </section>
+          </div>
+
+          <.inline_edit_form :if={@global_manager? && kind != :module} kind={kind} entry={entry} />
+        </article>
+      </section>
+    </div>
+    """
+  end
+
+  attr :kind, :atom, required: true
+  attr :entries, :list, required: true
+  attr :enabled, MapSet, required: true
+
+  defp access_form(assigns) do
+    ~H"""
+    <section>
+      <h3>{kind_title(@kind)}</h3>
+      <form phx-submit="set_access" id={"access-#{@kind}"}>
+        <input type="hidden" name="access[kind]" value={@kind} />
+        <input type="hidden" name="access[ids][]" value="" />
+        <label :for={entry <- @entries} class="checkbox">
+          <input
+            type="checkbox"
+            name="access[ids][]"
+            value={entry.id}
+            checked={MapSet.member?(@enabled, entry.id)}
+          />
+          <span>{entry_label(entry)} · v{entry.version || 1}</span>
+        </label>
+        <div class="environment-actions">
+          <button type="submit" class="primary">{gettext("Save access")}</button>
+          <button type="button" class="secondary" phx-click="enable_all" phx-value-kind={@kind}>
+            {gettext("Enable all")}
+          </button>
+          <button type="button" class="secondary" phx-click="disable_all" phx-value-kind={@kind}>
+            {gettext("Disable all")}
+          </button>
+        </div>
+      </form>
+    </section>
+    """
+  end
+
+  attr :kind, :atom, required: true
+
+  defp create_form(assigns) do
+    ~H"""
+    <details class="shared-library-create">
+      <summary>{gettext("Create shared %{kind}", kind: kind_singular(@kind))}</summary>
+      <form phx-submit="create" id={"create-shared-#{@kind}"}>
+        <input type="hidden" name="entry[kind]" value={@kind} />
+        <div class="environment-grid">
+          <label><span>{gettext("Name")}</span><input name="entry[name]" required /></label>
+          <label><span>{gettext("Namespace")}</span><input name="entry[namespace]" value="general" required /></label>
+          <label :if={@kind == :palette}><span>{gettext("Key")}</span><input name="entry[key]" required /></label>
+          <label :if={@kind == :container}>
+            <span>{gettext("Template type")}</span>
+            <select name="entry[type]"><option value="liquid">Liquid</option><option value="heex">HEEx</option></select>
+          </label>
+        </div>
+        <label :if={@kind in [:module, :container]}>
+          <span>{gettext("Code")}</span>
+          <textarea name="entry[code]" rows="6" required>{default_code(@kind)}</textarea>
+        </label>
+        <label :if={@kind == :palette}>
+          <span>{gettext("Colors (JSON)")}</span>
+          <textarea name="entry[colors_json]" rows="4">[]</textarea>
+        </label>
+        <button type="submit" class="primary">{gettext("Create")}</button>
+      </form>
+    </details>
+    """
+  end
+
+  attr :kind, :atom, required: true
+  attr :entry, :any, required: true
+
+  defp inline_edit_form(assigns) do
+    ~H"""
+    <details>
+      <summary>{gettext("Edit and publish a new version")}</summary>
+      <form phx-submit="update" id={"update-shared-#{@kind}-#{@entry.id}"}>
+        <input type="hidden" name="entry[kind]" value={@kind} />
+        <input type="hidden" name="entry[id]" value={@entry.id} />
+        <div class="environment-grid">
+          <label><span>{gettext("Name")}</span><input name="entry[name]" value={entry_label(@entry)} required /></label>
+          <label><span>{gettext("Namespace")}</span><input name="entry[namespace]" value={@entry.namespace} required /></label>
+          <label :if={@kind == :palette}><span>{gettext("Key")}</span><input name="entry[key]" value={@entry.key} required /></label>
+          <label><span>{gettext("Changelog note")}</span><input name="entry[version_note]" required /></label>
+        </div>
+        <label :if={@kind == :container}>
+          <span>{gettext("Code")}</span>
+          <textarea name="entry[code]" rows="8" required>{@entry.code}</textarea>
+        </label>
+        <label :if={@kind == :palette}>
+          <span>{gettext("Colors (JSON)")}</span>
+          <textarea name="entry[colors_json]" rows="5">{colors_json(@entry)}</textarea>
+        </label>
+        <button type="submit" class="primary">{gettext("Publish version")}</button>
+      </form>
+    </details>
+    """
+  end
+
+  @impl Phoenix.LiveView
+  def handle_event("refresh", _params, socket), do: {:noreply, refresh(socket)}
+
+  def handle_event(event, _params, %{assigns: %{global_manager?: false}} = socket)
+      when event in @global_events do
+    {:noreply, notify_error(socket, error_message(:not_authorized))}
+  end
+
+  def handle_event("select_site", %{"site_id" => site_id}, socket) do
+    {:noreply,
+     socket
+     |> assign(:selected_site_id, parse_id!(site_id))
+     |> assign(:selected_environment_id, nil)
+     |> refresh()}
+  end
+
+  def handle_event("select_environment", %{"environment_id" => environment_id}, socket) do
+    {:noreply, socket |> assign(:selected_environment_id, parse_id!(environment_id)) |> refresh()}
+  end
+
+  def handle_event("set_access", %{"access" => %{"kind" => kind, "ids" => ids}}, socket) do
+    with {:ok, kind} <- parse_kind(kind),
+         site when not is_nil(site) <- socket.assigns.selected_site,
+         :ok <- SharedLibrary.set_enabled(site, kind, Enum.reject(ids, &(&1 == ""))) do
+      {:noreply, socket |> notify(gettext("Shared library access updated.")) |> refresh()}
+    else
+      error -> {:noreply, notify_error(socket, error_message(error))}
+    end
+  end
+
+  def handle_event("enable_all", %{"kind" => kind}, socket) do
+    with {:ok, kind} <- parse_kind(kind),
+         site when not is_nil(site) <- socket.assigns.selected_site do
+      ids = Enum.map(Map.fetch!(socket.assigns.libraries, kind), & &1.id)
+      update_access(socket, site, kind, ids)
+    else
+      error -> {:noreply, notify_error(socket, error_message(error))}
+    end
+  end
+
+  def handle_event("disable_all", %{"kind" => kind}, socket) do
+    with {:ok, kind} <- parse_kind(kind),
+         site when not is_nil(site) <- socket.assigns.selected_site do
+      update_access(socket, site, kind, [])
+    else
+      error -> {:noreply, notify_error(socket, error_message(error))}
+    end
+  end
+
+  def handle_event("create", %{"entry" => params}, socket) do
+    with {:ok, kind} <- parse_kind(params["kind"]),
+         {:ok, attrs} <- entry_attrs(kind, params),
+         {:ok, _entry} <- SharedLibrary.create_shared(kind, attrs, socket.assigns.current_user) do
+      {:noreply, socket |> notify(gettext("Shared entry created.")) |> refresh()}
+    else
+      error -> {:noreply, notify_error(socket, error_message(error))}
+    end
+  end
+
+  def handle_event("update", %{"entry" => params}, socket) do
+    with {:ok, kind} <- parse_kind(params["kind"]),
+         {:ok, attrs} <- entry_attrs(kind, params),
+         {:ok, _entry} <-
+           SharedLibrary.update_shared(kind, params["id"], attrs, socket.assigns.current_user) do
+      {:noreply, socket |> notify(gettext("Shared version published.")) |> refresh()}
+    else
+      error -> {:noreply, notify_error(socket, error_message(error))}
+    end
+  end
+
+  def handle_event("delete", params, socket) do
+    with {:ok, kind} <- parse_kind(params["kind"]),
+         {:ok, _entry} <- SharedLibrary.delete_shared(kind, params["id"]) do
+      {:noreply, socket |> notify(gettext("Shared entry deleted.")) |> refresh()}
+    else
+      error -> {:noreply, notify_error(socket, error_message(error))}
+    end
+  end
+
+  for {event, function} <- [
+        {"customize", :customize},
+        {"reset", :reset},
+        {"accept_update", :accept_update},
+        {"dismiss_update", :dismiss_update}
+      ] do
+    def handle_event(unquote(event), params, socket) do
+      run_override_action(socket, unquote(function), params)
+    end
+  end
+
+  defp run_override_action(socket, function, params) do
+    with :ok <- authorize_customize(socket),
+         {:ok, kind} <- parse_kind(params["kind"]),
+         site when not is_nil(site) <- socket.assigns.selected_site,
+         environment when not is_nil(environment) <- socket.assigns.selected_environment do
+      prefix = Tenant.prefix(site, environment)
+
+      result =
+        case function do
+          :customize ->
+            SharedLibrary.customize(kind, params["id"], site, prefix, socket.assigns.current_user)
+
+          :reset ->
+            SharedLibrary.reset(kind, params["id"], site, prefix)
+
+          :accept_update ->
+            SharedLibrary.accept_update(kind, params["id"], site, prefix, socket.assigns.current_user)
+
+          :dismiss_update ->
+            SharedLibrary.dismiss_update(kind, params["id"], site, prefix)
+        end
+
+      case result do
+        :ok -> {:noreply, socket |> notify(gettext("Library override updated.")) |> refresh()}
+        {:ok, _entry} -> {:noreply, socket |> notify(gettext("Library override updated.")) |> refresh()}
+        error -> {:noreply, notify_error(socket, error_message(error))}
+      end
+    else
+      error -> {:noreply, notify_error(socket, error_message(error))}
+    end
+  end
+
+  defp update_access(socket, site, kind, ids) do
+    case SharedLibrary.set_enabled(site, kind, ids) do
+      :ok -> {:noreply, socket |> notify(gettext("Shared library access updated.")) |> refresh()}
+      error -> {:noreply, notify_error(socket, error_message(error))}
+    end
+  end
+
+  defp refresh(socket) do
+    sites =
+      if socket.assigns.global_manager? do
+        Registry.list_sites()
+      else
+        case socket.assigns.current_site do
+          nil -> []
+          site -> [Registry.get_site(site.id)]
+        end
+      end
+
+    selected_site = select_site(sites, socket.assigns[:selected_site_id])
+
+    selected_environment =
+      select_environment(selected_site, socket.assigns[:selected_environment_id])
+
+    all_libraries = Map.new(@kinds, &{&1, SharedLibrary.list_shared(&1)})
+
+    enabled =
+      Map.new(@kinds, fn kind ->
+        {kind, if(selected_site, do: SharedLibrary.enabled_ids(selected_site, kind), else: MapSet.new())}
+      end)
+
+    libraries =
+      visible_libraries(
+        all_libraries,
+        enabled,
+        selected_site,
+        selected_environment,
+        socket.assigns.global_manager?
+      )
+
+    usage =
+      for kind <- @kinds,
+          entry <- Map.fetch!(libraries, kind),
+          into: %{},
+          do: {{kind, entry.id}, usage_for_view(kind, entry.id, selected_site, socket.assigns.global_manager?)}
+
+    {effective, diffs} = context_entries(libraries, selected_site, selected_environment)
+
+    assign(socket,
+      sites: sites,
+      kinds: @kinds,
+      can_customize?: selected_site && Access.can_manage?(socket.assigns.current_user, selected_site),
+      selected_site: selected_site,
+      selected_site_id: selected_site && selected_site.id,
+      selected_environment: selected_environment,
+      selected_environment_id: selected_environment && selected_environment.id,
+      libraries: libraries,
+      enabled: enabled,
+      usage: usage,
+      effective: effective,
+      diffs: diffs
+    )
+  end
+
+  defp visible_libraries(libraries, _enabled, _site, _environment, true), do: libraries
+  defp visible_libraries(_libraries, _enabled, nil, _environment, false), do: empty_libraries()
+
+  defp visible_libraries(libraries, enabled, site, environment, false) do
+    prefix = environment && Tenant.prefix(site, environment)
+
+    Map.new(@kinds, fn kind ->
+      visible =
+        Enum.filter(Map.fetch!(libraries, kind), fn entry ->
+          MapSet.member?(Map.fetch!(enabled, kind), entry.id) or
+            overridden_in_environment?(kind, entry.id, site, prefix)
+        end)
+
+      {kind, visible}
+    end)
+  end
+
+  defp empty_libraries, do: Map.new(@kinds, &{&1, []})
+
+  defp overridden_in_environment?(_kind, _id, _site, nil), do: false
+
+  defp overridden_in_environment?(kind, id, site, prefix) do
+    case SharedLibrary.get(kind, id, :shared, site, prefix) do
+      nil -> false
+      effective -> not is_nil(Map.get(effective, source_field(kind)))
+    end
+  end
+
+  defp usage_for_view(kind, id, _site, true), do: SharedLibrary.usage(kind, id)
+
+  defp usage_for_view(kind, id, site, false) do
+    kind
+    |> SharedLibrary.usage(id)
+    |> Enum.filter(&(&1.site.id == site.id))
+  end
+
+  defp context_entries(_libraries, nil, _environment), do: {%{}, %{}}
+  defp context_entries(_libraries, _site, nil), do: {%{}, %{}}
+
+  defp context_entries(libraries, site, environment) do
+    prefix = Tenant.prefix(site, environment)
+
+    Enum.reduce(@kinds, {%{}, %{}}, fn kind, {effective_acc, diff_acc} ->
+      Enum.reduce(Map.fetch!(libraries, kind), {effective_acc, diff_acc}, fn entry, {entries, diffs} ->
+        effective = SharedLibrary.get(kind, entry.id, :shared, site, prefix)
+        entries = Map.put(entries, {kind, entry.id}, effective)
+
+        diffs =
+          case SharedLibrary.diff(kind, entry.id, site, prefix) do
+            {:ok, diff} -> Map.put(diffs, {kind, entry.id}, diff)
+            {:error, :not_found} -> diffs
+          end
+
+        {entries, diffs}
+      end)
+    end)
+  end
+
+  defp select_site([], _selected_id), do: nil
+  defp select_site(sites, selected_id), do: Enum.find(sites, hd(sites), &(&1.id == selected_id))
+
+  defp select_environment(nil, _selected_id), do: nil
+  defp select_environment(%{environments: []}, _selected_id), do: nil
+
+  defp select_environment(site, selected_id) do
+    Enum.find(site.environments, Enum.find(site.environments, hd(site.environments), & &1.live), fn environment ->
+      environment.id == selected_id
+    end)
+  end
+
+  defp entry_attrs(:module, params) do
+    {:ok,
+     params
+     |> Map.take(["name", "namespace", "code", "version_note"])
+     |> Map.put_new("help_text", "Shared module")
+     |> Map.put_new("class", "module")}
+  end
+
+  defp entry_attrs(:container, params) do
+    {:ok, Map.take(params, ["name", "namespace", "code", "type", "version_note"])}
+  end
+
+  defp entry_attrs(:palette, params) do
+    with {:ok, colors} <- Jason.decode(params["colors_json"] || "[]") do
+      {:ok,
+       params
+       |> Map.take(["name", "namespace", "key", "version_note"])
+       |> Map.put("status", "published")
+       |> Map.put("colors", colors)}
+    else
+      _error -> {:error, :invalid_colors_json}
+    end
+  end
+
+  defp parse_kind(kind) when kind in ["module", "container", "palette"],
+    do: {:ok, String.to_existing_atom(kind)}
+
+  defp parse_kind(kind) when kind in @kinds, do: {:ok, kind}
+  defp parse_kind(_kind), do: {:error, :invalid_library_kind}
+
+  defp parse_id!(id) when is_integer(id), do: id
+  defp parse_id!(id), do: String.to_integer(id)
+
+  defp enabled?(enabled, kind, id), do: enabled |> Map.fetch!(kind) |> MapSet.member?(id)
+
+  defp authorize_customize(%{assigns: %{can_customize?: true}}), do: :ok
+  defp authorize_customize(_socket), do: {:error, :not_authorized}
+
+  defp source_field(:module), do: :source_module_id
+  defp source_field(:container), do: :source_container_id
+  defp source_field(:palette), do: :source_palette_id
+
+  defp override_route(kind, effective, site, environment) do
+    base =
+      case kind do
+        :module -> "/admin/config/content/modules/update/#{effective.override_id}"
+        :container -> "/admin/config/content/containers/update/#{effective.override_id}"
+        :palette -> "/admin/config/content/palettes/update/#{effective.override_id}"
+      end
+
+    query = URI.encode_query(%{"brando_site_key" => site.key, "brando_environment_key" => environment.key})
+    "#{base}?#{query}"
+  end
+
+  defp kind_title(:module), do: gettext("Modules")
+  defp kind_title(:container), do: gettext("Containers")
+  defp kind_title(:palette), do: gettext("Palettes")
+  defp kind_singular(kind), do: kind |> to_string() |> String.replace("_", " ")
+
+  defp kind_description(:module), do: gettext("Templates, variables, and references used by content blocks.")
+  defp kind_description(:container), do: gettext("Shared wrappers for groups of blocks.")
+  defp kind_description(:palette), do: gettext("Shared color systems for container blocks.")
+
+  defp entry_label(%{name: name}) when is_map(name) do
+    Map.get(name, Gettext.get_locale(Brando.Gettext)) || name |> Map.values() |> List.first() || "—"
+  end
+
+  defp entry_label(%{name: name}), do: name || "—"
+
+  defp default_code(:module), do: "<section>{{ content }}</section>"
+  defp default_code(:container), do: "<section>{{ content }}</section>"
+
+  defp colors_json(%{colors: colors}) do
+    colors
+    |> Enum.map(fn color ->
+      color
+      |> Map.from_struct()
+      |> Map.take([:name, :key, :hex_value, :instructions])
+    end)
+    |> Jason.encode!()
+  end
+
+  defp format_value(value) do
+    value
+    |> inspect(limit: 10, printable_limit: 160)
+    |> String.slice(0, 240)
+  end
+
+  defp notify(socket, message) do
+    send(self(), {:toast, message})
+    socket
+  end
+
+  defp notify_error(socket, message) do
+    BrandoAdmin.Toast.send_to(socket.assigns.current_user, message, %{level: :error, type: :notification})
+    socket
+  end
+
+  defp error_message({:error, reason}), do: error_message(reason)
+
+  defp error_message(%Ecto.Changeset{} = changeset) do
+    changeset
+    |> Ecto.Changeset.traverse_errors(fn {message, _opts} -> message end)
+    |> Enum.flat_map(fn {field, messages} -> Enum.map(messages, &"#{field} #{&1}") end)
+    |> Enum.join(", ")
+  end
+
+  defp error_message({:shared_item_in_use, usages}) do
+    names = usages |> Enum.map(& &1.site.name) |> Enum.uniq() |> Enum.join(", ")
+    gettext("This entry is still enabled, customized, or referenced by: %{sites}", sites: names)
+  end
+
+  defp error_message(reason) when is_atom(reason), do: reason |> Atom.to_string() |> String.replace("_", " ")
+  defp error_message(reason), do: inspect(reason)
+end

--- a/lib/brando_admin/live_view/form/hooks.ex
+++ b/lib/brando_admin/live_view/form/hooks.ex
@@ -1247,6 +1247,7 @@ defmodule BrandoAdmin.LiveView.Form.Hooks do
         event: "remote_block_added",
         uid: msg.uid,
         module_id: msg.module_id,
+        module_origin: Map.get(msg, :module_origin, :local),
         sequence: msg.sequence,
         user_id: msg.user_id
       )

--- a/lib/brando_admin/menu.ex
+++ b/lib/brando_admin/menu.ex
@@ -307,6 +307,15 @@ defmodule BrandoAdmin.Menu do
                     name: gettext("Block modules"),
                     url: "/admin/config/content/modules"
                   },
+                  Brando.Tenant.mode() == :multi && current_user &&
+                    %{
+                      name:
+                        if(current_user.role == :superuser,
+                          do: gettext("Shared content library"),
+                          else: gettext("Site content library")
+                        ),
+                      url: "/admin/config/content/shared_library"
+                    },
                   %{
                     name: gettext("Block module sets"),
                     url: "/admin/config/content/module_sets"

--- a/lib/mix/tasks/brando.install.ex
+++ b/lib/mix/tasks/brando.install.ex
@@ -45,6 +45,29 @@ defmodule Mix.Tasks.Brando.Install do
 
     # Application-owned migrations for named environment schemas
     {:keep, "tenant_migrations", "priv/repo/tenant_migrations"},
+    {:eex, "tenant_migrations/20260816002300_add_shared_content_library.exs",
+     "priv/repo/tenant_migrations/20260816002300_add_shared_content_library.exs"},
+
+    # Current versioned Brando migrations. Reuse the same templates as
+    # `mix brando.upgrade` so new and existing applications get identical SQL.
+    {:eex, "../brando.upgrade/migrations/brando_155_harden_revisions.exs",
+     "priv/repo/migrations/20260716000000_brando_155_harden_revisions.exs"},
+    {:eex, "../brando.upgrade/migrations/brando_156_add_var_layout.exs",
+     "priv/repo/migrations/20260725000000_brando_156_add_var_layout.exs"},
+    {:eex, "../brando.upgrade/migrations/brando_157_add_uploads_pending_intents.exs",
+     "priv/repo/migrations/20260805000000_brando_157_add_uploads_pending_intents.exs"},
+    {:eex, "../brando.upgrade/migrations/brando_158_add_tenant_infrastructure.exs",
+     "priv/repo/migrations/20260816000000_brando_158_add_tenant_infrastructure.exs"},
+    {:eex, "../brando.upgrade/migrations/brando_159_add_environment_operation_logs.exs",
+     "priv/repo/migrations/20260816001000_brando_159_add_environment_operation_logs.exs"},
+    {:eex, "../brando.upgrade/migrations/brando_160_add_user_sites.exs",
+     "priv/repo/migrations/20260816002000_brando_160_add_user_sites.exs"},
+    {:eex, "../brando.upgrade/migrations/brando_161_add_site_archival.exs",
+     "priv/repo/migrations/20260816002100_brando_161_add_site_archival.exs"},
+    {:eex, "../brando.upgrade/migrations/brando_162_add_site_asset_sets.exs",
+     "priv/repo/migrations/20260816002200_brando_162_add_site_asset_sets.exs"},
+    {:eex, "../brando.upgrade/migrations/brando_163_add_shared_content_library.exs",
+     "priv/repo/migrations/20260816002300_brando_163_add_shared_content_library.exs"},
 
     # Etc. Various OS config files and log directory.
     {:keep, "log", "log"},

--- a/priv/repo/migrations/20260816002300_add_shared_content_library.exs
+++ b/priv/repo/migrations/20260816002300_add_shared_content_library.exs
@@ -1,0 +1,158 @@
+defmodule BrandoIntegration.Repo.Migrations.AddSharedContentLibrary do
+  use Ecto.Migration
+
+  def up do
+    alter table(:content_modules) do
+      add :version, :integer, null: false, default: 1
+      add :version_note, :text
+      add :source_module_id, :bigint
+      add :source_version, :integer
+      add :acknowledged_version, :integer
+    end
+
+    alter table(:content_containers) do
+      add :version, :integer, null: false, default: 1
+      add :version_note, :text
+      add :source_container_id, :bigint
+      add :source_version, :integer
+      add :acknowledged_version, :integer
+    end
+
+    alter table(:content_palettes) do
+      add :version, :integer, null: false, default: 1
+      add :version_note, :text
+      add :source_palette_id, :bigint
+      add :source_version, :integer
+      add :acknowledged_version, :integer
+    end
+
+    alter table(:content_blocks) do
+      add :module_origin, :text, null: false, default: "local"
+      add :container_origin, :text, null: false, default: "local"
+      add :palette_origin, :text, null: false, default: "local"
+    end
+
+    execute "ALTER TABLE content_blocks DROP CONSTRAINT IF EXISTS content_blocks_module_id_fkey"
+    execute "ALTER TABLE content_blocks DROP CONSTRAINT IF EXISTS content_blocks_container_id_fkey"
+    execute "ALTER TABLE content_blocks DROP CONSTRAINT IF EXISTS content_blocks_palette_id_fkey"
+    execute "ALTER TABLE content_containers DROP CONSTRAINT IF EXISTS content_containers_palette_id_fkey"
+
+    create unique_index(:content_modules, [:source_module_id], where: "source_module_id IS NOT NULL")
+
+    create unique_index(:content_containers, [:source_container_id], where: "source_container_id IS NOT NULL")
+
+    create unique_index(:content_palettes, [:source_palette_id], where: "source_palette_id IS NOT NULL")
+    create index(:content_blocks, [:module_origin, :module_id])
+    create index(:content_blocks, [:container_origin, :container_id])
+    create index(:content_blocks, [:palette_origin, :palette_id])
+
+    create table(:site_enabled_modules, prefix: "public") do
+      add :site_id, references(:sites, prefix: "public", on_delete: :delete_all), null: false
+      add :module_id, references(:content_modules, prefix: "public", on_delete: :delete_all), null: false
+      timestamps(type: :utc_datetime_usec)
+    end
+
+    create unique_index(:site_enabled_modules, [:site_id, :module_id], prefix: "public")
+
+    create table(:site_enabled_containers, prefix: "public") do
+      add :site_id, references(:sites, prefix: "public", on_delete: :delete_all), null: false
+      add :container_id, references(:content_containers, prefix: "public", on_delete: :delete_all), null: false
+      timestamps(type: :utc_datetime_usec)
+    end
+
+    create unique_index(:site_enabled_containers, [:site_id, :container_id], prefix: "public")
+
+    create table(:site_enabled_palettes, prefix: "public") do
+      add :site_id, references(:sites, prefix: "public", on_delete: :delete_all), null: false
+      add :palette_id, references(:content_palettes, prefix: "public", on_delete: :delete_all), null: false
+      timestamps(type: :utc_datetime_usec)
+    end
+
+    create unique_index(:site_enabled_palettes, [:site_id, :palette_id], prefix: "public")
+
+    execute tenant_upgrade_sql()
+  end
+
+  def down do
+    drop table(:site_enabled_palettes, prefix: "public")
+    drop table(:site_enabled_containers, prefix: "public")
+    drop table(:site_enabled_modules, prefix: "public")
+
+    drop_if_exists index(:content_blocks, [:palette_origin, :palette_id])
+    drop_if_exists index(:content_blocks, [:container_origin, :container_id])
+    drop_if_exists index(:content_blocks, [:module_origin, :module_id])
+    drop_if_exists unique_index(:content_palettes, [:source_palette_id])
+    drop_if_exists unique_index(:content_containers, [:source_container_id])
+    drop_if_exists unique_index(:content_modules, [:source_module_id])
+
+    alter table(:content_blocks) do
+      remove :palette_origin
+      remove :container_origin
+      remove :module_origin
+    end
+
+    alter table(:content_palettes) do
+      remove :acknowledged_version
+      remove :source_version
+      remove :source_palette_id
+      remove :version_note
+      remove :version
+    end
+
+    alter table(:content_containers) do
+      remove :acknowledged_version
+      remove :source_version
+      remove :source_container_id
+      remove :version_note
+      remove :version
+    end
+
+    alter table(:content_modules) do
+      remove :acknowledged_version
+      remove :source_version
+      remove :source_module_id
+      remove :version_note
+      remove :version
+    end
+  end
+
+  defp tenant_upgrade_sql do
+    """
+    DO $$
+    DECLARE tenant_schema text;
+    BEGIN
+      FOR tenant_schema IN
+        SELECT nspname FROM pg_namespace
+        WHERE nspname ~ '^tenant_[a-z0-9-]+_[a-z0-9-]+$'
+      LOOP
+        IF to_regclass(format('%I.content_modules', tenant_schema)) IS NOT NULL THEN
+          EXECUTE format('ALTER TABLE %I.content_modules ADD COLUMN IF NOT EXISTS version integer NOT NULL DEFAULT 1, ADD COLUMN IF NOT EXISTS version_note text, ADD COLUMN IF NOT EXISTS source_module_id bigint, ADD COLUMN IF NOT EXISTS source_version integer, ADD COLUMN IF NOT EXISTS acknowledged_version integer', tenant_schema);
+          EXECUTE format('ALTER TABLE %I.content_modules DROP CONSTRAINT IF EXISTS content_modules_parent_id_fkey', tenant_schema);
+          EXECUTE format('CREATE UNIQUE INDEX IF NOT EXISTS %I ON %I.content_modules (source_module_id) WHERE source_module_id IS NOT NULL', tenant_schema || '_content_modules_source_module_id_index', tenant_schema);
+        END IF;
+
+        IF to_regclass(format('%I.content_containers', tenant_schema)) IS NOT NULL THEN
+          EXECUTE format('ALTER TABLE %I.content_containers ADD COLUMN IF NOT EXISTS version integer NOT NULL DEFAULT 1, ADD COLUMN IF NOT EXISTS version_note text, ADD COLUMN IF NOT EXISTS source_container_id bigint, ADD COLUMN IF NOT EXISTS source_version integer, ADD COLUMN IF NOT EXISTS acknowledged_version integer', tenant_schema);
+          EXECUTE format('ALTER TABLE %I.content_containers DROP CONSTRAINT IF EXISTS content_containers_palette_id_fkey', tenant_schema);
+          EXECUTE format('CREATE UNIQUE INDEX IF NOT EXISTS %I ON %I.content_containers (source_container_id) WHERE source_container_id IS NOT NULL', tenant_schema || '_content_containers_source_container_id_index', tenant_schema);
+        END IF;
+
+        IF to_regclass(format('%I.content_palettes', tenant_schema)) IS NOT NULL THEN
+          EXECUTE format('ALTER TABLE %I.content_palettes ADD COLUMN IF NOT EXISTS version integer NOT NULL DEFAULT 1, ADD COLUMN IF NOT EXISTS version_note text, ADD COLUMN IF NOT EXISTS source_palette_id bigint, ADD COLUMN IF NOT EXISTS source_version integer, ADD COLUMN IF NOT EXISTS acknowledged_version integer', tenant_schema);
+          EXECUTE format('CREATE UNIQUE INDEX IF NOT EXISTS %I ON %I.content_palettes (source_palette_id) WHERE source_palette_id IS NOT NULL', tenant_schema || '_content_palettes_source_palette_id_index', tenant_schema);
+        END IF;
+
+        IF to_regclass(format('%I.content_blocks', tenant_schema)) IS NOT NULL THEN
+          EXECUTE format('ALTER TABLE %I.content_blocks ADD COLUMN IF NOT EXISTS module_origin text NOT NULL DEFAULT ''local'', ADD COLUMN IF NOT EXISTS container_origin text NOT NULL DEFAULT ''local'', ADD COLUMN IF NOT EXISTS palette_origin text NOT NULL DEFAULT ''local''', tenant_schema);
+          EXECUTE format('ALTER TABLE %I.content_blocks DROP CONSTRAINT IF EXISTS content_blocks_module_id_fkey', tenant_schema);
+          EXECUTE format('ALTER TABLE %I.content_blocks DROP CONSTRAINT IF EXISTS content_blocks_container_id_fkey', tenant_schema);
+          EXECUTE format('ALTER TABLE %I.content_blocks DROP CONSTRAINT IF EXISTS content_blocks_palette_id_fkey', tenant_schema);
+          EXECUTE format('CREATE INDEX IF NOT EXISTS %I ON %I.content_blocks (module_origin, module_id)', tenant_schema || '_content_blocks_module_origin_module_id_index', tenant_schema);
+          EXECUTE format('CREATE INDEX IF NOT EXISTS %I ON %I.content_blocks (container_origin, container_id)', tenant_schema || '_content_blocks_container_origin_container_id_index', tenant_schema);
+          EXECUTE format('CREATE INDEX IF NOT EXISTS %I ON %I.content_blocks (palette_origin, palette_id)', tenant_schema || '_content_blocks_palette_origin_palette_id_index', tenant_schema);
+        END IF;
+      END LOOP;
+    END $$;
+    """
+  end
+end

--- a/priv/repo/tenant_migrations/20260816002300_add_shared_content_library.exs
+++ b/priv/repo/tenant_migrations/20260816002300_add_shared_content_library.exs
@@ -1,0 +1,48 @@
+defmodule Brando.Repo.TenantMigrations.AddSharedContentLibrary do
+  use Ecto.Migration
+
+  def up do
+    case prefix() do
+      tenant_prefix when is_binary(tenant_prefix) -> execute(upgrade_sql(tenant_prefix))
+      nil -> :ok
+    end
+  end
+
+  def down, do: :ok
+
+  defp upgrade_sql(tenant_prefix) do
+    unless Regex.match?(~r/^tenant_[a-z0-9-]+_[a-z0-9-]+$/, tenant_prefix) do
+      raise ArgumentError, "invalid tenant migration prefix: #{inspect(tenant_prefix)}"
+    end
+
+    """
+    DO $$
+    DECLARE tenant_schema text := '#{tenant_prefix}';
+    BEGIN
+      IF to_regclass(format('%I.content_modules', tenant_schema)) IS NOT NULL THEN
+        EXECUTE format('ALTER TABLE %I.content_modules ADD COLUMN IF NOT EXISTS version integer NOT NULL DEFAULT 1, ADD COLUMN IF NOT EXISTS version_note text, ADD COLUMN IF NOT EXISTS source_module_id bigint, ADD COLUMN IF NOT EXISTS source_version integer, ADD COLUMN IF NOT EXISTS acknowledged_version integer', tenant_schema);
+        EXECUTE format('ALTER TABLE %I.content_modules DROP CONSTRAINT IF EXISTS content_modules_parent_id_fkey', tenant_schema);
+        EXECUTE format('CREATE UNIQUE INDEX IF NOT EXISTS %I ON %I.content_modules (source_module_id) WHERE source_module_id IS NOT NULL', tenant_schema || '_content_modules_source_module_id_index', tenant_schema);
+      END IF;
+      IF to_regclass(format('%I.content_containers', tenant_schema)) IS NOT NULL THEN
+        EXECUTE format('ALTER TABLE %I.content_containers ADD COLUMN IF NOT EXISTS version integer NOT NULL DEFAULT 1, ADD COLUMN IF NOT EXISTS version_note text, ADD COLUMN IF NOT EXISTS source_container_id bigint, ADD COLUMN IF NOT EXISTS source_version integer, ADD COLUMN IF NOT EXISTS acknowledged_version integer', tenant_schema);
+        EXECUTE format('ALTER TABLE %I.content_containers DROP CONSTRAINT IF EXISTS content_containers_palette_id_fkey', tenant_schema);
+        EXECUTE format('CREATE UNIQUE INDEX IF NOT EXISTS %I ON %I.content_containers (source_container_id) WHERE source_container_id IS NOT NULL', tenant_schema || '_content_containers_source_container_id_index', tenant_schema);
+      END IF;
+      IF to_regclass(format('%I.content_palettes', tenant_schema)) IS NOT NULL THEN
+        EXECUTE format('ALTER TABLE %I.content_palettes ADD COLUMN IF NOT EXISTS version integer NOT NULL DEFAULT 1, ADD COLUMN IF NOT EXISTS version_note text, ADD COLUMN IF NOT EXISTS source_palette_id bigint, ADD COLUMN IF NOT EXISTS source_version integer, ADD COLUMN IF NOT EXISTS acknowledged_version integer', tenant_schema);
+        EXECUTE format('CREATE UNIQUE INDEX IF NOT EXISTS %I ON %I.content_palettes (source_palette_id) WHERE source_palette_id IS NOT NULL', tenant_schema || '_content_palettes_source_palette_id_index', tenant_schema);
+      END IF;
+      IF to_regclass(format('%I.content_blocks', tenant_schema)) IS NOT NULL THEN
+        EXECUTE format('ALTER TABLE %I.content_blocks ADD COLUMN IF NOT EXISTS module_origin text NOT NULL DEFAULT ''local'', ADD COLUMN IF NOT EXISTS container_origin text NOT NULL DEFAULT ''local'', ADD COLUMN IF NOT EXISTS palette_origin text NOT NULL DEFAULT ''local''', tenant_schema);
+        EXECUTE format('ALTER TABLE %I.content_blocks DROP CONSTRAINT IF EXISTS content_blocks_module_id_fkey', tenant_schema);
+        EXECUTE format('ALTER TABLE %I.content_blocks DROP CONSTRAINT IF EXISTS content_blocks_container_id_fkey', tenant_schema);
+        EXECUTE format('ALTER TABLE %I.content_blocks DROP CONSTRAINT IF EXISTS content_blocks_palette_id_fkey', tenant_schema);
+        EXECUTE format('CREATE INDEX IF NOT EXISTS %I ON %I.content_blocks (module_origin, module_id)', tenant_schema || '_content_blocks_module_origin_module_id_index', tenant_schema);
+        EXECUTE format('CREATE INDEX IF NOT EXISTS %I ON %I.content_blocks (container_origin, container_id)', tenant_schema || '_content_blocks_container_origin_container_id_index', tenant_schema);
+        EXECUTE format('CREATE INDEX IF NOT EXISTS %I ON %I.content_blocks (palette_origin, palette_id)', tenant_schema || '_content_blocks_palette_origin_palette_id_index', tenant_schema);
+      END IF;
+    END $$;
+    """
+  end
+end

--- a/priv/templates/brando.install/tenant_migrations/20260816002300_add_shared_content_library.exs
+++ b/priv/templates/brando.install/tenant_migrations/20260816002300_add_shared_content_library.exs
@@ -1,0 +1,48 @@
+defmodule Brando.Repo.TenantMigrations.AddSharedContentLibrary do
+  use Ecto.Migration
+
+  def up do
+    case prefix() do
+      tenant_prefix when is_binary(tenant_prefix) -> execute(upgrade_sql(tenant_prefix))
+      nil -> :ok
+    end
+  end
+
+  def down, do: :ok
+
+  defp upgrade_sql(tenant_prefix) do
+    unless Regex.match?(~r/^tenant_[a-z0-9-]+_[a-z0-9-]+$/, tenant_prefix) do
+      raise ArgumentError, "invalid tenant migration prefix: #{inspect(tenant_prefix)}"
+    end
+
+    """
+    DO $$
+    DECLARE tenant_schema text := '#{tenant_prefix}';
+    BEGIN
+      IF to_regclass(format('%I.content_modules', tenant_schema)) IS NOT NULL THEN
+        EXECUTE format('ALTER TABLE %I.content_modules ADD COLUMN IF NOT EXISTS version integer NOT NULL DEFAULT 1, ADD COLUMN IF NOT EXISTS version_note text, ADD COLUMN IF NOT EXISTS source_module_id bigint, ADD COLUMN IF NOT EXISTS source_version integer, ADD COLUMN IF NOT EXISTS acknowledged_version integer', tenant_schema);
+        EXECUTE format('ALTER TABLE %I.content_modules DROP CONSTRAINT IF EXISTS content_modules_parent_id_fkey', tenant_schema);
+        EXECUTE format('CREATE UNIQUE INDEX IF NOT EXISTS %I ON %I.content_modules (source_module_id) WHERE source_module_id IS NOT NULL', tenant_schema || '_content_modules_source_module_id_index', tenant_schema);
+      END IF;
+      IF to_regclass(format('%I.content_containers', tenant_schema)) IS NOT NULL THEN
+        EXECUTE format('ALTER TABLE %I.content_containers ADD COLUMN IF NOT EXISTS version integer NOT NULL DEFAULT 1, ADD COLUMN IF NOT EXISTS version_note text, ADD COLUMN IF NOT EXISTS source_container_id bigint, ADD COLUMN IF NOT EXISTS source_version integer, ADD COLUMN IF NOT EXISTS acknowledged_version integer', tenant_schema);
+        EXECUTE format('ALTER TABLE %I.content_containers DROP CONSTRAINT IF EXISTS content_containers_palette_id_fkey', tenant_schema);
+        EXECUTE format('CREATE UNIQUE INDEX IF NOT EXISTS %I ON %I.content_containers (source_container_id) WHERE source_container_id IS NOT NULL', tenant_schema || '_content_containers_source_container_id_index', tenant_schema);
+      END IF;
+      IF to_regclass(format('%I.content_palettes', tenant_schema)) IS NOT NULL THEN
+        EXECUTE format('ALTER TABLE %I.content_palettes ADD COLUMN IF NOT EXISTS version integer NOT NULL DEFAULT 1, ADD COLUMN IF NOT EXISTS version_note text, ADD COLUMN IF NOT EXISTS source_palette_id bigint, ADD COLUMN IF NOT EXISTS source_version integer, ADD COLUMN IF NOT EXISTS acknowledged_version integer', tenant_schema);
+        EXECUTE format('CREATE UNIQUE INDEX IF NOT EXISTS %I ON %I.content_palettes (source_palette_id) WHERE source_palette_id IS NOT NULL', tenant_schema || '_content_palettes_source_palette_id_index', tenant_schema);
+      END IF;
+      IF to_regclass(format('%I.content_blocks', tenant_schema)) IS NOT NULL THEN
+        EXECUTE format('ALTER TABLE %I.content_blocks ADD COLUMN IF NOT EXISTS module_origin text NOT NULL DEFAULT ''local'', ADD COLUMN IF NOT EXISTS container_origin text NOT NULL DEFAULT ''local'', ADD COLUMN IF NOT EXISTS palette_origin text NOT NULL DEFAULT ''local''', tenant_schema);
+        EXECUTE format('ALTER TABLE %I.content_blocks DROP CONSTRAINT IF EXISTS content_blocks_module_id_fkey', tenant_schema);
+        EXECUTE format('ALTER TABLE %I.content_blocks DROP CONSTRAINT IF EXISTS content_blocks_container_id_fkey', tenant_schema);
+        EXECUTE format('ALTER TABLE %I.content_blocks DROP CONSTRAINT IF EXISTS content_blocks_palette_id_fkey', tenant_schema);
+        EXECUTE format('CREATE INDEX IF NOT EXISTS %I ON %I.content_blocks (module_origin, module_id)', tenant_schema || '_content_blocks_module_origin_module_id_index', tenant_schema);
+        EXECUTE format('CREATE INDEX IF NOT EXISTS %I ON %I.content_blocks (container_origin, container_id)', tenant_schema || '_content_blocks_container_origin_container_id_index', tenant_schema);
+        EXECUTE format('CREATE INDEX IF NOT EXISTS %I ON %I.content_blocks (palette_origin, palette_id)', tenant_schema || '_content_blocks_palette_origin_palette_id_index', tenant_schema);
+      END IF;
+    END $$;
+    """
+  end
+end

--- a/priv/templates/brando.upgrade/migrations/brando_163_add_shared_content_library.exs
+++ b/priv/templates/brando.upgrade/migrations/brando_163_add_shared_content_library.exs
@@ -1,0 +1,118 @@
+defmodule Brando.Repo.Migrations.Brando163AddSharedContentLibrary do
+  use Ecto.Migration
+
+  def up do
+    alter table(:content_modules) do
+      add :version, :integer, null: false, default: 1
+      add :version_note, :text
+      add :source_module_id, :bigint
+      add :source_version, :integer
+      add :acknowledged_version, :integer
+    end
+
+    alter table(:content_containers) do
+      add :version, :integer, null: false, default: 1
+      add :version_note, :text
+      add :source_container_id, :bigint
+      add :source_version, :integer
+      add :acknowledged_version, :integer
+    end
+
+    alter table(:content_palettes) do
+      add :version, :integer, null: false, default: 1
+      add :version_note, :text
+      add :source_palette_id, :bigint
+      add :source_version, :integer
+      add :acknowledged_version, :integer
+    end
+
+    alter table(:content_blocks) do
+      add :module_origin, :text, null: false, default: "local"
+      add :container_origin, :text, null: false, default: "local"
+      add :palette_origin, :text, null: false, default: "local"
+    end
+
+    execute "ALTER TABLE content_blocks DROP CONSTRAINT IF EXISTS content_blocks_module_id_fkey"
+    execute "ALTER TABLE content_blocks DROP CONSTRAINT IF EXISTS content_blocks_container_id_fkey"
+    execute "ALTER TABLE content_blocks DROP CONSTRAINT IF EXISTS content_blocks_palette_id_fkey"
+    execute "ALTER TABLE content_containers DROP CONSTRAINT IF EXISTS content_containers_palette_id_fkey"
+
+    create unique_index(:content_modules, [:source_module_id], where: "source_module_id IS NOT NULL")
+
+    create unique_index(:content_containers, [:source_container_id], where: "source_container_id IS NOT NULL")
+
+    create unique_index(:content_palettes, [:source_palette_id], where: "source_palette_id IS NOT NULL")
+    create index(:content_blocks, [:module_origin, :module_id])
+    create index(:content_blocks, [:container_origin, :container_id])
+    create index(:content_blocks, [:palette_origin, :palette_id])
+
+    create table(:site_enabled_modules, prefix: "public") do
+      add :site_id, references(:sites, prefix: "public", on_delete: :delete_all), null: false
+      add :module_id, references(:content_modules, prefix: "public", on_delete: :delete_all), null: false
+      timestamps(type: :utc_datetime_usec)
+    end
+
+    create unique_index(:site_enabled_modules, [:site_id, :module_id], prefix: "public")
+
+    create table(:site_enabled_containers, prefix: "public") do
+      add :site_id, references(:sites, prefix: "public", on_delete: :delete_all), null: false
+      add :container_id, references(:content_containers, prefix: "public", on_delete: :delete_all), null: false
+      timestamps(type: :utc_datetime_usec)
+    end
+
+    create unique_index(:site_enabled_containers, [:site_id, :container_id], prefix: "public")
+
+    create table(:site_enabled_palettes, prefix: "public") do
+      add :site_id, references(:sites, prefix: "public", on_delete: :delete_all), null: false
+      add :palette_id, references(:content_palettes, prefix: "public", on_delete: :delete_all), null: false
+      timestamps(type: :utc_datetime_usec)
+    end
+
+    create unique_index(:site_enabled_palettes, [:site_id, :palette_id], prefix: "public")
+
+    execute tenant_upgrade_sql()
+  end
+
+  def down do
+    drop table(:site_enabled_palettes, prefix: "public")
+    drop table(:site_enabled_containers, prefix: "public")
+    drop table(:site_enabled_modules, prefix: "public")
+  end
+
+  defp tenant_upgrade_sql do
+    """
+    DO $$
+    DECLARE tenant_schema text;
+    BEGIN
+      FOR tenant_schema IN
+        SELECT nspname FROM pg_namespace
+        WHERE nspname ~ '^tenant_[a-z0-9-]+_[a-z0-9-]+$'
+      LOOP
+        IF to_regclass(format('%I.content_modules', tenant_schema)) IS NOT NULL THEN
+          EXECUTE format('ALTER TABLE %I.content_modules ADD COLUMN IF NOT EXISTS version integer NOT NULL DEFAULT 1, ADD COLUMN IF NOT EXISTS version_note text, ADD COLUMN IF NOT EXISTS source_module_id bigint, ADD COLUMN IF NOT EXISTS source_version integer, ADD COLUMN IF NOT EXISTS acknowledged_version integer', tenant_schema);
+          EXECUTE format('ALTER TABLE %I.content_modules DROP CONSTRAINT IF EXISTS content_modules_parent_id_fkey', tenant_schema);
+          EXECUTE format('CREATE UNIQUE INDEX IF NOT EXISTS %I ON %I.content_modules (source_module_id) WHERE source_module_id IS NOT NULL', tenant_schema || '_content_modules_source_module_id_index', tenant_schema);
+        END IF;
+        IF to_regclass(format('%I.content_containers', tenant_schema)) IS NOT NULL THEN
+          EXECUTE format('ALTER TABLE %I.content_containers ADD COLUMN IF NOT EXISTS version integer NOT NULL DEFAULT 1, ADD COLUMN IF NOT EXISTS version_note text, ADD COLUMN IF NOT EXISTS source_container_id bigint, ADD COLUMN IF NOT EXISTS source_version integer, ADD COLUMN IF NOT EXISTS acknowledged_version integer', tenant_schema);
+          EXECUTE format('ALTER TABLE %I.content_containers DROP CONSTRAINT IF EXISTS content_containers_palette_id_fkey', tenant_schema);
+          EXECUTE format('CREATE UNIQUE INDEX IF NOT EXISTS %I ON %I.content_containers (source_container_id) WHERE source_container_id IS NOT NULL', tenant_schema || '_content_containers_source_container_id_index', tenant_schema);
+        END IF;
+        IF to_regclass(format('%I.content_palettes', tenant_schema)) IS NOT NULL THEN
+          EXECUTE format('ALTER TABLE %I.content_palettes ADD COLUMN IF NOT EXISTS version integer NOT NULL DEFAULT 1, ADD COLUMN IF NOT EXISTS version_note text, ADD COLUMN IF NOT EXISTS source_palette_id bigint, ADD COLUMN IF NOT EXISTS source_version integer, ADD COLUMN IF NOT EXISTS acknowledged_version integer', tenant_schema);
+          EXECUTE format('CREATE UNIQUE INDEX IF NOT EXISTS %I ON %I.content_palettes (source_palette_id) WHERE source_palette_id IS NOT NULL', tenant_schema || '_content_palettes_source_palette_id_index', tenant_schema);
+        END IF;
+        IF to_regclass(format('%I.content_blocks', tenant_schema)) IS NOT NULL THEN
+          EXECUTE format('ALTER TABLE %I.content_blocks ADD COLUMN IF NOT EXISTS module_origin text NOT NULL DEFAULT ''local'', ADD COLUMN IF NOT EXISTS container_origin text NOT NULL DEFAULT ''local'', ADD COLUMN IF NOT EXISTS palette_origin text NOT NULL DEFAULT ''local''', tenant_schema);
+          EXECUTE format('ALTER TABLE %I.content_blocks DROP CONSTRAINT IF EXISTS content_blocks_module_id_fkey', tenant_schema);
+          EXECUTE format('ALTER TABLE %I.content_blocks DROP CONSTRAINT IF EXISTS content_blocks_container_id_fkey', tenant_schema);
+          EXECUTE format('ALTER TABLE %I.content_blocks DROP CONSTRAINT IF EXISTS content_blocks_palette_id_fkey', tenant_schema);
+          EXECUTE format('CREATE INDEX IF NOT EXISTS %I ON %I.content_blocks (module_origin, module_id)', tenant_schema || '_content_blocks_module_origin_module_id_index', tenant_schema);
+          EXECUTE format('CREATE INDEX IF NOT EXISTS %I ON %I.content_blocks (container_origin, container_id)', tenant_schema || '_content_blocks_container_origin_container_id_index', tenant_schema);
+          EXECUTE format('CREATE INDEX IF NOT EXISTS %I ON %I.content_blocks (palette_origin, palette_id)', tenant_schema || '_content_blocks_palette_origin_palette_id_index', tenant_schema);
+        END IF;
+      END LOOP;
+    END $$;
+    """
+  end
+end

--- a/test/brando/shared_library_test.exs
+++ b/test/brando/shared_library_test.exs
@@ -1,0 +1,339 @@
+defmodule Brando.Content.SharedLibraryTest do
+  use ExUnit.Case, async: false
+  use Brando.ConnCase
+
+  alias Brando.Content.Block
+  alias Brando.Content.Module
+  alias Brando.Content.ModuleResolver
+  alias Brando.Content.SharedLibrary
+  alias Brando.Repo
+  alias Brando.Tenant
+  alias Brando.Tenant.Registry
+
+  @prefix "tenant_library-test_preview"
+
+  setup do
+    put_test_env(:tenancy_mode, :multi)
+    Tenant.put_prefix(nil)
+    SharedLibrary.Cache.clear()
+
+    user = Brando.Factory.insert(:random_user, role: :superuser)
+
+    {:ok, site} =
+      Registry.create_site(%{
+        name: "Library test",
+        key: "library-test",
+        languages: ["en"],
+        default_language: "en",
+        status: :active,
+        delivery_mode: :dynamic
+      })
+
+    {:ok, _environment} =
+      Registry.create_environment(site, %{
+        name: "Preview",
+        key: "preview",
+        live: true
+      })
+
+    Ecto.Adapters.SQL.query!(BrandoIntegration.Repo, ~s|CREATE SCHEMA "#{@prefix}"|)
+
+    for table <- ~w(content_modules content_vars content_refs content_containers content_palettes content_blocks) do
+      Ecto.Adapters.SQL.query!(
+        BrandoIntegration.Repo,
+        ~s|CREATE TABLE "#{@prefix}"."#{table}" (LIKE public."#{table}" INCLUDING ALL)|
+      )
+    end
+
+    on_exit(fn ->
+      Tenant.put_prefix(nil)
+      SharedLibrary.Cache.clear()
+    end)
+
+    %{site: site, user: user}
+  end
+
+  test "fully custom, hybrid, and disabled rendering behavior", %{site: site, user: user} do
+    shared = create_public_module("Shared hero", user)
+    local = Tenant.with_prefix(@prefix, fn -> create_module("Site hero", user) end)
+
+    assert [%{id: local_id, library_origin: :local}] =
+             SharedLibrary.list_available(:module, site, @prefix)
+
+    assert local_id == local.id
+    refute SharedLibrary.get(:module, shared.id, :shared, site, @prefix, require_enabled: true)
+
+    assert :ok = SharedLibrary.enable(site, :module, shared.id)
+
+    available =
+      site
+      |> then(&SharedLibrary.list_available(:module, &1, @prefix))
+      |> Enum.map(&{&1.id, &1.library_origin})
+      |> MapSet.new()
+
+    assert available == MapSet.new([{local.id, :local}, {shared.id, :shared}])
+
+    assert %{id: shared_id, library_origin: :shared} =
+             SharedLibrary.get(:module, shared.id, :shared, site, @prefix, require_enabled: true)
+
+    assert shared_id == shared.id
+    assert :ok = SharedLibrary.disable(site, :module, shared.id)
+    assert [%{id: remaining_id}] = SharedLibrary.list_available(:module, site, @prefix)
+    assert remaining_id == local.id
+
+    # Revoking picker access must not break blocks already referencing shared.
+    assert %{id: rendered_id, library_origin: :shared} =
+             SharedLibrary.get(:module, shared.id, :shared, site, @prefix)
+
+    assert rendered_id == shared.id
+  end
+
+  test "customize, dismiss, accept, and reset preserve the shared block identity", %{site: site, user: user} do
+    shared = create_public_module("Shared testimonial", user)
+    assert :ok = SharedLibrary.enable(site, :module, shared.id)
+
+    assert {:ok, override} = SharedLibrary.customize(:module, shared.id, site, @prefix, user)
+    assert override.source_module_id == shared.id
+    assert override.source_version == 1
+
+    assert [
+             %{
+               id: effective_id,
+               override_id: override_id,
+               source_module_id: source_id,
+               update_available: false
+             }
+           ] =
+             SharedLibrary.list_available(:module, site, @prefix)
+
+    assert effective_id == shared.id
+    assert override_id == override.id
+    assert source_id == shared.id
+
+    assert {:ok, shared_v2} =
+             SharedLibrary.update_shared(
+               :module,
+               shared.id,
+               %{help_text: %{"en" => "Version two"}, version_note: "Add a field"},
+               user
+             )
+
+    assert shared_v2.version == 2
+    assert [%{update_available: true}] = SharedLibrary.list_available(:module, site, @prefix)
+
+    assert {:ok, _dismissed} = SharedLibrary.dismiss_update(:module, shared.id, site, @prefix)
+    assert [%{update_available: false}] = SharedLibrary.list_available(:module, site, @prefix)
+
+    assert {:ok, accepted} = SharedLibrary.accept_update(:module, shared.id, site, @prefix, user)
+    assert accepted.source_version == 2
+    assert accepted.help_text == %{"en" => "Version two"}
+
+    assert :ok = SharedLibrary.reset(:module, shared.id, site, @prefix)
+
+    assert %{source_module_id: nil, version: 2} =
+             SharedLibrary.get(:module, shared.id, :shared, site, @prefix)
+  end
+
+  test "containers and palettes use the same allowlist and override contract", %{site: site, user: user} do
+    palette = create_public_palette("Shared dark", user)
+    container = create_public_container("Shared section", user)
+
+    assert :ok = SharedLibrary.set_enabled(site, :palette, [palette.id])
+    assert :ok = SharedLibrary.set_enabled(site, :container, [container.id])
+
+    assert [%{id: palette_id, library_origin: :shared}] =
+             SharedLibrary.list_available(:palette, site, @prefix)
+
+    assert [%{id: container_id, library_origin: :shared}] =
+             SharedLibrary.list_available(:container, site, @prefix)
+
+    assert palette_id == palette.id
+    assert container_id == container.id
+
+    assert {:ok, palette_override} =
+             SharedLibrary.customize(:palette, palette.id, site, @prefix, user)
+
+    assert {:ok, container_override} =
+             SharedLibrary.customize(:container, container.id, site, @prefix, user)
+
+    assert palette_override.source_palette_id == palette.id
+    assert container_override.source_container_id == container.id
+  end
+
+  test "module customization copies editable variables and references", %{site: site, user: user} do
+    attrs =
+      "Shared rich module"
+      |> module_attrs()
+      |> Map.put(:vars, [
+        %{
+          type: :text,
+          label: "Eyebrow",
+          key: "eyebrow",
+          value: "Shared value",
+          sequence: 0
+        }
+      ])
+      |> Map.put(:refs, [
+        %{
+          name: "body",
+          description: "Body copy",
+          uid: Brando.Utils.generate_uid(),
+          sequence: 0,
+          data: %{type: "text", data: %{text: "Shared body"}}
+        }
+      ])
+
+    assert {:ok, shared} = SharedLibrary.create_shared(:module, attrs, user)
+    assert :ok = SharedLibrary.enable(site, :module, shared.id)
+    assert {:ok, override} = SharedLibrary.customize(:module, shared.id, site, @prefix, user)
+
+    assert [%{key: "eyebrow", value: "Shared value", module_id: override_id}] = override.vars
+    assert override_id == override.id
+    assert [%{name: "body", description: "Body copy", module_id: ref_override_id}] = override.refs
+    assert ref_override_id == override.id
+  end
+
+  test "origin-qualified block fields round-trip independently from integer IDs" do
+    changeset =
+      Block.block_changeset(
+        %Block{},
+        %{
+          uid: "shared-origin",
+          module_id: 42,
+          module_origin: "shared",
+          container_id: 42,
+          container_origin: "local",
+          palette_id: 42,
+          palette_origin: "shared"
+        },
+        :system
+      )
+
+    block = Ecto.Changeset.apply_changes(changeset)
+    assert block.module_id == block.container_id
+    assert block.module_origin == :shared
+    assert block.container_origin == :local
+    assert block.palette_origin == :shared
+  end
+
+  test "shared references have an unambiguous picker encoding" do
+    assert {:shared, 42} = "shared:42" |> SharedLibrary.reference()
+    assert {:local, 42} = "42" |> SharedLibrary.reference()
+    assert "shared:42" == SharedLibrary.encode_reference(:shared, 42)
+  end
+
+  test "tenant-first compatibility and explicit origins survive integer ID collisions", %{
+    site: site,
+    user: user
+  } do
+    shared = create_public_module("Shared collision", user)
+
+    local =
+      Tenant.with_prefix(@prefix, fn ->
+        {:ok, module} =
+          %Module{id: shared.id}
+          |> Module.changeset(module_attrs("Local collision"), user)
+          |> Repo.insert()
+
+        module
+      end)
+
+    assert local.id == shared.id
+    assert :ok = SharedLibrary.enable(site, :module, shared.id)
+
+    assert %{name: %{"en" => "Local collision"}, library_origin: :local} =
+             ModuleResolver.get_module(shared.id, site, @prefix)
+
+    assert %{name: %{"en" => "Shared collision"}, library_origin: :shared} =
+             ModuleResolver.get_module(shared.id, :shared, site, @prefix)
+  end
+
+  test "deletion remains blocked after access is revoked when an existing block still references shared", %{
+    site: site,
+    user: user
+  } do
+    shared = create_public_module("Shared in use", user)
+    assert :ok = SharedLibrary.enable(site, :module, shared.id)
+    assert {:error, {:shared_item_in_use, _usage}} = SharedLibrary.delete_shared(:module, shared.id)
+
+    assert :ok = SharedLibrary.disable(site, :module, shared.id)
+    refute Enum.any?(SharedLibrary.list_for_rendering(:module, site, @prefix), &(&1.id == shared.id))
+
+    Ecto.Adapters.SQL.query!(
+      BrandoIntegration.Repo,
+      ~s|INSERT INTO "#{@prefix}".content_blocks (uid, type, module_id, module_origin, inserted_at, updated_at) VALUES ('shared-in-use', 'module', $1, 'shared', now(), now())|,
+      [shared.id]
+    )
+
+    assert {:error, {:shared_item_in_use, [usage]}} = SharedLibrary.delete_shared(:module, shared.id)
+    refute usage.enabled
+    assert usage.referenced_environments == ["preview"]
+
+    assert Enum.any?(SharedLibrary.list_for_rendering(:module, site, @prefix), fn entry ->
+             entry.id == shared.id and entry.library_origin == :shared
+           end)
+  end
+
+  defp create_public_module(name, user) do
+    Tenant.put_prefix(nil)
+
+    {:ok, module} = SharedLibrary.create_shared(:module, module_attrs(name), user)
+    module
+  end
+
+  defp create_module(name, user) do
+    {:ok, module} =
+      %Module{}
+      |> Module.changeset(module_attrs(name), user)
+      |> Repo.insert()
+
+    module
+  end
+
+  defp module_attrs(name) do
+    %{
+      name: %{"en" => name},
+      namespace: %{"en" => "general"},
+      help_text: %{"en" => "Help"},
+      class: "module",
+      code: "<section>#{name}</section>"
+    }
+  end
+
+  defp create_public_container(name, user) do
+    Tenant.put_prefix(nil)
+
+    {:ok, container} =
+      SharedLibrary.create_shared(
+        :container,
+        %{
+          name: name,
+          namespace: "general",
+          help_text: "Help",
+          code: "<section>{{ content }}</section>"
+        },
+        user
+      )
+
+    container
+  end
+
+  defp create_public_palette(name, user) do
+    Tenant.put_prefix(nil)
+
+    {:ok, palette} =
+      SharedLibrary.create_shared(
+        :palette,
+        %{
+          name: name,
+          key: "sharedDark",
+          namespace: "general",
+          status: :published,
+          colors: []
+        },
+        user
+      )
+
+    palette
+  end
+end

--- a/test/brando_admin/live/shared_library_live_test.exs
+++ b/test/brando_admin/live/shared_library_live_test.exs
@@ -1,0 +1,158 @@
+defmodule BrandoAdmin.Content.SharedLibraryLiveTest do
+  use Brando.LiveCase
+
+  alias Brando.Content.SharedLibrary
+  alias Brando.Tenant.Access
+  alias Brando.Tenant.Registry
+
+  @prefix "tenant_shared-library-live_preview"
+
+  setup %{current_user: current_user} do
+    put_test_env(:tenancy_mode, :multi)
+    Brando.Tenant.put_prefix(nil)
+    SharedLibrary.Cache.clear()
+
+    on_exit(fn ->
+      Brando.Tenant.put_prefix(nil)
+      SharedLibrary.Cache.clear()
+    end)
+
+    {:ok, site} =
+      Registry.create_site(%{
+        name: "Library Site",
+        key: "shared-library-live",
+        languages: ["en"],
+        default_language: "en",
+        status: :active,
+        delivery_mode: :dynamic
+      })
+
+    {:ok, _environment} =
+      Registry.create_environment(site, %{
+        name: "Preview",
+        key: "preview",
+        live: true
+      })
+
+    Ecto.Adapters.SQL.query!(BrandoIntegration.Repo, ~s|CREATE SCHEMA "#{@prefix}"|)
+
+    for table <- ~w(content_modules content_vars content_refs content_containers content_palettes content_blocks) do
+      Ecto.Adapters.SQL.query!(
+        BrandoIntegration.Repo,
+        ~s|CREATE TABLE "#{@prefix}"."#{table}" (LIKE public."#{table}" INCLUDING ALL)|
+      )
+    end
+
+    {:ok, shared_module} =
+      SharedLibrary.create_shared(
+        :module,
+        %{
+          name: %{"en" => "Shared hero"},
+          namespace: %{"en" => "general"},
+          help_text: %{"en" => "Help"},
+          class: "hero",
+          code: "<section>Hero</section>"
+        },
+        current_user
+      )
+
+    %{site: site, shared_module: shared_module}
+  end
+
+  test "superusers manage access and create entries", %{
+    conn: conn,
+    site: site,
+    shared_module: shared_module
+  } do
+    {:ok, view, html} = live(conn, "/admin/config/content/shared_library")
+
+    assert html =~ "Shared content library"
+    assert html =~ "Shared hero"
+    assert has_element?(view, "#access-module")
+
+    view
+    |> form("#access-module", access: %{kind: "module", ids: [shared_module.id]})
+    |> render_submit()
+
+    assert SharedLibrary.enabled?(site, :module, shared_module.id)
+
+    view
+    |> element("#shared-module-#{shared_module.id} button[phx-click=customize]")
+    |> render_click()
+
+    assert %{source_module_id: source_id} =
+             SharedLibrary.get(:module, shared_module.id, :shared, site, @prefix)
+
+    assert source_id == shared_module.id
+    assert has_element?(view, "#shared-module-#{shared_module.id}", "Edit customization")
+
+    view
+    |> form("#create-shared-container",
+      entry: %{
+        kind: "container",
+        name: "Shared wrapper",
+        namespace: "general",
+        type: "liquid",
+        code: "<main>{{ content }}</main>"
+      }
+    )
+    |> render_submit()
+
+    assert has_element?(view, "#shared-library-container", "Shared wrapper")
+  end
+
+  test "the full module editor opens shared entries from public", %{
+    conn: conn,
+    shared_module: shared_module
+  } do
+    assert {:ok, _view, html} =
+             live(conn, "/admin/config/content/shared_library/modules/update/#{shared_module.id}")
+
+    assert html =~ "Shared module library"
+    assert html =~ "Changelog note"
+  end
+
+  test "site administrators can customize enabled entries but cannot mutate the global library", %{
+    site: site,
+    shared_module: shared_module
+  } do
+    site_admin =
+      Brando.Factory.insert(:random_user,
+        role: :editor,
+        config: %Brando.Users.UserConfig{}
+      )
+
+    assert :ok = SharedLibrary.enable(site, :module, shared_module.id)
+    assert {:ok, _assignment} = Access.grant(site_admin, site, :admin)
+    conn = log_in_user(Phoenix.ConnTest.build_conn(), site_admin)
+
+    assert {:ok, view, html} = live(conn, "/admin/config/content/shared_library")
+    assert html =~ "Site library"
+    refute has_element?(view, "#create-shared-module")
+
+    view
+    |> element("#shared-module-#{shared_module.id} button[phx-click=customize]")
+    |> render_click()
+
+    assert %{source_module_id: source_id} =
+             SharedLibrary.get(:module, shared_module.id, :shared, site, @prefix)
+
+    assert source_id == shared_module.id
+
+    render_click(view, "delete", %{"kind" => "module", "id" => shared_module.id})
+    assert SharedLibrary.get_shared(:module, shared_module.id)
+  end
+
+  test "users without site access are redirected" do
+    editor =
+      Brando.Factory.insert(:random_user,
+        role: :editor,
+        config: %Brando.Users.UserConfig{}
+      )
+
+    conn = log_in_user(Phoenix.ConnTest.build_conn(), editor)
+
+    assert {:error, {:redirect, %{to: "/admin"}}} =
+             live(conn, "/admin/config/content/shared_library")
+  end
+end

--- a/test/mix/tasks/brando/brando.install_test.exs
+++ b/test/mix/tasks/brando/brando.install_test.exs
@@ -44,6 +44,8 @@ defmodule Mix.Tasks.Brando.GenerateTest do
     assert File.exists?("lib/brando_web/villain")
     assert_file("lib/brando_web/villain/parser.ex")
     assert File.dir?("priv/repo/tenant_migrations")
+    assert_file("priv/repo/migrations/20260816002300_brando_163_add_shared_content_library.exs")
+    assert_file("priv/repo/tenant_migrations/20260816002300_add_shared_content_library.exs")
 
     assert_file("config/runtime.exs", fn file ->
       assert file =~ ~s<url: System.get_env("BRANDO_DB_URL")>


### PR DESCRIPTION
## Summary
- add opt-in shared module, container, and palette libraries in the public schema
- add origin-qualified tenant resolution, cached site allowlists, per-environment overrides, version/diff/update workflows, and safe deletion checks
- integrate shared entries with rendering, rerender cascades, block forms, selectors, and the module picker
- add superuser and site-admin library management UI, installer/upgrade/tenant migrations, and tenancy guide coverage

## Validation
- mix format --check-formatted
- mix compile --warnings-as-errors
- mix test --warnings-as-errors: 1670 passed
- mix credo --strict lib/brando/blueprint.ex lib/brando/blueprint
- mix xref graph --format cycles --label compile-connected --fail-above 1
- MIX_ENV=docs mix docs --warnings-as-errors

Depends on #2740
Closes #2685