### PR TITLE
Add versioned static-site publishing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -242,6 +242,14 @@
 
 #### Features
 
+- **Igniter-assisted tenancy setup for existing applications.** The opt-in
+  `mix brando.setup.tenancy` task configures `:single` or `:multi` mode, inserts
+  `Brando.Plug.Tenant` idempotently into recognized browser pipelines before
+  Brando content-loading plugs, and installs Brando's tenant migration support.
+  It reports unsupported router layouts and prints the ordered migration and
+  provisioning workflow without inferring application tables, touching the
+  database, or copying production data.
+
 - **Versioned static-site publishing for sites with `delivery_mode: :static`.**
   The new Publishing screen builds any named content environment on a serial
   Oban queue, records monotonic versions, progress, logs, and failed URLs, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -242,6 +242,19 @@
 
 #### Features
 
+- **Versioned static-site publishing for sites with `delivery_mode: :static`.**
+  The new Publishing screen builds any named content environment on a serial
+  Oban queue, records monotonic versions, progress, logs, and failed URLs, and
+  provides expiring previews. Successful artifacts persist outside OTP
+  releases and can be deployed or rolled back through rsync or S3, with
+  optional automatic deployment, webhooks, and retention pruning. The
+  interactive `mix brando.ssg` task now calls the same tenant-safe renderer and
+  retains a non-tenant dry-run/non-interactive workflow.
+
+  This lifecycle is intentionally separate from Florist: Florist deploys and
+  rolls back the running Phoenix release; Brando republishes static artifacts.
+  See `guides/tenancy_and_environments.md` and `guides/deployment.md`.
+
 - **A video form field can declare playback defaults for new videos.**
 
       input :video, :video,

--- a/guides/deployment.md
+++ b/guides/deployment.md
@@ -5,6 +5,11 @@ a zero-downtime deployment tool for Elixir applications. Florist handles the ful
 lifecycle: building Docker releases, uploading to servers, managing systemd services,
 configuring web servers, database operations, and blue/green deployments.
 
+This guide's `deploy` and `rollback` commands refer to the running Phoenix/OTP
+application. A site whose `delivery_mode` is `:static` also has an independent
+artifact lifecycle in Brando's **Publishing** screen: SSG build, preview, static
+deploy, and static rollback. Rolling back one does not roll back the other.
+
 ## Prerequisites
 
 - **Florist** installed locally (`mix escript.install github brandocms/florist`)
@@ -280,6 +285,14 @@ florist prod db:migrate
 ```
 
 ## Rollback
+
+> #### Application rollback versus static-site rollback {: .info}
+>
+> `florist prod rollback` switches the running OTP release (and optionally its
+> database). In `/admin/config/publishing`, **Roll back** republishes an older
+> `sites/{site_key}/ssg/builds/{version}` artifact to that site's rsync or S3
+> target. Static artifacts live outside release `priv/static`, so they survive
+> blue/green switches and Florist release pruning.
 
 ### Blue/green rollback (instant, zero-downtime)
 

--- a/guides/migrating_to_054.md
+++ b/guides/migrating_to_054.md
@@ -68,6 +68,14 @@ fallback for any Python expression it cannot convert safely.
 It does not connect to the database, generate application Blueprint migrations,
 choose identifier persistence, migrate data, or resolve production constraints.
 
+Named environments and multi-site tenancy remain opt-in. After completing this
+general source upgrade, applications choosing tenancy can run
+`mix brando.setup.tenancy --mode single --site-key my-site` or
+`mix brando.setup.tenancy --mode multi`. That separate Igniter task configures
+the deterministic application source changes without running migrations or
+copying live data; see `guides/tenancy_and_environments.md` for the ordered
+conversion workflow.
+
 The following 0.54 changelog items remain manual because their correct rewrite
 depends on application semantics:
 

--- a/guides/tenancy_and_environments.md
+++ b/guides/tenancy_and_environments.md
@@ -4,20 +4,6 @@ Brando can run in three tenancy modes. The default preserves the traditional
 single-site, `public`-schema setup; the other modes introduce named content
 environments backed by PostgreSQL schemas.
 
-> #### Implementation status {: .warning}
->
-> The tenant registry, schema lifecycle, routing context, archive/copy/rollback
-> operations, scheduling and management UI, admin environment switcher, and
-> cross-environment local-media cleanup are available. Multi-site roles,
-> strict host and admin authorization, compensated site provisioning,
-> retention-aware site deletion, per-site media, tenant-scoped caches,
-> uploadable frontend asset sets, and the existing-installation migration task
-> are also available. Multi-site installations can curate a shared module,
-> container, and palette library with per-site access and per-environment
-> overrides.
-> Before enabling tenancy for an application, you must provide tenant migrations
-> for every table the application queries as tenant content.
-
 ## Choose a mode
 
 | Mode | Storage and behavior | Intended use |

--- a/guides/tenancy_and_environments.md
+++ b/guides/tenancy_and_environments.md
@@ -71,14 +71,18 @@ assets packaged in `priv/static`. Activating an asset set therefore changes
 frontend files without changing the site's content environment or requiring a
 full application release.
 
-For `:static`, the flag records that the site belongs to the SSG delivery
-workflow. The current tenancy phases provide the field and a tenant-aware
-manual `mix brando.ssg --site SITE_KEY` command. They do **not** yet enqueue,
-version, deploy, or route traffic to static builds automatically. Those build
-records, workers, deploy targets, previews, and rollbacks belong to the
-versioned SSG phase. Until that phase or an application-owned deploy pipeline
-is configured, selecting `:static` does not stop Phoenix from serving the
-site's domains and does not itself publish a build.
+For `:static`, Brando exposes **Publishing** under the selected site's admin
+configuration. Site administrators can build the live environment or any
+working environment, schedule a build, inspect progress and failed URLs,
+preview a completed artifact, deploy it, or roll back by redeploying an older
+artifact. Builds receive monotonic versions (`v1`, `v2`, …) per site and run on
+the serial `ssg_builds` Oban queue.
+
+Setting the flag still does not move public traffic by itself. The public host
+continues to reach Phoenix until its web server or CDN is pointed at the
+configured static target. This separation makes a first static build safe to
+preview before the infrastructure cutover and keeps changing delivery mode
+independent from changing content environments.
 
 An asset set and a delivery mode answer different questions:
 
@@ -87,7 +91,9 @@ An asset set and a delivery mode answer different questions:
 - the delivery mode states whether Phoenix responses or a deployed static
   snapshot are intended to be the public site.
 
-Choose `:dynamic` unless the site already has an SSG build-and-deploy pipeline.
+Choose `:dynamic` when editors should publish directly through Phoenix. Choose
+`:static` when publication should create a reviewable, immutable artifact and
+the public site can be served by rsync- or S3-backed static infrastructure.
 Changing the field later does not move traffic or activate an asset set; treat
 that change and the corresponding infrastructure cutover as separate
 operations.
@@ -576,9 +582,71 @@ clears the active cache and immediately restores `priv/static` fallback.
 Vite manifest and critical CSS resolution follow the same active-set-first,
 release-fallback order. In multi-site mode caches are keyed by the full tenant
 prefix, so Production, Staging, and another site cannot share rendered content
-or manifests. `mix brando.ssg --site acme` copies Acme's active uploaded set and
-media root when present; without an active set it retains the existing local
-Vite build flow.
+or manifests. Every queued static build snapshots the active asset-set record
+and deployment configuration at creation time. A later asset activation or
+target edit therefore affects new builds, never an artifact already being
+reviewed or deployed.
+
+## Build and publish static sites
+
+Declare public paths in your application's web SSG module:
+
+```elixir
+defmodule MyAppWeb.SSG do
+  import Brando.SSG
+
+  urls :pages do
+    ["/", "/about", "/contact"]
+  end
+
+  urls :projects do
+    MyApp.Projects.list_projects!(%{status: :published})
+    |> Enum.map(&MyApp.Projects.Project.__absolute_url__/1)
+  end
+end
+```
+
+URL callbacks execute under the selected environment's tenant prefix. The
+renderer sends a short-lived signed context header through the normal endpoint,
+so a working environment can be built without assigning it a temporary domain.
+Responses outside the 200 range are retained in the build's failed-URL list and
+make the build fail without hiding partial logs or counts.
+
+Open `/admin/config/publishing` while a static site is selected. The deployment
+form supports:
+
+- `rsync`, with a target such as `deploy@example.com:/srv/www`;
+- `s3`, with `s3://bucket` or `s3://bucket/prefix`;
+- an optional public CDN URL and completion webhook;
+- automatic deployment after successful builds; and
+- artifact retention from 1 through 100 builds (10 by default).
+
+Generated output is persistent at
+`sites/{site_key}/ssg/builds/{version}`. Old ready, archived, and failed artifact
+directories are pruned after the retention window, while their database history
+and logs remain. Preview tokens expire after seven days and stop working as soon
+as their artifact is pruned.
+
+The command-line task uses the same renderer and remains interactive by default:
+
+```bash
+# Standalone application
+mix brando.ssg
+
+# Any environment in a multi-site application
+mix brando.ssg --site acme --environment staging
+
+# Inspect the plan without requests or filesystem writes
+mix brando.ssg --site acme --environment production --dry-run
+
+# Non-interactive build to an explicit directory
+mix brando.ssg --site acme --force --output /tmp/acme-static
+```
+
+Without an uploaded asset set, the task builds the local frontend with Vite and
+copies `priv/static`. Pass `--no-compile-assets` to reuse the current release
+files. Background builds never compile source assets on the server: they copy
+the snapshotted uploaded set or the running release's `priv/static`.
 
 The storage roots can be made explicit; otherwise they are derived alongside
 the configured media directory:
@@ -591,9 +659,11 @@ config :brando,
 ```
 
 Back up `sites/` and `site_assets/` alongside `media/`. Florist remains
-responsible for clean builds, upload transport, retention pruning, and
-blue/green shared-directory symlinks; Brando owns registration, activation,
-serving, manifest selection, and the management UI.
+responsible for clean frontend builds and blue/green shared-directory symlinks;
+Brando owns asset registration/activation and the versioned static artifact
+lifecycle. If the application overrides `config :brando, Oban`, re-declare a
+serial `ssg_builds` queue because an application-level Oban configuration
+replaces, rather than merges with, Brando's defaults.
 
 ## Migrate an existing installation
 

--- a/guides/tenancy_and_environments.md
+++ b/guides/tenancy_and_environments.md
@@ -131,8 +131,32 @@ Configuration is validated when Brando starts. An invalid mode or a missing or
 invalid single-site key stops startup with a configuration error.
 
 The installer does **not** create registry records or generate application
-content migrations. Complete the next two sections before serving requests in
-an enabled tenancy mode.
+content migrations. Complete the tenant migration and provisioning steps below
+before serving requests in an enabled tenancy mode.
+
+## Prepare an existing installation
+
+Existing applications can apply the deterministic source changes with the
+opt-in Igniter task:
+
+```bash
+# One site with named environments
+mix brando.setup.tenancy --mode single --site-key my-site
+
+# Multiple isolated sites
+mix brando.setup.tenancy --mode multi
+```
+
+The task updates `config/brando.exs`, adds `Brando.Plug.Tenant` to recognized
+`:browser` and `:browser_api` pipelines before Brando content-loading plugs,
+and installs Brando's tenant migration support under
+`priv/repo/tenant_migrations`. It is idempotent and warns when it cannot find a
+standard Phoenix router or `:browser` pipeline.
+
+Review the complete Igniter diff before applying it. The task deliberately does
+not infer application content tables, run database migrations, provision sites,
+or copy production data. Create and review the application-owned migrations in
+the next section before running the separate data conversion task.
 
 ## Tenant migrations
 
@@ -653,7 +677,13 @@ replaces, rather than merges with, Brando's defaults.
 
 ## Migrate an existing installation
 
-After writing and applying tenant migrations, copy an existing public-schema
+First prepare the application's source and review the Igniter diff:
+
+```bash
+mix brando.setup.tenancy --mode single --site-key my-site
+```
+
+After writing and applying tenant migrations, copy the existing public-schema
 site with:
 
 ```bash
@@ -711,10 +741,11 @@ create  copy  set_live  rollback  delete
 Before enabling `:single` or `:multi`:
 
 1. Keep a restorable external database backup.
-2. Apply public migrations.
-3. Provide tenant migrations for every tenant content table.
-4. Provision the site or run `mix brando.migrate_to_tenant` for existing data.
-5. Add `Brando.Plug.Tenant` before content-loading plugs in existing routers.
+2. Run `mix brando.setup.tenancy` for an existing application and review its
+   source diff.
+3. Apply public migrations.
+4. Provide tenant migrations for every tenant content table.
+5. Provision the site or run `mix brando.migrate_to_tenant` for existing data.
 6. Verify `pg_dump` and `psql` availability from the release environment.
 7. Run tenant migrations for every environment.
 8. Exercise copy and recovery on representative production-sized data.

--- a/lib/brando/assets/site_assets.ex
+++ b/lib/brando/assets/site_assets.ex
@@ -174,13 +174,13 @@ defmodule Brando.Assets.SiteAssets do
     end
   end
 
-  @doc false
+  @doc "Returns the configured standalone asset-set storage root."
   def standalone_root do
     Brando.config(:site_assets_path) ||
       Brando.config(:media_path) |> Path.expand() |> Path.dirname() |> Path.join("site_assets")
   end
 
-  @doc false
+  @doc "Returns the asset-set storage root for a standalone or site scope."
   def sets_root(nil), do: Path.join(standalone_root(), "sets")
   def sets_root(%Site{} = site), do: Path.join(Storage.assets_root(site), "sets")
 
@@ -225,32 +225,34 @@ defmodule Brando.Assets.SiteAssets do
   defp scan_directory(root, directory, files, size) do
     case File.ls(directory) do
       {:ok, entries} ->
-        Enum.reduce_while(entries, {:ok, files, size}, fn entry, {:ok, acc_files, acc_size} ->
-          path = Path.join(directory, entry)
-
-          case File.lstat(path) do
-            {:ok, %{type: :directory}} ->
-              case scan_directory(root, path, acc_files, acc_size) do
-                {:ok, nested_files, nested_size} -> {:cont, {:ok, nested_files, nested_size}}
-                {:error, reason} -> {:halt, {:error, reason}}
-              end
-
-            {:ok, %{type: :regular, size: file_size}} ->
-              relative_path = Path.relative_to(path, root)
-              {:cont, {:ok, MapSet.put(acc_files, relative_path), acc_size + file_size}}
-
-            {:ok, _symlink_or_special} ->
-              {:halt, {:error, {:unsupported_asset_file, path}}}
-
-            {:error, reason} ->
-              {:halt, {:error, {:asset_file_stat_failed, path, reason}}}
-          end
-        end)
+        Enum.reduce_while(entries, {:ok, files, size}, &scan_entry(root, directory, &1, &2))
 
       {:error, reason} ->
         {:error, {:asset_directory_scan_failed, directory, reason}}
     end
   end
+
+  defp scan_entry(root, directory, entry, {:ok, files, size}) do
+    path = Path.join(directory, entry)
+
+    case File.lstat(path) do
+      {:ok, %{type: :directory}} ->
+        continue_scan(scan_directory(root, path, files, size))
+
+      {:ok, %{type: :regular, size: file_size}} ->
+        relative_path = Path.relative_to(path, root)
+        {:cont, {:ok, MapSet.put(files, relative_path), size + file_size}}
+
+      {:ok, _symlink_or_special} ->
+        {:halt, {:error, {:unsupported_asset_file, path}}}
+
+      {:error, reason} ->
+        {:halt, {:error, {:asset_file_stat_failed, path, reason}}}
+    end
+  end
+
+  defp continue_scan({:ok, files, size}), do: {:cont, {:ok, files, size}}
+  defp continue_scan({:error, reason}), do: {:halt, {:error, reason}}
 
   defp build_cache(%SiteAssetSet{} = asset_set) do
     with {:ok, files, _size} <- scan_files(asset_set.path),
@@ -317,15 +319,11 @@ defmodule Brando.Assets.SiteAssets do
   defp current_scope do
     case Tenant.mode() do
       :multi ->
-        case Tenant.current_site_key() do
-          nil ->
-            :error
-
-          site_key ->
-            case Brando.Tenant.Cache.get_site(site_key) do
-              nil -> :error
-              site -> {:ok, site}
-            end
+        with site_key when is_binary(site_key) <- Tenant.current_site_key(),
+             site when not is_nil(site) <- Brando.Tenant.Cache.get_site(site_key) do
+          {:ok, site}
+        else
+          _missing_context -> :error
         end
 
       _standalone ->

--- a/lib/brando/cache/palettes.ex
+++ b/lib/brando/cache/palettes.ex
@@ -2,8 +2,8 @@ defmodule Brando.Cache.Palettes do
   @moduledoc """
   Interaction with palettes cache
   """
-  alias Brando.Content
   alias Brando.Cache
+  alias Brando.Content
 
   @type changeset :: Ecto.Changeset.t()
 
@@ -41,9 +41,8 @@ defmodule Brando.Cache.Palettes do
     {:ok, palettes} = get_palettes()
     palettes_css = get_palettes_css(palettes)
 
-    with {:ok, true} <- Cache.put(:palettes, palettes, :infinite),
-         {:ok, true} <- Cache.put(:palettes_css, palettes_css, :infinite) do
-      {:ok, true}
+    with {:ok, true} <- Cache.put(:palettes, palettes, :infinite) do
+      Cache.put(:palettes_css, palettes_css, :infinite)
     end
   end
 

--- a/lib/brando/content/shared_library.ex
+++ b/lib/brando/content/shared_library.ex
@@ -9,9 +9,9 @@ defmodule Brando.Content.SharedLibrary do
 
   import Ecto.Query, only: [from: 2]
 
-  alias Brando.Content.Container
   alias Brando.Content.Block
   alias Brando.Content.Blocks
+  alias Brando.Content.Container
   alias Brando.Content.Module
   alias Brando.Content.Palette
   alias Brando.Content.SharedLibrary.Cache
@@ -209,17 +209,7 @@ defmodule Brando.Content.SharedLibrary do
 
     with override when not is_nil(override) <- get_override(kind, id, prefix),
          shared when not is_nil(shared) <- get_public(kind, id) do
-      case Repo.transaction(fn ->
-             with {:ok, _deleted} <- Repo.delete(override, prefix: prefix),
-                  {:ok, replacement} <- create_override(kind, shared, prefix, user) do
-               replacement
-             else
-               {:error, reason} -> Repo.rollback(reason)
-             end
-           end) do
-        {:ok, replacement} -> {:ok, replacement}
-        {:error, reason} -> {:error, reason}
-      end
+      replace_override(kind, override, shared, prefix, user)
     else
       nil -> {:error, :not_found}
     end
@@ -258,21 +248,23 @@ defmodule Brando.Content.SharedLibrary do
     definition = definition(kind)
     schema = definition.schema
 
-    with shared when not is_nil(shared) <- get_public(kind, normalize_id!(id)) do
-      attrs =
-        attrs
-        |> Map.put(version_key(attrs), (shared.version || 1) + 1)
-        |> Map.delete(opposite_version_key(attrs))
+    case get_public(kind, normalize_id!(id)) do
+      nil ->
+        {:error, :not_found}
 
-      result =
-        shared
-        |> schema.changeset(attrs, user)
-        |> Changeset.validate_required([:version_note])
-        |> Repo.update(@public_opts)
+      shared ->
+        attrs =
+          attrs
+          |> Map.put(version_key(attrs), (shared.version || 1) + 1)
+          |> Map.delete(opposite_version_key(attrs))
 
-      after_shared_update(result, kind)
-    else
-      nil -> {:error, :not_found}
+        result =
+          shared
+          |> schema.changeset(attrs, user)
+          |> Changeset.validate_required([:version_note])
+          |> Repo.update(@public_opts)
+
+        after_shared_update(result, kind)
     end
   end
 
@@ -281,29 +273,7 @@ defmodule Brando.Content.SharedLibrary do
     id = normalize_id!(id)
 
     Registry.list_sites()
-    |> Enum.map(fn site ->
-      {overridden, referenced} =
-        Enum.reduce(site.environments, {[], []}, fn environment, {overridden_acc, referenced_acc} ->
-          prefix = Tenant.prefix(site, environment)
-
-          overridden_acc =
-            if get_override(kind, id, prefix), do: [environment.key | overridden_acc], else: overridden_acc
-
-          referenced_acc =
-            if shared_reference_exists?(kind, id, prefix),
-              do: [environment.key | referenced_acc],
-              else: referenced_acc
-
-          {overridden_acc, referenced_acc}
-        end)
-
-      %{
-        site: site,
-        enabled: enabled?(site, kind, id),
-        overridden_environments: Enum.reverse(overridden),
-        referenced_environments: Enum.reverse(referenced)
-      }
-    end)
+    |> Enum.map(&usage_for_site(&1, kind, id))
     |> Enum.reject(&(!&1.enabled and &1.overridden_environments == [] and &1.referenced_environments == []))
   end
 
@@ -484,18 +454,54 @@ defmodule Brando.Content.SharedLibrary do
   end
 
   defp rerender_shared(kind, id) do
-    Enum.each(Registry.list_sites(), fn site ->
-      Enum.each(site.environments, fn environment ->
-        prefix = Tenant.prefix(site, environment)
+    Enum.each(Registry.list_sites(), &rerender_site(&1, kind, id))
+  end
 
-        Tenant.with_prefix(prefix, fn ->
-          case kind do
-            :module -> Blocks.render_entries_with_module_id(id, :shared)
-            :container -> Blocks.render_entries_with_container_id(id, :shared)
-            :palette -> Blocks.render_entries_with_palette_id(id, :shared)
-          end
-        end)
-      end)
+  defp rerender_site(site, kind, id) do
+    Enum.each(site.environments, &rerender_environment(site, &1, kind, id))
+  end
+
+  defp rerender_environment(site, environment, kind, id) do
+    prefix = Tenant.prefix(site, environment)
+    Tenant.with_prefix(prefix, fn -> rerender_kind(kind, id) end)
+  end
+
+  defp rerender_kind(:module, id), do: Blocks.render_entries_with_module_id(id, :shared)
+  defp rerender_kind(:container, id), do: Blocks.render_entries_with_container_id(id, :shared)
+  defp rerender_kind(:palette, id), do: Blocks.render_entries_with_palette_id(id, :shared)
+
+  defp usage_for_site(site, kind, id) do
+    {overridden, referenced} =
+      Enum.reduce(site.environments, {[], []}, &collect_environment_usage(&1, &2, site, kind, id))
+
+    %{
+      site: site,
+      enabled: enabled?(site, kind, id),
+      overridden_environments: Enum.reverse(overridden),
+      referenced_environments: Enum.reverse(referenced)
+    }
+  end
+
+  defp collect_environment_usage(environment, {overridden, referenced}, site, kind, id) do
+    prefix = Tenant.prefix(site, environment)
+
+    {
+      prepend_if(overridden, environment.key, get_override(kind, id, prefix)),
+      prepend_if(referenced, environment.key, shared_reference_exists?(kind, id, prefix))
+    }
+  end
+
+  defp prepend_if(values, value, present) when present not in [false, nil], do: [value | values]
+  defp prepend_if(values, _value, _missing), do: values
+
+  defp replace_override(kind, override, shared, prefix, user) do
+    Repo.transaction(fn ->
+      with {:ok, _deleted} <- Repo.delete(override, prefix: prefix),
+           {:ok, replacement} <- create_override(kind, shared, prefix, user) do
+        replacement
+      else
+        {:error, reason} -> Repo.rollback(reason)
+      end
     end)
   end
 

--- a/lib/brando/environments.ex
+++ b/lib/brando/environments.ex
@@ -52,10 +52,9 @@ defmodule Brando.Environments do
   @doc "Runs tenant migrations on one environment schema."
   @spec migrate(Environment.t()) :: {:ok, [integer()]} | {:error, term()}
   def migrate(%Environment{} = environment) do
-    with %Site{} = site <- Registry.get_site(environment.site_id) do
-      migrator().migrate(site, environment)
-    else
+    case Registry.get_site(environment.site_id) do
       nil -> {:error, :site_not_found}
+      %Site{} = site -> migrator().migrate(site, environment)
     end
   end
 
@@ -83,18 +82,10 @@ defmodule Brando.Environments do
   def delete_environment(environment, opts \\ [])
 
   def delete_environment(%Environment{} = environment, opts) do
-    case Registry.get_environment(environment.id) do
-      %Environment{} = current_environment ->
-        case Registry.get_site(current_environment.site_id) do
-          %Site{} = site ->
-            with_site_lock(site, fn ->
-              delete_under_lock(site, current_environment.id, opts)
-            end)
-
-          nil ->
-            {:error, :site_or_environment_not_found}
-        end
-
+    with %Environment{} = current_environment <- Registry.get_environment(environment.id),
+         %Site{} = site <- Registry.get_site(current_environment.site_id) do
+      with_site_lock(site, fn -> delete_under_lock(site, current_environment.id, opts) end)
+    else
       nil ->
         {:error, :site_or_environment_not_found}
     end
@@ -110,23 +101,27 @@ defmodule Brando.Environments do
         {:ok, current_environment}
 
       %Environment{} = current_environment ->
-        site = Registry.get_site(current_environment.site_id)
-
-        case with_site_lock(site, fn ->
-               set_current_environment_live(site, current_environment, opts)
-             end) do
-          {:ok, _live_environment} = result ->
-            Cache.invalidate()
-            result
-
-          {:error, _reason} = error ->
-            error
-        end
+        current_environment.site_id
+        |> Registry.get_site()
+        |> set_live_for_site(current_environment, opts)
 
       nil ->
         {:error, :environment_not_found}
     end
   end
+
+  defp set_live_for_site(%Site{} = site, environment, opts) do
+    case with_site_lock(site, fn -> set_current_environment_live(site, environment, opts) end) do
+      {:ok, _live_environment} = result ->
+        Cache.invalidate()
+        result
+
+      {:error, _reason} = error ->
+        error
+    end
+  end
+
+  defp set_live_for_site(nil, _environment, _opts), do: {:error, :site_not_found}
 
   @doc """
   Archives the target schema, replaces it with a complete copy of the source,

--- a/lib/brando/environments/schema_cloner/postgres.ex
+++ b/lib/brando/environments/schema_cloner/postgres.ex
@@ -18,48 +18,45 @@ defmodule Brando.Environments.SchemaCloner.Postgres do
     with :ok <- validate_identifier(source_prefix),
          :ok <- validate_identifier(target_prefix),
          {:ok, dump} <- dump_schema(source_prefix),
-         {:ok, rewritten_dump} <- rewrite_schema(dump, source_prefix, target_prefix),
-         :ok <- restore_dump(rewritten_dump) do
-      :ok
+         {:ok, rewritten_dump} <- rewrite_schema(dump, source_prefix, target_prefix) do
+      restore_dump(rewritten_dump)
     end
   end
 
-  @doc false
+  @doc "Rewrites quoted schema identifiers in a plain PostgreSQL dump."
   def rewrite_schema(dump, source_prefix, target_prefix) do
     source_identifier = ~s|"#{source_prefix}"|
 
     if String.contains?(dump, source_identifier) do
       target_identifier = ~s|"#{target_prefix}"|
-
-      rewritten_dump =
-        dump
-        |> String.split("\n")
-        |> Enum.map_reduce(:sql, fn
-          "\\." = line, :copy_data ->
-            {line, :sql}
-
-          line, :copy_data ->
-            {line, :copy_data}
-
-          line, :sql ->
-            rewritten_line = String.replace(line, source_identifier, target_identifier)
-            next_state = if copy_from_stdin?(line), do: :copy_data, else: :sql
-            {rewritten_line, next_state}
-        end)
-        |> elem(0)
-        |> Enum.join("\n")
-
-      {:ok, rewritten_dump}
+      {:ok, rewrite_dump(dump, source_identifier, target_identifier)}
     else
       {:error, {:source_schema_not_found_in_dump, source_prefix}}
     end
+  end
+
+  defp rewrite_dump(dump, source_identifier, target_identifier) do
+    dump
+    |> String.split("\n")
+    |> Enum.map_reduce(:sql, &rewrite_dump_line(&1, &2, source_identifier, target_identifier))
+    |> elem(0)
+    |> Enum.join("\n")
+  end
+
+  defp rewrite_dump_line("\\." = line, :copy_data, _source, _target), do: {line, :sql}
+  defp rewrite_dump_line(line, :copy_data, _source, _target), do: {line, :copy_data}
+
+  defp rewrite_dump_line(line, :sql, source_identifier, target_identifier) do
+    rewritten_line = String.replace(line, source_identifier, target_identifier)
+    next_state = if copy_from_stdin?(line), do: :copy_data, else: :sql
+    {rewritten_line, next_state}
   end
 
   defp copy_from_stdin?(line) do
     String.starts_with?(line, "COPY ") and String.ends_with?(line, " FROM stdin;")
   end
 
-  @doc false
+  @doc "Dumps one PostgreSQL schema as quoted, restorable plain SQL."
   def dump_schema(prefix, extra_args \\ []) do
     with :ok <- validate_identifier(prefix),
          {:ok, executable} <- executable(:pg_dump_path, "pg_dump"),
@@ -89,7 +86,7 @@ defmodule Brando.Environments.SchemaCloner.Postgres do
     end
   end
 
-  @doc false
+  @doc "Restores a plain SQL dump with PostgreSQL's stop-on-error mode enabled."
   def restore_dump(sql) do
     with {:ok, executable} <- executable(:psql_path, "psql"),
          {:ok, path} <- write_temporary_dump(sql) do

--- a/lib/brando/media/orphan_cleanup.ex
+++ b/lib/brando/media/orphan_cleanup.ex
@@ -83,15 +83,17 @@ defmodule Brando.Media.OrphanCleanup do
         {:error, :no_environments}
 
       environments ->
-        Enum.reduce_while(environments, {:ok, MapSet.new()}, fn environment, {:ok, paths} ->
-          case environment_paths(site, environment) do
-            {:ok, environment_paths} ->
-              {:cont, {:ok, MapSet.union(paths, environment_paths)}}
+        Enum.reduce_while(environments, {:ok, MapSet.new()}, &collect_environment_paths(&1, &2, site))
+    end
+  end
 
-            {:error, reason} ->
-              {:halt, {:error, {:environment_scan_failed, environment.key, reason}}}
-          end
-        end)
+  defp collect_environment_paths(environment, {:ok, paths}, site) do
+    case environment_paths(site, environment) do
+      {:ok, environment_paths} ->
+        {:cont, {:ok, MapSet.union(paths, environment_paths)}}
+
+      {:error, reason} ->
+        {:halt, {:error, {:environment_scan_failed, environment.key, reason}}}
     end
   end
 
@@ -165,26 +167,7 @@ defmodule Brando.Media.OrphanCleanup do
   defp regular_files(directory) do
     case File.ls(directory) do
       {:ok, entries} ->
-        Enum.reduce_while(entries, {:ok, []}, fn entry, {:ok, files} ->
-          path = Path.join(directory, entry)
-
-          case File.lstat(path) do
-            {:ok, %{type: :regular}} ->
-              {:cont, {:ok, [path | files]}}
-
-            {:ok, %{type: :directory}} ->
-              case regular_files(path) do
-                {:ok, nested} -> {:cont, {:ok, nested ++ files}}
-                {:error, reason} -> {:halt, {:error, reason}}
-              end
-
-            {:ok, _symlink_or_special} ->
-              {:cont, {:ok, files}}
-
-            {:error, reason} ->
-              {:halt, {:error, {path, reason}}}
-          end
-        end)
+        Enum.reduce_while(entries, {:ok, []}, &collect_regular_file(&1, &2, directory))
 
       {:error, :enoent} ->
         {:ok, []}
@@ -193,6 +176,20 @@ defmodule Brando.Media.OrphanCleanup do
         {:error, reason}
     end
   end
+
+  defp collect_regular_file(entry, {:ok, files}, directory) do
+    path = Path.join(directory, entry)
+
+    case File.lstat(path) do
+      {:ok, %{type: :regular}} -> {:cont, {:ok, [path | files]}}
+      {:ok, %{type: :directory}} -> continue_file_scan(regular_files(path), files)
+      {:ok, _symlink_or_special} -> {:cont, {:ok, files}}
+      {:error, reason} -> {:halt, {:error, {path, reason}}}
+    end
+  end
+
+  defp continue_file_scan({:ok, nested}, files), do: {:cont, {:ok, nested ++ files}}
+  defp continue_file_scan({:error, reason}, _files), do: {:halt, {:error, reason}}
 
   defp orphan_paths(candidates, root, references, grace_seconds) do
     candidates
@@ -203,9 +200,8 @@ defmodule Brando.Media.OrphanCleanup do
   end
 
   defp old_enough?(path, grace_seconds) do
-    with {:ok, %{mtime: modified_at}} <- File.stat(path, time: :posix) do
-      System.os_time(:second) - modified_at >= grace_seconds
-    else
+    case File.stat(path, time: :posix) do
+      {:ok, %{mtime: modified_at}} -> System.os_time(:second) - modified_at >= grace_seconds
       _ -> false
     end
   end

--- a/lib/brando/plug/tenant.ex
+++ b/lib/brando/plug/tenant.ex
@@ -11,6 +11,7 @@ defmodule Brando.Plug.Tenant do
 
   import Plug.Conn, only: [assign: 3, halt: 1, send_resp: 3]
 
+  alias Brando.SSG.Context
   alias Brando.Tenant
   alias Brando.Tenant.Frontend
 
@@ -21,7 +22,7 @@ defmodule Brando.Plug.Tenant do
 
   @impl Plug
   def call(conn, _opts) do
-    case Frontend.resolve(conn.host) do
+    case resolve(conn) do
       {site, environment} ->
         prefix = Tenant.prefix(site, environment)
         Tenant.put_prefix(prefix)
@@ -35,6 +36,14 @@ defmodule Brando.Plug.Tenant do
         Tenant.put_prefix(nil)
         reject_missing_multi_site(conn)
     end
+  end
+
+  defp resolve(conn) do
+    conn
+    |> Plug.Conn.get_req_header(Context.header())
+    |> List.first()
+    |> Context.resolve()
+    |> Kernel.||(Frontend.resolve(conn.host))
   end
 
   defp reject_missing_multi_site(conn) do

--- a/lib/brando/plugs/ssg.ex
+++ b/lib/brando/plugs/ssg.ex
@@ -1,43 +1,16 @@
 defmodule Brando.Plug.SSG do
-  @moduledoc false
-  def init(_) do
-    Application.get_env(:brando, :ssg_run, :normal)
-  end
+  @moduledoc """
+  Backwards-compatible no-op.
 
-  def call(conn, :html) do
-    {:ok, ssg_urls} = Brando.SSG.get_urls()
+  Static output is now captured by `Brando.SSG.build/3` after ordinary HTTP
+  responses, so applications may remove this plug from their browser pipeline.
+  """
 
-    Plug.Conn.register_before_send(conn, fn conn ->
-      cond do
-        conn.request_path in ssg_urls and conn.status == 200 -> write_file(conn)
-        conn.request_path in ssg_urls -> write_failed(conn)
-        true -> conn
-      end
-    end)
-  end
+  @behaviour Plug
 
-  def call(conn, :normal), do: conn
+  @impl Plug
+  def init(opts), do: opts
 
-  # no need to process further if it's an ssg run and not :html
-  def call(conn, _) do
-    conn
-    |> Plug.Conn.halt()
-    |> Plug.Conn.send_resp(200, "")
-  end
-
-  defp write_file(conn) do
-    root_path = Brando.SSG.get_root_path()
-    render_path = Path.join([root_path, conn.request_path])
-    render_file = Path.join([render_path, "index.html"])
-    File.mkdir_p!(render_path)
-    formatted_body = Phoenix.LiveView.HTMLFormatter.format(to_string(conn.resp_body), [])
-    File.write!(render_file, formatted_body)
-    Mix.shell().info([:green, "* ok 200 writing `#{conn.request_path}` -> `#{render_file}"])
-    conn
-  end
-
-  defp write_failed(conn) do
-    Mix.shell().info([:red, "* failed #{conn.status} `#{conn.request_path}`"])
-    conn
-  end
+  @impl Plug
+  def call(conn, _opts), do: conn
 end

--- a/lib/brando/router.ex
+++ b/lib/brando/router.ex
@@ -18,6 +18,7 @@ defmodule Brando.Router do
       if unquote(options)[:root] do
         get "/robots.txt", Brando.SEOController, :robots
         get "/__p__/:preview_key", Brando.PreviewController, :show
+        get "/__ssg_preview__/:token/*path", Brando.SSG.PreviewController, :show
         get "/sitemaps/:file", Brando.SitemapController, :show
       end
 
@@ -115,6 +116,7 @@ defmodule Brando.Router do
           scope "/config" do
             live "/assets", BrandoAdmin.Sites.AssetLive
             live "/environments", BrandoAdmin.Sites.EnvironmentLive
+            live "/publishing", BrandoAdmin.Sites.PublishingLive
             live "/cache", BrandoAdmin.Sites.CacheLive
             live "/global_sets", BrandoAdmin.Sites.GlobalSetListLive
             live "/global_sets/create", BrandoAdmin.Sites.GlobalSetFormLive, :create

--- a/lib/brando/sites/deploy_config.ex
+++ b/lib/brando/sites/deploy_config.ex
@@ -3,9 +3,12 @@ defmodule Brando.Sites.DeployConfig do
   Deployment settings for a site using static delivery.
 
   The embed lives with the public site registry. It is deliberately inert for
-  dynamically delivered sites, but keeping one stable shape here lets the SSG
-  and deploy phases build on the tenant foundation without another registry
-  migration.
+  dynamically delivered sites. Static builds snapshot this configuration so a
+  later site edit cannot silently change how an already-built artifact deploys.
+
+  `:rsync` targets are ordinary rsync destinations such as
+  `deploy@example.com:/srv/www`; `:s3` targets use `s3://bucket/optional-prefix`.
+  Florist application releases are configured separately.
   """
 
   use Ecto.Schema
@@ -20,11 +23,50 @@ defmodule Brando.Sites.DeployConfig do
     field :strategy, Ecto.Enum, values: [:s3, :rsync, :cloudflare_pages]
     field :target, :string
     field :cdn_url, :string
+    field :webhook_url, :string
+    field :auto_deploy, :boolean, default: false
+    field :retention_count, :integer, default: 10
   end
 
-  @fields [:strategy, :target, :cdn_url]
+  @fields [:strategy, :target, :cdn_url, :webhook_url, :auto_deploy, :retention_count]
 
   def changeset(config, attrs) do
-    cast(config, attrs, @fields)
+    config
+    |> cast(attrs, @fields)
+    |> require_target_for_strategy()
+    |> validate_strategy_target()
+    |> validate_number(:retention_count, greater_than_or_equal_to: 1, less_than_or_equal_to: 100)
+    |> validate_http_url(:cdn_url)
+    |> validate_http_url(:webhook_url)
+  end
+
+  defp require_target_for_strategy(changeset) do
+    if get_field(changeset, :strategy), do: validate_required(changeset, [:target]), else: changeset
+  end
+
+  defp validate_strategy_target(changeset) do
+    case {get_field(changeset, :strategy), get_field(changeset, :target)} do
+      {:s3, target} when is_binary(target) ->
+        case URI.parse(target) do
+          %URI{scheme: "s3", host: host} when is_binary(host) and host != "" -> changeset
+          _invalid -> add_error(changeset, :target, "must use s3://bucket/optional-prefix")
+        end
+
+      _other ->
+        changeset
+    end
+  end
+
+  defp validate_http_url(changeset, field) do
+    validate_change(changeset, field, fn ^field, value -> http_url_errors(field, value) end)
+  end
+
+  defp http_url_errors(_field, value) when value in [nil, ""], do: []
+
+  defp http_url_errors(field, value) do
+    case URI.parse(value) do
+      %URI{scheme: scheme, host: host} when scheme in ["http", "https"] and is_binary(host) -> []
+      _invalid -> [{field, "must be an HTTP or HTTPS URL"}]
+    end
   end
 end

--- a/lib/brando/ssg.ex
+++ b/lib/brando/ssg.ex
@@ -1,18 +1,26 @@
 defmodule Brando.SSG do
-  @moduledoc false
+  @moduledoc """
+  Static-site generation primitives and callable build API.
+
+  Applications declare URLs in their web `SSG` module with `urls/2`. Brando's
+  publish lifecycle calls `build/3` for a particular site and named content
+  environment; `mix brando.ssg` remains available as an interactive wrapper.
+  """
+
+  alias Brando.Assets.SiteAssetSet
+  alias Brando.Environments.Environment
+  alias Brando.Sites.Site
+  alias Brando.SSG.Context
+  alias Brando.Tenant
+  alias Brando.Tenant.Storage
+
+  @default_base_url "http://localhost:4000"
+  @default_receive_timeout 60_000
+
   @doc """
-  Static site generation
+  Declares a group of paths in the application's web SSG module.
 
-  - In your `router.ex` add the SSG plug to your `:browser` pipeline:
-
-  ```
-      pipeline :browser do
-        # ...
-        plug Brando.Plug.SSG
-      end
-  ```
-
-  - Create `lib/my_app_web/ssg.ex`:
+  Create `lib/my_app_web/ssg.ex`:
 
   ```
       defmodule MyAppWeb.SSG do
@@ -30,14 +38,7 @@ defmodule Brando.SSG do
       end
   ```
 
-  Run `mix brando.ssg`
-
-  Then create an rsync script: `code sync.sh`
-
-  ```
-  #!/bin/sh
-  rsync -arvzi -e 'ssh -p 30000' --progress ssg/ my_user@my_server:/sites/prod/my_app/ --delete
-  ```
+  The functions run inside the selected environment's tenant prefix.
   """
   defmacro urls(key, do: block) do
     quote do
@@ -59,8 +60,9 @@ defmodule Brando.SSG do
     {:__render_path__, 0} in module.__info__(:functions)
   end
 
-  def get_root_path do
-    ssg_module = Brando.web_module(SSG)
+  @doc "Returns the legacy standalone output directory."
+  def get_root_path(module \\ Brando.web_module(SSG)) do
+    ssg_module = module
 
     case Code.ensure_compiled(ssg_module) do
       {:module, _} ->
@@ -75,15 +77,18 @@ defmodule Brando.SSG do
     end
   end
 
-  def get_urls do
-    ssg_module = Brando.web_module(SSG)
+  @doc "Evaluates all declared URL groups in a database transaction."
+  def get_urls(module \\ Brando.web_module(SSG)) do
+    ssg_module = module
 
     case Code.ensure_compiled(ssg_module) do
       {:module, _} ->
         ssg_functions =
           :functions
           |> ssg_module.__info__()
-          |> Enum.reject(&(&1 == {:__render_path__, 0}))
+          |> Enum.filter(fn {name, arity} ->
+            arity == 0 and String.starts_with?(Atom.to_string(name), "__urls_for_")
+          end)
 
         entries = Stream.flat_map(ssg_functions, &apply(ssg_module, elem(&1, 0), []))
 
@@ -92,5 +97,320 @@ defmodule Brando.SSG do
       {:error, _} ->
         raise "Missing SSG module `#{ssg_module}`"
     end
+  end
+
+  @doc """
+  Builds a static snapshot for one site and environment.
+
+  Output is written to `:output_path`. Assets come from the build's selected
+  `Brando.Assets.SiteAssetSet`, falling back to the release's `priv/static`.
+  Requests carry a short-lived signed SSG header so environments without a
+  domain can be rendered through the normal endpoint and tenant plug.
+
+  The injectable `:fetcher` option has arity two (`url`, request options) and
+  is intended for tests or custom transports.
+  """
+  @spec build(keyword()) :: {:ok, map()} | {:error, term(), map()}
+  def build(opts) when is_list(opts) do
+    site = %Site{id: nil, key: "standalone", delivery_mode: :static}
+    environment = %Environment{id: nil, site_id: nil, key: "live", live: true}
+    build(site, environment, opts)
+  end
+
+  @spec build(Site.t(), Environment.t(), keyword()) :: {:ok, map()} | {:error, term(), map()}
+  def build(%Site{id: site_id} = site, %Environment{site_id: site_id} = environment, opts) do
+    output_path = Keyword.fetch!(opts, :output_path)
+    dry_run? = Keyword.get(opts, :dry_run, false)
+    progress = Keyword.get(opts, :progress, fn _event -> :ok end)
+
+    Tenant.with_prefix(Tenant.prefix(site, environment), fn ->
+      build_under_tenant(site, environment, output_path, opts, dry_run?, progress)
+    end)
+  end
+
+  def build(%Site{}, %Environment{}, opts),
+    do: {:error, :environment_belongs_to_another_site, empty_result(opts[:output_path], false)}
+
+  defp build_under_tenant(site, environment, output_path, opts, dry_run?, progress) do
+    with {:ok, urls} <- get_urls(Keyword.get(opts, :ssg_module, Brando.web_module(SSG))),
+         {:ok, normalized_urls} <- normalize_urls(urls),
+         :ok <- prepare_output(output_path, dry_run?),
+         :ok <- copy_assets(site, output_path, opts, dry_run?),
+         {:ok, render_result} <-
+           render_urls(site, environment, normalized_urls, output_path, opts, dry_run?, progress),
+         :ok <- copy_media(site, output_path, opts, dry_run?),
+         {:ok, stats} <- output_stats(output_path, dry_run?) do
+      result =
+        render_result
+        |> Map.merge(stats)
+        |> Map.put(:output_path, output_path)
+        |> Map.put(:dry_run, dry_run?)
+
+      if result.failed_urls == [], do: {:ok, result}, else: {:error, :url_failures, result}
+    else
+      {:error, reason, result} -> {:error, reason, result}
+      {:error, reason} -> {:error, reason, empty_result(output_path, dry_run?)}
+    end
+  end
+
+  defp normalize_urls(urls) when is_list(urls) do
+    urls
+    |> Enum.reduce_while({:ok, []}, fn url, {:ok, normalized} ->
+      case normalize_url(url) do
+        {:ok, path} -> {:cont, {:ok, [path | normalized]}}
+        {:error, reason} -> {:halt, {:error, reason}}
+      end
+    end)
+    |> case do
+      {:ok, paths} -> {:ok, paths |> Enum.reverse() |> Enum.uniq()}
+      error -> error
+    end
+  end
+
+  defp normalize_urls(_urls), do: {:error, :invalid_url_list}
+
+  defp normalize_url(url) when is_binary(url) do
+    uri = URI.parse(url)
+    path = if uri.scheme, do: uri.path, else: String.split(url, "?", parts: 2) |> hd()
+    path = if path in [nil, ""], do: "/", else: path
+    decoded = URI.decode(path)
+    segments = String.split(decoded, "/", trim: true)
+
+    if Enum.any?(segments, &(&1 in [".", ".."] or String.contains?(&1, ["\\", <<0>>]))) do
+      {:error, {:unsafe_url_path, url}}
+    else
+      {:ok, "/" <> Enum.join(segments, "/")}
+    end
+  rescue
+    _invalid_encoding -> {:error, {:invalid_url, url}}
+  end
+
+  defp normalize_url(url), do: {:error, {:invalid_url, url}}
+
+  defp prepare_output(_output_path, true), do: :ok
+
+  defp prepare_output(output_path, false) when is_binary(output_path) do
+    expanded_path = Path.expand(output_path)
+
+    if unsafe_output_root?(expanded_path) do
+      {:error, {:unsafe_output_path, expanded_path}}
+    else
+      case File.rm_rf(expanded_path) do
+        {:ok, _removed} -> File.mkdir_p(expanded_path)
+        {:error, reason, path} -> {:error, {:prepare_output_failed, path, reason}}
+      end
+    end
+  end
+
+  defp prepare_output(output_path, false), do: {:error, {:invalid_output_path, output_path}}
+
+  defp copy_assets(_site, _output_path, _opts, true), do: :ok
+
+  defp copy_assets(site, output_path, opts, false) do
+    source = asset_source(site, opts)
+
+    cond do
+      is_nil(source) -> :ok
+      File.dir?(source) -> copy_directory(source, output_path)
+      true -> {:error, {:asset_source_not_found, source}}
+    end
+  end
+
+  defp asset_source(_site, opts) do
+    case Keyword.get(opts, :asset_set) do
+      %SiteAssetSet{path: path} -> path
+      _release -> Keyword.get(opts, :static_path, Path.join([File.cwd!(), "priv", "static"]))
+    end
+  end
+
+  defp render_urls(site, environment, urls, output_path, opts, dry_run?, progress) do
+    token = if Tenant.enabled?(), do: Context.sign(site, environment)
+    total = length(urls)
+
+    urls
+    |> Enum.with_index(1)
+    |> Enum.reduce({[], 0}, fn {url, index}, {failures, processed} ->
+      progress.({:rendering, index, total, url})
+
+      case render_url(url, token, output_path, opts, dry_run?) do
+        :ok -> {failures, processed + 1}
+        {:error, reason} -> {[format_failure(url, reason) | failures], processed + 1}
+      end
+    end)
+    |> then(fn {failures, processed} ->
+      {:ok,
+       %{
+         url_count: total,
+         processed_urls: processed,
+         failed_urls: Enum.reverse(failures)
+       }}
+    end)
+  end
+
+  defp render_url(_url, _token, _output_path, _opts, true), do: :ok
+
+  defp render_url(url, token, output_path, opts, false) do
+    base_url = Keyword.get(opts, :base_url, @default_base_url)
+    request_url = URI.merge(ensure_trailing_slash(base_url), String.trim_leading(url, "/")) |> to_string()
+    fetcher = Keyword.get(opts, :fetcher, &default_fetcher/2)
+
+    headers = if token, do: [{Context.header(), token}], else: []
+
+    request_opts = [
+      headers: headers,
+      receive_timeout: Keyword.get(opts, :receive_timeout, @default_receive_timeout),
+      retry: false
+    ]
+
+    case fetcher.(request_url, request_opts) do
+      {:ok, %{status: status, body: body}} when status in 200..299 ->
+        write_response(output_path, url, body)
+
+      {:ok, %{status: status}} ->
+        {:error, {:http_status, status}}
+
+      {:error, reason} ->
+        {:error, {:request_failed, reason}}
+
+      response ->
+        {:error, {:invalid_fetcher_response, response}}
+    end
+  rescue
+    exception -> {:error, {:request_exception, Exception.message(exception)}}
+  end
+
+  defp default_fetcher(url, opts), do: Req.get(url, opts)
+
+  defp write_response(output_path, url, body) do
+    target = output_file(output_path, url)
+
+    with :ok <- File.mkdir_p(Path.dirname(target)),
+         :ok <- File.write(target, format_body(body, url)) do
+      :ok
+    else
+      {:error, reason} -> {:error, {:write_failed, target, reason}}
+    end
+  end
+
+  defp output_file(output_path, "/"), do: Path.join(output_path, "index.html")
+
+  defp output_file(output_path, url) do
+    relative = String.trim_leading(url, "/")
+
+    if Path.extname(relative) == "" do
+      Path.join([output_path, relative, "index.html"])
+    else
+      Path.join(output_path, relative)
+    end
+  end
+
+  defp format_body(body, url) do
+    body = IO.iodata_to_binary(body)
+
+    if Path.extname(url) in ["", ".html", ".htm"] do
+      try do
+        Phoenix.LiveView.HTMLFormatter.format(body, [])
+      rescue
+        _not_html -> body
+      end
+    else
+      body
+    end
+  end
+
+  defp copy_media(_site, _output_path, _opts, true), do: :ok
+
+  defp copy_media(site, output_path, opts, false) do
+    source = Keyword.get(opts, :media_path, media_source(site))
+
+    if File.dir?(source) do
+      copy_directory(source, Path.join(output_path, "media"))
+    else
+      :ok
+    end
+  end
+
+  defp media_source(site) do
+    if Tenant.mode() == :multi, do: Storage.media_root(site), else: Brando.config(:media_path)
+  end
+
+  defp copy_directory(source, destination) do
+    with :ok <- validate_copy_source(source),
+         :ok <- File.mkdir_p(Path.dirname(destination)),
+         {:ok, _files} <- File.cp_r(source, destination) do
+      :ok
+    else
+      {:error, {:unsupported_source_file, _path}} = error -> error
+      {:error, {:source_file_stat_failed, _path, _reason}} = error -> error
+      {:error, {:source_directory_read_failed, _path, _reason}} = error -> error
+      {:error, reason, path} -> {:error, {:copy_failed, path, reason}}
+      {:error, reason} -> {:error, {:copy_failed, source, reason}}
+    end
+  end
+
+  defp validate_copy_source(directory) do
+    case File.ls(directory) do
+      {:ok, entries} -> validate_copy_entries(directory, entries)
+      {:error, reason} -> {:error, {:source_directory_read_failed, directory, reason}}
+    end
+  end
+
+  defp validate_copy_entries(directory, entries) do
+    Enum.reduce_while(entries, :ok, fn entry, :ok ->
+      case validate_copy_entry(Path.join(directory, entry)) do
+        :ok -> {:cont, :ok}
+        {:error, reason} -> {:halt, {:error, reason}}
+      end
+    end)
+  end
+
+  defp validate_copy_entry(path) do
+    case File.lstat(path) do
+      {:ok, %{type: :directory}} -> validate_copy_source(path)
+      {:ok, %{type: :regular}} -> :ok
+      {:ok, _symlink_or_special} -> {:error, {:unsupported_source_file, path}}
+      {:error, reason} -> {:error, {:source_file_stat_failed, path, reason}}
+    end
+  end
+
+  defp output_stats(_output_path, true), do: {:ok, %{file_count: 0, total_size: 0}}
+
+  defp output_stats(output_path, false) do
+    output_path
+    |> Path.join("**/*")
+    |> Path.wildcard(match_dot: true)
+    |> Enum.reduce_while({:ok, 0, 0}, fn path, {:ok, count, size} ->
+      case File.stat(path) do
+        {:ok, %{type: :regular, size: file_size}} -> {:cont, {:ok, count + 1, size + file_size}}
+        {:ok, _other} -> {:cont, {:ok, count, size}}
+        {:error, reason} -> {:halt, {:error, {:stat_failed, path, reason}}}
+      end
+    end)
+    |> case do
+      {:ok, count, size} -> {:ok, %{file_count: count, total_size: size}}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp ensure_trailing_slash(url), do: String.trim_trailing(url, "/") <> "/"
+
+  defp unsafe_output_root?(path) do
+    forbidden = ["/", Path.expand(File.cwd!()), System.user_home(), System.tmp_dir!()]
+    path in Enum.reject(forbidden, &is_nil/1)
+  end
+
+  defp format_failure(url, {:http_status, status}), do: "#{url} (HTTP #{status})"
+  defp format_failure(url, reason), do: "#{url} (#{inspect(reason)})"
+
+  defp empty_result(output_path, dry_run?) do
+    %{
+      output_path: output_path,
+      dry_run: dry_run?,
+      file_count: 0,
+      total_size: 0,
+      url_count: 0,
+      processed_urls: 0,
+      failed_urls: []
+    }
   end
 end

--- a/lib/brando/ssg/build.ex
+++ b/lib/brando/ssg/build.ex
@@ -1,0 +1,100 @@
+defmodule Brando.SSG.Build do
+  @moduledoc "Metadata and lifecycle state for one versioned static-site build."
+
+  use Ecto.Schema
+
+  import Ecto.Changeset
+
+  alias Brando.Assets.SiteAssetSet
+  alias Brando.Environments.Environment
+  alias Brando.Sites.Site
+  alias Brando.Users.User
+
+  @schema_prefix "public"
+  @timestamps_opts [type: :utc_datetime_usec]
+
+  @statuses [:queued, :building, :ready, :deployed, :failed, :archived]
+
+  @type t :: %__MODULE__{}
+
+  schema "ssg_builds" do
+    belongs_to :site, Site
+    belongs_to :environment, Environment
+    belongs_to :asset_set, SiteAssetSet
+    belongs_to :creator, User
+
+    field :version, :string
+    field :build_number, :integer
+    field :environment_name, :string
+    field :environment_key, :string
+    field :status, Ecto.Enum, values: @statuses, default: :queued
+    field :build_path, :string
+    field :build_log, :string, default: ""
+    field :note, :string
+    field :file_count, :integer, default: 0
+    field :total_size, :integer, default: 0
+    field :url_count, :integer, default: 0
+    field :processed_urls, :integer, default: 0
+    field :failed_urls, {:array, :string}, default: []
+    field :auto_deploy, :boolean, default: false
+    field :deploy_config, :map, default: %{}
+    field :preview_token, :string
+    field :preview_expires_at, :utc_datetime_usec
+    field :scheduled_at, :utc_datetime_usec
+    field :built_at, :utc_datetime_usec
+    field :deployed_at, :utc_datetime_usec
+    field :pruned_at, :utc_datetime_usec
+
+    timestamps()
+  end
+
+  @required_fields [
+    :site_id,
+    :version,
+    :build_number,
+    :environment_name,
+    :environment_key,
+    :status,
+    :build_path,
+    :preview_token,
+    :preview_expires_at
+  ]
+
+  @optional_fields [
+    :environment_id,
+    :asset_set_id,
+    :creator_id,
+    :build_log,
+    :note,
+    :file_count,
+    :total_size,
+    :url_count,
+    :processed_urls,
+    :failed_urls,
+    :auto_deploy,
+    :deploy_config,
+    :scheduled_at,
+    :built_at,
+    :deployed_at,
+    :pruned_at
+  ]
+
+  def changeset(build \\ %__MODULE__{}, attrs) do
+    build
+    |> cast(attrs, @required_fields ++ @optional_fields)
+    |> validate_required(@required_fields)
+    |> validate_number(:build_number, greater_than: 0)
+    |> validate_number(:file_count, greater_than_or_equal_to: 0)
+    |> validate_number(:total_size, greater_than_or_equal_to: 0)
+    |> validate_number(:url_count, greater_than_or_equal_to: 0)
+    |> validate_number(:processed_urls, greater_than_or_equal_to: 0)
+    |> foreign_key_constraint(:site_id)
+    |> foreign_key_constraint(:environment_id)
+    |> foreign_key_constraint(:asset_set_id)
+    |> foreign_key_constraint(:creator_id)
+    |> unique_constraint([:site_id, :build_number])
+    |> unique_constraint(:preview_token)
+  end
+
+  def statuses, do: @statuses
+end

--- a/lib/brando/ssg/builds.ex
+++ b/lib/brando/ssg/builds.ex
@@ -1,0 +1,236 @@
+defmodule Brando.SSG.Builds do
+  @moduledoc """
+  Public lifecycle API for versioned static-site builds.
+
+  Build metadata lives in the public schema while generated output stays in
+  persistent per-site storage. Creating a build and enqueueing its Oban job is
+  serialized per site so automatically assigned versions remain monotonic.
+  """
+
+  import Ecto.Query, only: [from: 2]
+
+  alias Brando.Assets.SiteAssets
+  alias Brando.Assets.SiteAssetSet
+  alias Brando.Environments.Environment
+  alias Brando.Repo
+  alias Brando.Sites.DeployConfig
+  alias Brando.Sites.Site
+  alias Brando.SSG.Build
+  alias Brando.Tenant
+  alias Brando.Tenant.Lock
+  alias Brando.Tenant.Storage
+  alias Brando.Worker.SSGBuild
+
+  @public_opts [prefix: "public"]
+  @preview_lifetime_days 7
+
+  @doc "Queues a versioned build for one named environment."
+  @spec request_build(Site.t(), Environment.t(), keyword()) ::
+          {:ok, Build.t()} | {:error, Ecto.Changeset.t() | term()}
+  def request_build(%Site{} = site, %Environment{} = environment, opts \\ []) do
+    asset_set = Keyword.get_lazy(opts, :asset_set, fn -> SiteAssets.active_set(asset_scope(site)) end)
+    opts = Keyword.put(opts, :asset_set, asset_set)
+
+    with :ok <- validate_build_request(site, environment, opts) do
+      Lock.with("ssg-build:#{site.id}", fn -> insert_build_and_job(site, environment, opts) end)
+    end
+  end
+
+  @doc "Lists builds newest first, optionally limited by `:limit`."
+  @spec list_builds(Site.t(), keyword()) :: [Build.t()]
+  def list_builds(%Site{id: site_id}, opts \\ []) do
+    limit = Keyword.get(opts, :limit, 50)
+
+    from(build in Build,
+      where: build.site_id == ^site_id,
+      order_by: [desc: build.build_number],
+      limit: ^limit,
+      preload: [:environment, :asset_set, :creator]
+    )
+    |> Repo.all(@public_opts)
+  end
+
+  @doc "Returns one build with its public associations preloaded."
+  @spec get_build(pos_integer()) :: Build.t() | nil
+  def get_build(id) do
+    Build
+    |> Repo.get(id, @public_opts)
+    |> preload()
+  end
+
+  @doc "Returns a previewable build by its unguessable token."
+  @spec get_preview(String.t()) :: Build.t() | nil
+  def get_preview(token) when is_binary(token) do
+    now = DateTime.utc_now()
+
+    from(build in Build,
+      where:
+        build.preview_token == ^token and build.preview_expires_at > ^now and
+          build.status in [:ready, :deployed, :archived],
+      preload: [:site, :environment]
+    )
+    |> Repo.one(@public_opts)
+  end
+
+  @doc "Records coarse URL progress for the publishing UI."
+  @spec update(Build.t(), map()) :: {:ok, Build.t()} | {:error, Ecto.Changeset.t()}
+  def update(%Build{} = build, attrs) do
+    result = build |> Build.changeset(attrs) |> Repo.update(@public_opts)
+
+    case result do
+      {:ok, updated_build} ->
+        broadcast(updated_build)
+        {:ok, updated_build}
+
+      {:error, _changeset} = error ->
+        error
+    end
+  end
+
+  @doc "Appends a timestamped line to a build log."
+  @spec append_log(Build.t(), String.t()) :: {:ok, Build.t()} | {:error, Ecto.Changeset.t()}
+  def append_log(%Build{} = build, message) when is_binary(message) do
+    timestamp = Calendar.strftime(DateTime.utc_now(), "%Y-%m-%d %H:%M:%S UTC")
+    update(build, %{build_log: build.build_log <> "[#{timestamp}] #{message}\n"})
+  end
+
+  @doc "Records coarse URL progress for the publishing UI."
+  @spec record_progress(pos_integer(), non_neg_integer(), non_neg_integer() | nil) :: :ok
+  def record_progress(build_id, processed_urls, url_count \\ nil) do
+    fields =
+      [processed_urls: processed_urls, updated_at: DateTime.utc_now()]
+      |> then(fn fields -> if is_integer(url_count), do: Keyword.put(fields, :url_count, url_count), else: fields end)
+
+    from(build in Build, where: build.id == ^build_id)
+    |> Repo.update_all([set: fields], @public_opts)
+
+    case get_build(build_id) do
+      %Build{} = build -> broadcast(build)
+      nil -> :ok
+    end
+  end
+
+  @doc "Returns the persistent root containing one site's versioned artifacts."
+  @spec build_root(Site.t()) :: String.t()
+  def build_root(%Site{} = site), do: Path.join([Storage.site_root(site), "ssg", "builds"])
+
+  @doc "Broadcasts a build transition to connected publishing screens."
+  @spec broadcast(Build.t()) :: :ok
+  def broadcast(%Build{site_id: site_id} = build) do
+    Phoenix.PubSub.broadcast(Brando.pubsub(), topic(site_id), {:ssg_build_updated, build})
+  end
+
+  @doc "Returns the PubSub topic for a site's build lifecycle."
+  @spec topic(Site.t() | pos_integer()) :: String.t()
+  def topic(%Site{id: site_id}), do: topic(site_id)
+  def topic(site_id), do: "ssg:site:#{site_id}"
+
+  defp validate_build_request(%Site{status: status}, _environment, _opts) when status != :active,
+    do: {:error, :inactive_site}
+
+  defp validate_build_request(%Site{delivery_mode: mode}, _environment, _opts) when mode != :static,
+    do: {:error, :dynamic_site}
+
+  defp validate_build_request(%Site{id: site_id}, %Environment{site_id: site_id}, opts) do
+    expected_site_id = if Tenant.mode() == :multi, do: site_id
+
+    case Keyword.get(opts, :asset_set) do
+      nil -> :ok
+      %SiteAssetSet{site_id: ^expected_site_id} -> :ok
+      %SiteAssetSet{} -> {:error, :asset_set_belongs_to_another_site}
+      _invalid -> {:error, :invalid_asset_set}
+    end
+  end
+
+  defp validate_build_request(%Site{}, %Environment{}, _opts), do: {:error, :environment_belongs_to_another_site}
+
+  defp insert_build_and_job(site, environment, opts) do
+    build_number = next_build_number(site.id)
+    version = "v#{build_number}"
+    asset_set = Keyword.get(opts, :asset_set)
+    scheduled_at = Keyword.get(opts, :scheduled_at)
+    deploy_config = deploy_config(site)
+
+    attrs = %{
+      site_id: site.id,
+      environment_id: environment.id,
+      environment_name: environment.name,
+      environment_key: environment.key,
+      asset_set_id: asset_set && asset_set.id,
+      creator_id: Keyword.get(opts, :creator_id),
+      version: version,
+      build_number: build_number,
+      status: :queued,
+      build_path: Path.join(build_root(site), version),
+      note: Keyword.get(opts, :note),
+      auto_deploy: Keyword.get(opts, :auto_deploy, deploy_config["auto_deploy"] || false),
+      deploy_config: deploy_config,
+      preview_token: preview_token(),
+      preview_expires_at: DateTime.add(DateTime.utc_now(), @preview_lifetime_days, :day),
+      scheduled_at: scheduled_at
+    }
+
+    Repo.transaction(fn ->
+      with {:ok, build} <- %Build{} |> Build.changeset(attrs) |> Repo.insert(@public_opts),
+           {:ok, _job} <- enqueue(build, scheduled_at) do
+        build
+      else
+        {:error, reason} -> Repo.rollback(reason)
+      end
+    end)
+    |> case do
+      {:ok, build} ->
+        broadcast(build)
+        {:ok, build}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp enqueue(build, nil) do
+    build.id
+    |> then(&SSGBuild.new(%{"build_id" => &1}, tags: ["ssg-build", "site:#{build.site_id}"]))
+    |> Oban.insert()
+  end
+
+  defp enqueue(build, %DateTime{} = scheduled_at) do
+    build.id
+    |> then(
+      &SSGBuild.new(%{"build_id" => &1},
+        scheduled_at: scheduled_at,
+        tags: ["ssg-build", "site:#{build.site_id}"]
+      )
+    )
+    |> Oban.insert()
+  end
+
+  defp enqueue(_build, scheduled_at), do: {:error, {:invalid_scheduled_at, scheduled_at}}
+
+  defp next_build_number(site_id) do
+    from(build in Build, where: build.site_id == ^site_id, select: max(build.build_number))
+    |> Repo.one(@public_opts)
+    |> Kernel.||(0)
+    |> Kernel.+(1)
+  end
+
+  defp deploy_config(%Site{deploy_config: %DeployConfig{} = config}) do
+    config
+    |> Map.from_struct()
+    |> Map.drop([:__meta__])
+    |> Map.new(fn {key, value} -> {to_string(key), encode(value)} end)
+  end
+
+  defp deploy_config(%Site{}), do: %{}
+
+  defp encode(nil), do: nil
+  defp encode(value) when is_atom(value), do: Atom.to_string(value)
+  defp encode(value), do: value
+
+  defp asset_scope(site), do: if(Tenant.mode() == :multi, do: site)
+
+  defp preview_token, do: Base.url_encode64(:crypto.strong_rand_bytes(24), padding: false)
+
+  defp preload(nil), do: nil
+  defp preload(build), do: Repo.preload(build, [:site, :environment, :asset_set, :creator], @public_opts)
+end

--- a/lib/brando/ssg/context.ex
+++ b/lib/brando/ssg/context.ex
@@ -1,0 +1,39 @@
+defmodule Brando.SSG.Context do
+  @moduledoc """
+  Signs short-lived tenant context used by the SSG HTTP renderer.
+
+  A build may render any named environment, including one without a public
+  domain. The signed header lets `Brando.Plug.Tenant` select that environment
+  without changing DNS or temporarily mutating the tenant registry.
+  """
+
+  alias Brando.Environments.Environment
+  alias Brando.Sites.Site
+  alias Brando.Tenant.Registry
+
+  @salt "brando-ssg-context"
+  @max_age 3_600
+  @header "x-brando-ssg-token"
+
+  @spec header() :: String.t()
+  def header, do: @header
+
+  @spec sign(Site.t(), Environment.t()) :: String.t()
+  def sign(%Site{id: site_id}, %Environment{id: environment_id, site_id: site_id}) do
+    Phoenix.Token.sign(Brando.endpoint(), @salt, %{site_id: site_id, environment_id: environment_id})
+  end
+
+  @spec resolve(String.t()) :: {Site.t(), Environment.t()} | nil
+  def resolve(token) when is_binary(token) do
+    with {:ok, %{site_id: site_id, environment_id: environment_id}} <-
+           Phoenix.Token.verify(Brando.endpoint(), @salt, token, max_age: @max_age),
+         %Site{status: :active} = site <- Registry.get_site(site_id),
+         %Environment{site_id: ^site_id} = environment <- Registry.get_environment(environment_id) do
+      {site, environment}
+    else
+      _invalid_or_expired -> nil
+    end
+  end
+
+  def resolve(_token), do: nil
+end

--- a/lib/brando/ssg/deploy.ex
+++ b/lib/brando/ssg/deploy.ex
@@ -1,0 +1,300 @@
+defmodule Brando.SSG.Deploy do
+  @moduledoc """
+  Deploys and rolls back persistent SSG artifacts.
+
+  This is deliberately separate from Florist's OTP release deployment. A
+  rollback here republishes an older static artifact; it does not switch the
+  running Phoenix release or mutate its ephemeral `priv/static` directory.
+  """
+
+  import Ecto.Query, only: [from: 2]
+
+  alias Brando.Repo
+  alias Brando.Sites.Site
+  alias Brando.SSG.Build
+  alias Brando.SSG.Builds
+  alias Brando.Tenant.Lock
+
+  @public_opts [prefix: "public"]
+
+  @doc "Deploys a ready or archived build using its snapshotted configuration."
+  @spec deploy(Build.t(), keyword()) :: {:ok, Build.t()} | {:error, term()}
+  def deploy(%Build{} = build, opts \\ []) do
+    Lock.with("ssg-deploy:#{build.site_id}", fn -> deploy_locked(build.id, opts) end)
+    |> notify_webhook(opts)
+  end
+
+  @doc "Redeploys an older artifact and makes it the site's current static release."
+  @spec rollback(Site.t(), Build.t(), keyword()) :: {:ok, Build.t()} | {:error, term()}
+  def rollback(site, build, opts \\ [])
+
+  def rollback(%Site{id: site_id}, %Build{site_id: site_id} = build, opts) do
+    deploy(build, Keyword.put(opts, :event, :rollback))
+  end
+
+  def rollback(%Site{}, %Build{}, _opts), do: {:error, :build_belongs_to_another_site}
+
+  @doc "Prunes old ready, archived, and failed artifact directories while retaining history rows."
+  @spec prune(Site.t(), pos_integer()) :: {:ok, [Build.t()]} | {:error, term()}
+  def prune(%Site{} = site, keep) when is_integer(keep) and keep > 0 do
+    candidates =
+      from(build in Build,
+        where:
+          build.site_id == ^site.id and build.status in [:ready, :archived, :failed] and
+            is_nil(build.pruned_at),
+        order_by: [desc: build.build_number],
+        offset: ^keep
+      )
+      |> Repo.all(@public_opts)
+
+    candidates
+    |> Enum.reduce_while({:ok, []}, fn build, {:ok, pruned} ->
+      with :ok <- remove_build_path(site, build),
+           {:ok, updated} <- Builds.update(build, %{pruned_at: DateTime.utc_now()}) do
+        {:cont, {:ok, [updated | pruned]}}
+      else
+        {:error, reason} -> {:halt, {:error, reason}}
+      end
+    end)
+    |> case do
+      {:ok, pruned} -> {:ok, Enum.reverse(pruned)}
+      error -> error
+    end
+  end
+
+  def prune(%Site{}, keep), do: {:error, {:invalid_retention_count, keep}}
+
+  defp deploy_locked(build_id, opts) do
+    build = Builds.get_build(build_id)
+
+    with %Build{} <- build,
+         true <- build.site.status == :active,
+         true <- build.status in [:ready, :deployed, :archived],
+         true <- managed_build_path?(build),
+         true <- is_nil(build.pruned_at) and File.dir?(build.build_path),
+         :ok <- run_strategy(build, opts) do
+      mark_deployed(build)
+    else
+      nil -> {:error, :build_not_found}
+      false -> {:error, :build_not_deployable}
+      {:error, _reason} = error -> error
+    end
+  end
+
+  defp run_strategy(%Build{deploy_config: config} = build, opts) do
+    case config["strategy"] do
+      "rsync" -> deploy_rsync(build, config["target"], opts)
+      "s3" -> deploy_s3(build, config["target"], opts)
+      "cloudflare_pages" -> {:error, :cloudflare_pages_not_implemented}
+      nil -> {:error, :deploy_strategy_not_configured}
+      strategy -> {:error, {:unsupported_deploy_strategy, strategy}}
+    end
+  end
+
+  defp deploy_rsync(_build, target, _opts) when target in [nil, ""],
+    do: {:error, :deploy_target_not_configured}
+
+  defp deploy_rsync(build, target, opts) do
+    runner = Keyword.get(opts, :runner, &System.cmd/3)
+    args = ["-az", "--delete", String.trim_trailing(build.build_path, "/") <> "/", target]
+
+    case runner.("rsync", args, stderr_to_stdout: true) do
+      {_output, 0} -> :ok
+      {output, exit_status} -> {:error, {:rsync_failed, exit_status, output}}
+    end
+  rescue
+    exception -> {:error, {:rsync_failed, Exception.message(exception)}}
+  end
+
+  defp deploy_s3(_build, target, _opts) when target in [nil, ""],
+    do: {:error, :deploy_target_not_configured}
+
+  defp deploy_s3(build, target, opts) do
+    with {:ok, bucket, prefix} <- parse_s3_target(target),
+         request = Keyword.get(opts, :s3_request, &ExAws.request/1),
+         {:ok, existing_keys} <- list_s3_keys(bucket, prefix, request),
+         :ok <- delete_s3_keys(bucket, existing_keys, request) do
+      upload_s3_files(build, bucket, prefix, request)
+    end
+  rescue
+    exception -> {:error, {:s3_upload_failed, Exception.message(exception)}}
+  end
+
+  defp upload_s3_files(build, bucket, prefix, request) do
+    build.build_path
+    |> regular_files()
+    |> Enum.reduce_while(:ok, fn path, :ok ->
+      case upload_s3_file(build, bucket, prefix, path, request) do
+        :ok -> {:cont, :ok}
+        {:error, reason} -> {:halt, {:error, reason}}
+      end
+    end)
+  end
+
+  defp upload_s3_file(build, bucket, prefix, path, request) do
+    key = path |> Path.relative_to(build.build_path) |> then(&Path.join(prefix, &1))
+    operation = ExAws.S3.put_object(bucket, key, File.read!(path), content_type: MIME.from_path(path))
+
+    case request.(operation) do
+      {:ok, _response} -> :ok
+      {:error, reason} -> {:error, {:s3_upload_failed, key, reason}}
+    end
+  end
+
+  defp list_s3_keys(bucket, prefix, request, continuation_token \\ nil, keys \\ []) do
+    opts =
+      [prefix: s3_prefix(prefix)]
+      |> then(fn opts ->
+        if continuation_token, do: Keyword.put(opts, :continuation_token, continuation_token), else: opts
+      end)
+
+    operation = ExAws.S3.list_objects_v2(bucket, opts)
+
+    case request.(operation) do
+      {:ok, %{body: body}} ->
+        page_keys = Enum.map(Map.get(body, :contents, []), & &1.key)
+        all_keys = keys ++ page_keys
+
+        if body[:is_truncated] in [true, "true"] and body[:next_continuation_token] do
+          list_s3_keys(bucket, prefix, request, body.next_continuation_token, all_keys)
+        else
+          {:ok, all_keys}
+        end
+
+      {:error, reason} ->
+        {:error, {:s3_list_failed, reason}}
+
+      response ->
+        {:error, {:invalid_s3_list_response, response}}
+    end
+  end
+
+  defp delete_s3_keys(_bucket, [], _request), do: :ok
+
+  defp delete_s3_keys(bucket, keys, request) do
+    keys
+    |> Enum.chunk_every(1_000)
+    |> Enum.reduce_while(:ok, fn chunk, :ok ->
+      case bucket |> ExAws.S3.delete_all_objects(chunk) |> request.() do
+        {:ok, _response} -> {:cont, :ok}
+        {:error, reason} -> {:halt, {:error, {:s3_delete_failed, reason}}}
+      end
+    end)
+  end
+
+  defp s3_prefix(""), do: ""
+  defp s3_prefix(prefix), do: String.trim_trailing(prefix, "/") <> "/"
+
+  defp parse_s3_target(target) do
+    case URI.parse(target) do
+      %URI{scheme: "s3", host: bucket, path: path} when is_binary(bucket) and bucket != "" ->
+        {:ok, bucket, path |> Kernel.||("/") |> String.trim("/")}
+
+      _invalid ->
+        {:error, {:invalid_s3_target, target}}
+    end
+  end
+
+  defp regular_files(root) do
+    root
+    |> Path.join("**/*")
+    |> Path.wildcard(match_dot: true)
+    |> Enum.filter(&File.regular?/1)
+  end
+
+  defp managed_build_path?(%Build{site: %Site{} = site, build_path: build_path}) do
+    Path.dirname(Path.expand(build_path)) == Path.expand(Builds.build_root(site))
+  end
+
+  defp managed_build_path?(%Build{}), do: false
+
+  defp mark_deployed(build) do
+    now = DateTime.utc_now()
+
+    Repo.transaction(fn ->
+      from(other in Build,
+        where:
+          other.site_id == ^build.site_id and other.status == :deployed and
+            other.id != ^build.id
+      )
+      |> Repo.update_all([set: [status: :archived, updated_at: now]], @public_opts)
+
+      case Builds.update(build, %{
+             status: :deployed,
+             deployed_at: now,
+             build_log: build.build_log <> log_line("Artifact deployed")
+           }) do
+        {:ok, deployed} -> deployed
+        {:error, changeset} -> Repo.rollback(changeset)
+      end
+    end)
+    |> case do
+      {:ok, deployed} ->
+        Builds.broadcast(deployed)
+        {:ok, deployed}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp notify_webhook({:ok, build} = result, opts) do
+    case build.deploy_config["webhook_url"] do
+      url when is_binary(url) and url != "" ->
+        event = Keyword.get(opts, :event, :deploy)
+        webhook = Keyword.get(opts, :webhook, &default_webhook/2)
+
+        payload = %{
+          event: event,
+          build_id: build.id,
+          site_id: build.site_id,
+          version: build.version,
+          status: build.status
+        }
+
+        case webhook.(url, payload) do
+          :ok ->
+            result
+
+          {:ok, _response} ->
+            result
+
+          {:error, reason} ->
+            Builds.append_log(build, "Deployment webhook failed: #{inspect(reason)}")
+            result
+        end
+
+      _not_configured ->
+        result
+    end
+  end
+
+  defp notify_webhook(error, _opts), do: error
+
+  defp default_webhook(url, payload) do
+    case Req.post(url, json: payload, retry: false) do
+      {:ok, %{status: status}} when status in 200..299 -> :ok
+      {:ok, %{status: status}} -> {:error, {:http_status, status}}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp remove_build_path(site, build) do
+    root = Builds.build_root(site) |> Path.expand()
+    path = Path.expand(build.build_path)
+
+    if Path.dirname(path) == root do
+      case File.rm_rf(path) do
+        {:ok, _removed} -> :ok
+        {:error, reason, failed_path} -> {:error, {:prune_failed, failed_path, reason}}
+      end
+    else
+      {:error, {:unsafe_build_path, path}}
+    end
+  end
+
+  defp log_line(message) do
+    timestamp = Calendar.strftime(DateTime.utc_now(), "%Y-%m-%d %H:%M:%S UTC")
+    "[#{timestamp}] #{message}\n"
+  end
+end

--- a/lib/brando/ssg/preview_controller.ex
+++ b/lib/brando/ssg/preview_controller.ex
@@ -1,0 +1,43 @@
+defmodule Brando.SSG.PreviewController do
+  @moduledoc "Serves a short-lived preview from a versioned SSG artifact."
+
+  use BrandoAdmin, :controller
+
+  alias Brando.SSG.Builds
+
+  @doc false
+  def show(conn, %{"token" => token} = params) do
+    with build when not is_nil(build) <- Builds.get_preview(token),
+         true <- is_nil(build.pruned_at) and File.dir?(build.build_path),
+         true <- managed_build_path?(build),
+         {:ok, relative_path} <- preview_path(Map.get(params, "path", [])),
+         file_path <- Path.join(build.build_path, relative_path),
+         {:ok, %{type: :regular}} <- File.lstat(file_path) do
+      conn
+      |> put_resp_header("cache-control", "private, no-store")
+      |> put_resp_content_type(MIME.from_path(file_path))
+      |> send_file(200, file_path)
+    else
+      _missing_or_unsafe ->
+        conn
+        |> send_resp(404, "Static preview not found")
+        |> halt()
+    end
+  end
+
+  defp preview_path([]), do: {:ok, "index.html"}
+
+  defp preview_path(segments) when is_list(segments) do
+    with {:ok, safe_path} <- segments |> Enum.join("/") |> Path.safe_relative() do
+      if Path.extname(safe_path) == "" do
+        {:ok, Path.join(safe_path, "index.html")}
+      else
+        {:ok, safe_path}
+      end
+    end
+  end
+
+  defp managed_build_path?(build) do
+    Path.dirname(Path.expand(build.build_path)) == Path.expand(Builds.build_root(build.site))
+  end
+end

--- a/lib/brando/supervisor.ex
+++ b/lib/brando/supervisor.ex
@@ -62,6 +62,9 @@ defmodule Brando.Supervisor do
           # dedicated queue also prevents multiple expensive pg_dump restores
           # from saturating the database host.
           environment_operations: [limit: 1],
+          # Static builds are CPU, disk, and network heavy. Serializing them
+          # also keeps their versioned output and deploy transitions simple.
+          ssg_builds: [limit: 1],
           image_processing: [limit: 1],
           # Its own queue on purpose. :default has limit: 1 and also carries the
           # interactive FileUploader/ImageUploader, so a reaper sweep doing one

--- a/lib/brando/tenant/job.ex
+++ b/lib/brando/tenant/job.ex
@@ -49,15 +49,7 @@ defmodule Brando.Tenant.Job do
     if Tenant.enabled?() do
       Registry.list_sites()
       |> Enum.filter(&(&1.status == :active))
-      |> Enum.flat_map(fn site ->
-        site.environments
-        |> select_environments(scope)
-        |> Enum.map(fn environment ->
-          site
-          |> Tenant.prefix(environment)
-          |> Tenant.with_prefix(fun)
-        end)
-      end)
+      |> Enum.flat_map(&run_for_site(&1, scope, fun))
     else
       [fun.()]
     end
@@ -72,6 +64,17 @@ defmodule Brando.Tenant.Job do
   end
 
   defp prefix_from(args), do: Map.get(args, @prefix_key) || Map.get(args, :tenant_prefix)
+
+  defp run_for_site(site, scope, fun) do
+    site.environments
+    |> select_environments(scope)
+    |> Enum.map(fn environment ->
+      site
+      |> Tenant.prefix(environment)
+      |> Tenant.with_prefix(fun)
+    end)
+  end
+
   defp select_environments(environments, :all), do: environments
   defp select_environments(environments, :live), do: Enum.filter(environments, & &1.live)
 end

--- a/lib/brando/tenant/public_data_migrator/postgres.ex
+++ b/lib/brando/tenant/public_data_migrator/postgres.ex
@@ -11,6 +11,7 @@ defmodule Brando.Tenant.PublicDataMigrator.Postgres do
     oban_jobs
     schema_migrations
     site_asset_sets
+    ssg_builds
     sites
     sites_previews
     uploads_pending_intents

--- a/lib/brando/tenant/setup.ex
+++ b/lib/brando/tenant/setup.ex
@@ -48,10 +48,9 @@ defmodule Brando.Tenant.Setup do
     now = Keyword.get_lazy(opts, :now, &DateTime.utc_now/0)
 
     Lock.with(lifecycle_lock_key(site.key), fn ->
-      with %Site{} = current_site <- Registry.get_site(site.id) do
-        Registry.update_site(current_site, %{status: :archived, archived_at: now})
-      else
+      case Registry.get_site(site.id) do
         nil -> {:error, :site_not_found}
+        %Site{} = current_site -> Registry.update_site(current_site, %{status: :archived, archived_at: now})
       end
     end)
   end
@@ -148,10 +147,9 @@ defmodule Brando.Tenant.Setup do
 
   defp update_status(site, status) do
     Lock.with(lifecycle_lock_key(site.key), fn ->
-      with %Site{} = current_site <- Registry.get_site(site.id) do
-        Registry.update_site(current_site, %{status: status, archived_at: nil})
-      else
+      case Registry.get_site(site.id) do
         nil -> {:error, :site_not_found}
+        %Site{} = current_site -> Registry.update_site(current_site, %{status: status, archived_at: nil})
       end
     end)
   end
@@ -182,21 +180,23 @@ defmodule Brando.Tenant.Setup do
   defp deletable?(%Site{}, _opts), do: {:error, :site_must_be_archived}
 
   defp delete_registry_and_schemas(site) do
-    case Repo.transaction(fn ->
-           Enum.each(site_schema_prefixes(site), fn prefix ->
-             case Schema.drop(prefix) do
-               :ok -> :ok
-               {:error, reason} -> Repo.rollback({:schema_drop_failed, prefix, reason})
-             end
-           end)
+    Repo.transaction(fn ->
+      Enum.each(site_schema_prefixes(site), &drop_schema!/1)
+      delete_registry_site!(site)
+    end)
+  end
 
-           case Registry.delete_site(site) do
-             {:ok, deleted_site} -> deleted_site
-             {:error, reason} -> Repo.rollback(reason)
-           end
-         end) do
-      {:ok, deleted_site} -> {:ok, deleted_site}
-      {:error, reason} -> {:error, reason}
+  defp drop_schema!(prefix) do
+    case Schema.drop(prefix) do
+      :ok -> :ok
+      {:error, reason} -> Repo.rollback({:schema_drop_failed, prefix, reason})
+    end
+  end
+
+  defp delete_registry_site!(site) do
+    case Registry.delete_site(site) do
+      {:ok, deleted_site} -> deleted_site
+      {:error, reason} -> Repo.rollback(reason)
     end
   end
 

--- a/lib/brando/workers/ssg_build.ex
+++ b/lib/brando/workers/ssg_build.ex
@@ -1,0 +1,172 @@
+defmodule Brando.Worker.SSGBuild do
+  @moduledoc "Builds one versioned static artifact under a named tenant environment."
+
+  use Oban.Worker, queue: :ssg_builds, max_attempts: 3, unique: [period: :infinity, fields: [:args]]
+
+  alias Brando.SSG.Build
+  alias Brando.SSG.Builds
+  alias Brando.SSG.Deploy
+
+  @impl Oban.Worker
+  def perform(%Oban.Job{args: %{"build_id" => build_id}}) do
+    case Builds.get_build(build_id) do
+      %Build{site: %{status: status}} = build when status != :active ->
+        cancel_unbuildable(build, :site_not_active)
+
+      %Build{environment: nil} = build ->
+        cancel_unbuildable(build, :environment_not_found)
+
+      %Build{status: status} = build when status in [:queued, :building] ->
+        run_build(build)
+
+      %Build{status: status} when status in [:ready, :deployed, :archived] ->
+        :ok
+
+      %Build{status: :failed} ->
+        {:cancel, :build_already_failed}
+
+      %Build{} ->
+        {:cancel, :build_not_queued}
+
+      nil ->
+        {:cancel, :build_not_found}
+    end
+  end
+
+  @impl Oban.Worker
+  def timeout(_job), do: :timer.minutes(30)
+
+  defp run_build(build) do
+    with {:ok, building} <-
+           Builds.update(build, %{
+             status: :building,
+             build_log: build.build_log <> log_line(build_start_message(build))
+           }),
+         result <- call_builder(building),
+         {:ok, ready} <- finish_build(building, result),
+         {:ok, final} <- maybe_deploy(ready),
+         :ok <- prune_and_log(final) do
+      notify_creator(final, "Static build #{final.version} is #{final.status}", :success)
+      :ok
+    else
+      {:error, {:deploy_failed, reason}, ready} -> record_deploy_failure(ready, reason)
+      {:error, reason, result} -> fail_build(build, reason, result)
+      {:error, reason} -> fail_build(build, reason, %{})
+    end
+  rescue
+    exception ->
+      fail_build(build, {:exception, Exception.message(exception)}, %{})
+  end
+
+  defp call_builder(build) do
+    builder = Application.get_env(:brando, :ssg_builder, Brando.SSG)
+
+    builder.build(build.site, build.environment,
+      output_path: build.build_path,
+      asset_set: build.asset_set,
+      progress: fn
+        {:rendering, processed, total, _url}
+        when processed == 1 or processed == total or rem(processed, 10) == 0 ->
+          Builds.record_progress(build.id, processed - 1, total)
+
+        _event ->
+          :ok
+      end
+    )
+  end
+
+  defp finish_build(build, {:ok, result}) do
+    now = DateTime.utc_now()
+
+    Builds.update(build, %{
+      status: :ready,
+      built_at: now,
+      file_count: result.file_count,
+      total_size: result.total_size,
+      url_count: result.url_count,
+      processed_urls: result.processed_urls,
+      failed_urls: result.failed_urls,
+      build_log: build.build_log <> log_line("Build completed with #{result.file_count} files")
+    })
+  end
+
+  defp finish_build(_build, {:error, reason, result}), do: {:error, reason, result}
+  defp finish_build(_build, {:error, reason}), do: {:error, reason}
+  defp finish_build(_build, result), do: {:error, {:invalid_builder_result, result}}
+
+  defp maybe_deploy(%Build{auto_deploy: true} = build) do
+    case Deploy.deploy(build) do
+      {:ok, deployed} -> {:ok, deployed}
+      {:error, reason} -> {:error, {:deploy_failed, reason}, build}
+    end
+  end
+
+  defp maybe_deploy(build), do: {:ok, build}
+
+  defp prune_and_log(%Build{site: site, deploy_config: config} = build) do
+    case Deploy.prune(site, config["retention_count"] || 10) do
+      {:ok, _pruned} ->
+        :ok
+
+      {:error, reason} ->
+        Builds.append_log(build, "Artifact pruning failed: #{inspect(reason)}")
+        :ok
+    end
+  end
+
+  defp record_deploy_failure(build, reason) do
+    Builds.append_log(build, "Automatic deployment failed: #{inspect(reason)}")
+    notify_creator(build, "Static build #{build.version} is ready, but deployment failed", :error)
+    {:error, {:deploy_failed, reason}}
+  end
+
+  defp fail_build(build, reason, result) do
+    current = Builds.get_build(build.id) || build
+
+    attrs = %{
+      status: :failed,
+      built_at: DateTime.utc_now(),
+      file_count: Map.get(result, :file_count, current.file_count),
+      total_size: Map.get(result, :total_size, current.total_size),
+      url_count: Map.get(result, :url_count, current.url_count),
+      processed_urls: Map.get(result, :processed_urls, current.processed_urls),
+      failed_urls: Map.get(result, :failed_urls, current.failed_urls),
+      build_log: current.build_log <> log_line("Build failed: #{inspect(reason)}")
+    }
+
+    case Builds.update(current, attrs) do
+      {:ok, failed} ->
+        notify_creator(failed, "Static build #{failed.version} failed", :error)
+        {:error, reason}
+
+      {:error, changeset} ->
+        {:error, {:persist_build_failure_failed, reason, changeset}}
+    end
+  end
+
+  defp notify_creator(%Build{creator: nil}, _message, _level), do: :ok
+
+  defp notify_creator(%Build{creator: creator}, message, level) do
+    BrandoAdmin.Toast.send_to(creator, message, %{level: level, type: :notification})
+  rescue
+    _endpoint_unavailable -> :ok
+  end
+
+  defp cancel_unbuildable(build, reason) do
+    Builds.update(build, %{
+      status: :failed,
+      built_at: DateTime.utc_now(),
+      build_log: build.build_log <> log_line("Build cancelled: #{inspect(reason)}")
+    })
+
+    {:cancel, reason}
+  end
+
+  defp log_line(message) do
+    timestamp = Calendar.strftime(DateTime.utc_now(), "%Y-%m-%d %H:%M:%S UTC")
+    "[#{timestamp}] #{message}\n"
+  end
+
+  defp build_start_message(%Build{status: :building}), do: "Build restarted after an interrupted attempt"
+  defp build_start_message(%Build{}), do: "Build started"
+end

--- a/lib/brando/workers/ssg_deploy.ex
+++ b/lib/brando/workers/ssg_deploy.ex
@@ -1,0 +1,40 @@
+defmodule Brando.Worker.SSGDeploy do
+  @moduledoc "Deploys or rolls back an existing static artifact on the serial SSG queue."
+
+  use Oban.Worker, queue: :ssg_builds, max_attempts: 3
+
+  alias Brando.SSG.Build
+  alias Brando.SSG.Builds
+  alias Brando.SSG.Deploy
+
+  @impl Oban.Worker
+  def perform(%Oban.Job{args: %{"build_id" => build_id, "action" => action}})
+      when action in ["deploy", "rollback"] do
+    with %Build{} = build <- Builds.get_build(build_id),
+         {:ok, deployed} <- run(action, build) do
+      notify_creator(deployed, action)
+      :ok
+    else
+      nil -> {:cancel, :build_not_found}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  @impl Oban.Worker
+  def timeout(_job), do: :timer.minutes(30)
+
+  defp run("deploy", build), do: Deploy.deploy(build)
+  defp run("rollback", build), do: Deploy.rollback(build.site, build)
+
+  defp notify_creator(%Build{creator: nil}, _action), do: :ok
+
+  defp notify_creator(%Build{creator: creator} = build, action) do
+    BrandoAdmin.Toast.send_to(
+      creator,
+      "Static #{action} completed with #{build.version}",
+      %{level: :success, type: :notification}
+    )
+  rescue
+    _endpoint_unavailable -> :ok
+  end
+end

--- a/lib/brando/workers/upload_intent_reaper.ex
+++ b/lib/brando/workers/upload_intent_reaper.ex
@@ -23,8 +23,8 @@ defmodule Brando.Worker.UploadIntentReaper do
   """
   use Oban.Worker, queue: :upload_reaping, max_attempts: 2
 
-  alias Brando.Uploads
   alias Brando.Tenant.Job, as: TenantJob
+  alias Brando.Uploads
 
   require Logger
 

--- a/lib/brando_admin/live/config/publishing_live.ex
+++ b/lib/brando_admin/live/config/publishing_live.ex
@@ -1,0 +1,458 @@
+defmodule BrandoAdmin.Sites.PublishingLive do
+  @moduledoc false
+
+  use BrandoAdmin, :live_view
+  use BrandoAdmin.Toast
+  use Gettext, backend: Brando.Gettext
+
+  alias Brando.Environments.Environment
+  alias Brando.SSG.Build
+  alias Brando.SSG.Builds
+  alias Brando.Tenant
+  alias Brando.Tenant.Access
+  alias Brando.Tenant.Registry
+  alias Brando.Worker.SSGDeploy
+  alias BrandoAdmin.Components.Content
+
+  @manager_roles [:admin, :superuser]
+
+  @impl Phoenix.LiveView
+  def mount(_params, _session, socket) do
+    site = socket.assigns[:current_site]
+
+    cond do
+      is_nil(site) or site.delivery_mode != :static ->
+        {:ok, redirect(socket, to: "/admin")}
+
+      connected?(socket) ->
+        Phoenix.PubSub.subscribe(Brando.pubsub(), Builds.topic(site))
+
+        {:ok,
+         socket
+         |> assign(:socket_connected, true)
+         |> assign(:site, site)
+         |> assign(:can_manage?, can_manage?(socket.assigns.current_user, site))
+         |> assign(:default_scheduled_at, default_scheduled_at())
+         |> refresh()}
+
+      true ->
+        {:ok, assign(socket, :socket_connected, false)}
+    end
+  end
+
+  @impl Phoenix.LiveView
+  def render(%{socket_connected: false} = assigns) do
+    ~H"""
+    """
+  end
+
+  def render(assigns) do
+    ~H"""
+    <Content.header
+      title={gettext("Publishing")}
+      subtitle={gettext("Build, preview, deploy, and roll back versioned static artifacts")}
+    >
+      <button type="button" class="secondary" phx-click="refresh">{gettext("Refresh")}</button>
+    </Content.header>
+
+    <div class="environment-management-live">
+      <div :if={!@can_manage?} class="environment-notice warning">
+        {gettext("Only site administrators and superusers can publish static builds.")}
+      </div>
+
+      <section class="environment-panel environment-overview">
+        <header>
+          <div>
+            <h2>{@site.name}</h2>
+            <p>{deploy_summary(@site.deploy_config)}</p>
+          </div>
+          <span class="environment-state live">{gettext("Static delivery")}</span>
+        </header>
+
+        <form id="build-static-site" phx-submit="request_build">
+          <label>
+            <span>{gettext("Content environment")}</span>
+            <select name="build[environment_id]" required>
+              <option :for={environment <- @environments} value={environment.id}>
+                {environment.name}{if environment.live, do: " • live", else: ""}
+              </option>
+            </select>
+          </label>
+          <label>
+            <span>{gettext("Note (optional)")}</span>
+            <input name="build[note]" placeholder={gettext("Homepage campaign update")} />
+          </label>
+          <label>
+            <input type="checkbox" name="build[auto_deploy]" value="true" checked={auto_deploy?(@site)} />
+            <span>{gettext("Deploy automatically after a successful build")}</span>
+          </label>
+          <div class="environment-actions">
+            <button
+              type="submit"
+              class="primary"
+              disabled={!@can_manage?}
+              phx-disable-with={gettext("Queueing…")}
+            >
+              {gettext("Build now")}
+            </button>
+          </div>
+        </form>
+
+        <form id="schedule-static-site" phx-submit="schedule_build">
+          <label>
+            <span>{gettext("Schedule a build")}</span>
+            <input type="datetime-local" name="build[scheduled_at]" value={@default_scheduled_at} required />
+          </label>
+          <label>
+            <span>{gettext("Content environment")}</span>
+            <select name="build[environment_id]" required>
+              <option :for={environment <- @environments} value={environment.id}>
+                {environment.name}{if environment.live, do: " • live", else: ""}
+              </option>
+            </select>
+          </label>
+          <label>
+            <input type="checkbox" name="build[auto_deploy]" value="true" checked={auto_deploy?(@site)} />
+            <span>{gettext("Deploy automatically")}</span>
+          </label>
+          <button type="submit" class="secondary" disabled={!@can_manage?}>
+            {gettext("Schedule")}
+          </button>
+        </form>
+      </section>
+
+      <section class="environment-panel">
+        <h2>{gettext("Deployment target")}</h2>
+        <p>
+          {gettext(
+            "This publishes static artifacts only. Florist continues to deploy and roll back the Phoenix application release."
+          )}
+        </p>
+        <form id="static-deploy-config" phx-submit="save_deploy_config">
+          <label>
+            <span>{gettext("Strategy")}</span>
+            <select name="deploy[strategy]">
+              <option value="">{gettext("Build and preview only")}</option>
+              <option value="rsync" selected={deploy_value(@site, :strategy) == :rsync}>Rsync</option>
+              <option value="s3" selected={deploy_value(@site, :strategy) == :s3}>Amazon S3</option>
+            </select>
+          </label>
+          <label>
+            <span>{gettext("Target")}</span>
+            <input
+              name="deploy[target]"
+              value={deploy_value(@site, :target)}
+              placeholder="deploy@example.com:/srv/www or s3://bucket/prefix"
+            />
+          </label>
+          <label>
+            <span>{gettext("Public CDN URL (optional)")}</span>
+            <input name="deploy[cdn_url]" value={deploy_value(@site, :cdn_url)} placeholder="https://www.example.com" />
+          </label>
+          <label>
+            <span>{gettext("Completion webhook (optional)")}</span>
+            <input
+              name="deploy[webhook_url]"
+              value={deploy_value(@site, :webhook_url)}
+              placeholder="https://hooks.example.com/static-published"
+            />
+          </label>
+          <label>
+            <span>{gettext("Artifact retention")}</span>
+            <input
+              type="number"
+              min="1"
+              max="100"
+              name="deploy[retention_count]"
+              value={deploy_value(@site, :retention_count) || 10}
+            />
+          </label>
+          <label>
+            <input
+              type="checkbox"
+              name="deploy[auto_deploy]"
+              value="true"
+              checked={auto_deploy?(@site)}
+            />
+            <span>{gettext("Default new builds to automatic deployment")}</span>
+          </label>
+          <button type="submit" class="secondary" disabled={!@can_manage?}>
+            {gettext("Save deployment settings")}
+          </button>
+        </form>
+      </section>
+
+      <section class="environment-panel">
+        <header>
+          <div>
+            <h2>{gettext("Build history")}</h2>
+            <p>{gettext("Artifacts are stored outside the OTP release and survive blue/green switches.")}</p>
+          </div>
+          <span class="environment-count">
+            {ngettext("%{count} build", "%{count} builds", length(@builds))}
+          </span>
+        </header>
+
+        <div :if={@builds == []} class="environment-notice">
+          {gettext("No static builds have been requested yet.")}
+        </div>
+
+        <div :if={@builds != []} class="environment-table-wrap">
+          <table>
+            <thead>
+              <tr>
+                <th>{gettext("Version")}</th>
+                <th>{gettext("Environment")}</th>
+                <th>{gettext("Progress")}</th>
+                <th>{gettext("State")}</th>
+                <th>{gettext("Created")}</th>
+                <th>{gettext("Actions")}</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr :for={build <- @builds} id={"ssg-build-#{build.id}"}>
+                <td>
+                  <strong>{build.version}</strong>
+                  <code>{build.note || asset_name(build)}</code>
+                </td>
+                <td>{build.environment_name}</td>
+                <td>{build.processed_urls}/{build.url_count}</td>
+                <td>
+                  <span class={["environment-state", build.status == :deployed && "live"]}>
+                    {human_status(build.status)}
+                  </span>
+                  <small :if={build.pruned_at}>{gettext("artifact pruned")}</small>
+                </td>
+                <td>{format_datetime(build.scheduled_at || build.inserted_at)}</td>
+                <td class="environment-actions">
+                  <a
+                    :if={previewable?(build)}
+                    class="button secondary small"
+                    href={preview_url(build)}
+                    target="_blank"
+                    rel="noreferrer"
+                  >
+                    {gettext("Preview")}
+                  </a>
+                  <a
+                    :if={build.status == :deployed && public_url(build)}
+                    class="button secondary small"
+                    href={public_url(build)}
+                    target="_blank"
+                    rel="noreferrer"
+                  >
+                    {gettext("Open site")}
+                  </a>
+                  <button
+                    :if={build.status == :ready && is_nil(build.pruned_at)}
+                    type="button"
+                    class="primary small"
+                    disabled={!@can_manage? || !deploy_configured?(@site)}
+                    phx-click="deploy"
+                    phx-value-id={build.id}
+                    phx-confirm={gettext("Deploy %{version}?", version: build.version)}
+                  >
+                    {gettext("Deploy")}
+                  </button>
+                  <button
+                    :if={build.status == :archived && is_nil(build.pruned_at)}
+                    type="button"
+                    class="secondary small"
+                    disabled={!@can_manage? || !deploy_configured?(@site)}
+                    phx-click="rollback"
+                    phx-value-id={build.id}
+                    phx-confirm={gettext("Roll back to %{version}?", version: build.version)}
+                  >
+                    {gettext("Roll back")}
+                  </button>
+                  <details :if={build.build_log != "" || build.failed_urls != []}>
+                    <summary>{gettext("Log")}</summary>
+                    <pre>{build.build_log}</pre>
+                    <ul :if={build.failed_urls != []}>
+                      <li :for={failed_url <- build.failed_urls}>{failed_url}</li>
+                    </ul>
+                  </details>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+    </div>
+    """
+  end
+
+  @impl Phoenix.LiveView
+  def handle_event("refresh", _params, socket), do: {:noreply, refresh(socket)}
+
+  def handle_event("request_build", %{"build" => params}, socket) do
+    queue_build(socket, params, nil)
+  end
+
+  def handle_event("schedule_build", %{"build" => params}, socket) do
+    case parse_future_datetime(params["scheduled_at"]) do
+      {:ok, scheduled_at} -> queue_build(socket, params, scheduled_at)
+      {:error, _reason} -> toast_error(socket, gettext("Choose a valid future date and time."))
+    end
+  end
+
+  def handle_event("save_deploy_config", %{"deploy" => params}, socket) do
+    attrs = %{
+      strategy: deploy_strategy(params["strategy"]),
+      target: blank_to_nil(params["target"]),
+      cdn_url: blank_to_nil(params["cdn_url"]),
+      webhook_url: blank_to_nil(params["webhook_url"]),
+      auto_deploy: params["auto_deploy"] == "true",
+      retention_count: parse_integer(params["retention_count"], 10)
+    }
+
+    with true <- socket.assigns.can_manage?,
+         {:ok, _site} <- Registry.update_site(socket.assigns.site, %{deploy_config: attrs}) do
+      send(self(), {:toast, gettext("Static deployment settings saved")})
+      {:noreply, refresh(socket)}
+    else
+      {:error, %Ecto.Changeset{} = changeset} ->
+        toast_error(socket, BrandoAdmin.Utils.format_changeset_errors(changeset))
+
+      _error ->
+        toast_error(socket, gettext("Could not save static deployment settings."))
+    end
+  end
+
+  def handle_event(action, %{"id" => id}, socket) when action in ["deploy", "rollback"] do
+    with true <- socket.assigns.can_manage?,
+         {build_id, ""} <- Integer.parse(id),
+         %Build{site_id: site_id} <- Enum.find(socket.assigns.builds, &(&1.id == build_id)),
+         true <- site_id == socket.assigns.site.id,
+         {:ok, _job} <-
+           %{"build_id" => build_id, "action" => action}
+           |> SSGDeploy.new(tags: ["ssg-deploy", "site:#{site_id}"])
+           |> Oban.insert() do
+      send(self(), {:toast, gettext("Static %{action} queued", action: action)})
+      {:noreply, socket}
+    else
+      _error -> toast_error(socket, gettext("Could not queue the publishing action."))
+    end
+  end
+
+  @impl Phoenix.LiveView
+  def handle_info({:ssg_build_updated, _build}, socket), do: {:noreply, refresh(socket)}
+
+  defp queue_build(socket, params, scheduled_at) do
+    with true <- socket.assigns.can_manage?,
+         %Environment{} = environment <- environment(socket, params["environment_id"]),
+         {:ok, build} <-
+           Builds.request_build(socket.assigns.site, environment,
+             creator_id: socket.assigns.current_user.id,
+             note: blank_to_nil(params["note"]),
+             auto_deploy: params["auto_deploy"] == "true",
+             scheduled_at: scheduled_at
+           ) do
+      send(self(), {:toast, gettext("Queued static build %{version}", version: build.version)})
+      {:noreply, refresh(socket)}
+    else
+      _error -> toast_error(socket, gettext("Could not queue the static build."))
+    end
+  end
+
+  defp environment(socket, id) when is_binary(id) do
+    case Integer.parse(id) do
+      {environment_id, ""} -> Enum.find(socket.assigns.environments, &(&1.id == environment_id))
+      _invalid -> nil
+    end
+  end
+
+  defp environment(_socket, _id), do: nil
+
+  defp refresh(socket) do
+    site = Registry.get_site(socket.assigns.site.id)
+
+    socket
+    |> assign(:site, site)
+    |> assign(:environments, site.environments |> Enum.sort_by(&{not &1.live, &1.name}))
+    |> assign(:builds, Builds.list_builds(site))
+  end
+
+  defp can_manage?(user, site) do
+    case Tenant.mode() do
+      :multi -> Access.can_manage?(user, site)
+      _other -> user.role in @manager_roles
+    end
+  end
+
+  defp parse_future_datetime(value) when is_binary(value) do
+    with {:ok, naive} <- NaiveDateTime.from_iso8601(value <> ":00"),
+         {:ok, scheduled_at} <- DateTime.from_naive(naive, Brando.timezone()),
+         :gt <- DateTime.compare(scheduled_at, DateTime.utc_now()) do
+      {:ok, scheduled_at}
+    else
+      _invalid -> {:error, :invalid_scheduled_at}
+    end
+  end
+
+  defp parse_future_datetime(_value), do: {:error, :invalid_scheduled_at}
+
+  defp default_scheduled_at do
+    Brando.timezone()
+    |> DateTime.now!()
+    |> DateTime.add(10, :minute)
+    |> Calendar.strftime("%Y-%m-%dT%H:%M")
+  end
+
+  defp toast_error(socket, message) do
+    BrandoAdmin.Toast.send_to(socket.assigns.current_user, message, %{
+      level: :error,
+      type: :notification
+    })
+
+    {:noreply, socket}
+  end
+
+  defp blank_to_nil(value) when value in [nil, ""], do: nil
+  defp blank_to_nil(value), do: value
+
+  defp deploy_strategy("rsync"), do: :rsync
+  defp deploy_strategy("s3"), do: :s3
+  defp deploy_strategy(_none), do: nil
+
+  defp parse_integer(value, default) do
+    case Integer.parse(to_string(value)) do
+      {integer, ""} -> integer
+      _invalid -> default
+    end
+  end
+
+  defp auto_deploy?(site), do: site.deploy_config && site.deploy_config.auto_deploy
+
+  defp deploy_value(%{deploy_config: nil}, _field), do: nil
+  defp deploy_value(%{deploy_config: config}, field), do: Map.get(config, field)
+
+  defp deploy_configured?(site) do
+    site.deploy_config && site.deploy_config.strategy && site.deploy_config.target not in [nil, ""]
+  end
+
+  defp deploy_summary(nil), do: gettext("No deployment target configured; builds and previews remain available.")
+
+  defp deploy_summary(config) do
+    if config.strategy && config.target not in [nil, ""] do
+      gettext("Deploy via %{strategy} to %{target}", strategy: config.strategy, target: config.target)
+    else
+      gettext("No deployment target configured; builds and previews remain available.")
+    end
+  end
+
+  defp asset_name(%Build{asset_set: nil}), do: gettext("release assets")
+  defp asset_name(%Build{asset_set: asset_set}), do: asset_set.name
+
+  defp previewable?(build),
+    do: build.status in [:ready, :deployed, :archived] and is_nil(build.pruned_at)
+
+  defp preview_url(build), do: "/__ssg_preview__/#{build.preview_token}/"
+
+  defp public_url(build), do: build.deploy_config["cdn_url"]
+
+  defp human_status(status), do: status |> Atom.to_string() |> String.capitalize()
+
+  defp format_datetime(nil), do: "—"
+  defp format_datetime(datetime), do: Calendar.strftime(datetime, "%Y-%m-%d %H:%M UTC")
+end

--- a/lib/brando_admin/live/config/site_live.ex
+++ b/lib/brando_admin/live/config/site_live.ex
@@ -380,10 +380,7 @@ defmodule BrandoAdmin.Sites.SiteLive do
     do: gettext("This site must remain archived for %{days} days before permanent deletion.", days: days)
 
   defp lifecycle_error(%Ecto.Changeset{} = changeset) do
-    changeset
-    |> Ecto.Changeset.traverse_errors(fn {message, _opts} -> message end)
-    |> Enum.flat_map(fn {field, messages} -> Enum.map(messages, &"#{field} #{&1}") end)
-    |> Enum.join(", ")
+    BrandoAdmin.Utils.format_changeset_errors(changeset)
   end
 
   defp lifecycle_error({:site_setup_failed, reason, _compensation}), do: lifecycle_error(reason)

--- a/lib/brando_admin/live/config/site_live.ex
+++ b/lib/brando_admin/live/config/site_live.ex
@@ -305,18 +305,20 @@ defmodule BrandoAdmin.Sites.SiteLive do
   defp directory_size(path) do
     case File.ls(path) do
       {:ok, entries} ->
-        Enum.reduce(entries, 0, fn entry, total ->
-          child = Path.join(path, entry)
-
-          case File.lstat(child) do
-            {:ok, %{type: :regular, size: size}} -> total + size
-            {:ok, %{type: :directory}} -> total + directory_size(child)
-            _symlink_or_error -> total
-          end
-        end)
+        Enum.reduce(entries, 0, fn entry, total -> total + entry_size(path, entry) end)
 
       {:error, _reason} ->
         0
+    end
+  end
+
+  defp entry_size(path, entry) do
+    child = Path.join(path, entry)
+
+    case File.lstat(child) do
+      {:ok, %{type: :regular, size: size}} -> size
+      {:ok, %{type: :directory}} -> directory_size(child)
+      _symlink_or_error -> 0
     end
   end
 

--- a/lib/brando_admin/live/content/shared_library_live.ex
+++ b/lib/brando_admin/live/content/shared_library_live.ex
@@ -593,19 +593,25 @@ defmodule BrandoAdmin.Content.SharedLibraryLive do
     prefix = Tenant.prefix(site, environment)
 
     Enum.reduce(@kinds, {%{}, %{}}, fn kind, {effective_acc, diff_acc} ->
-      Enum.reduce(Map.fetch!(libraries, kind), {effective_acc, diff_acc}, fn entry, {entries, diffs} ->
-        effective = SharedLibrary.get(kind, entry.id, :shared, site, prefix)
-        entries = Map.put(entries, {kind, entry.id}, effective)
-
-        diffs =
-          case SharedLibrary.diff(kind, entry.id, site, prefix) do
-            {:ok, diff} -> Map.put(diffs, {kind, entry.id}, diff)
-            {:error, :not_found} -> diffs
-          end
-
-        {entries, diffs}
-      end)
+      Enum.reduce(
+        Map.fetch!(libraries, kind),
+        {effective_acc, diff_acc},
+        &put_context_entry(&1, &2, kind, site, prefix)
+      )
     end)
+  end
+
+  defp put_context_entry(entry, {entries, diffs}, kind, site, prefix) do
+    effective = SharedLibrary.get(kind, entry.id, :shared, site, prefix)
+    entries = Map.put(entries, {kind, entry.id}, effective)
+
+    diffs =
+      case SharedLibrary.diff(kind, entry.id, site, prefix) do
+        {:ok, diff} -> Map.put(diffs, {kind, entry.id}, diff)
+        {:error, :not_found} -> diffs
+      end
+
+    {entries, diffs}
   end
 
   defp select_site([], _selected_id), do: nil
@@ -633,14 +639,16 @@ defmodule BrandoAdmin.Content.SharedLibraryLive do
   end
 
   defp entry_attrs(:palette, params) do
-    with {:ok, colors} <- Jason.decode(params["colors_json"] || "[]") do
-      {:ok,
-       params
-       |> Map.take(["name", "namespace", "key", "version_note"])
-       |> Map.put("status", "published")
-       |> Map.put("colors", colors)}
-    else
-      _error -> {:error, :invalid_colors_json}
+    case Jason.decode(params["colors_json"] || "[]") do
+      {:ok, colors} ->
+        {:ok,
+         params
+         |> Map.take(["name", "namespace", "key", "version_note"])
+         |> Map.put("status", "published")
+         |> Map.put("colors", colors)}
+
+      _error ->
+        {:error, :invalid_colors_json}
     end
   end
 

--- a/lib/brando_admin/live/content/shared_library_live.ex
+++ b/lib/brando_admin/live/content/shared_library_live.ex
@@ -721,10 +721,7 @@ defmodule BrandoAdmin.Content.SharedLibraryLive do
   defp error_message({:error, reason}), do: error_message(reason)
 
   defp error_message(%Ecto.Changeset{} = changeset) do
-    changeset
-    |> Ecto.Changeset.traverse_errors(fn {message, _opts} -> message end)
-    |> Enum.flat_map(fn {field, messages} -> Enum.map(messages, &"#{field} #{&1}") end)
-    |> Enum.join(", ")
+    BrandoAdmin.Utils.format_changeset_errors(changeset)
   end
 
   defp error_message({:shared_item_in_use, usages}) do

--- a/lib/brando_admin/live/nav.ex
+++ b/lib/brando_admin/live/nav.ex
@@ -18,7 +18,10 @@ defmodule BrandoAdmin.Nav do
       |> assign(:current_url, url)
       |> put_locale()
       |> assign_tenant_options()
-      |> assign(:menu_sections, BrandoAdmin.Menu.get_menu(socket.assigns.current_user))
+      |> assign(
+        :menu_sections,
+        BrandoAdmin.Menu.get_menu(socket.assigns.current_user, socket.assigns[:current_site])
+      )
       |> then(&{:ok, &1})
     else
       socket

--- a/lib/brando_admin/menu.ex
+++ b/lib/brando_admin/menu.ex
@@ -15,6 +15,8 @@ defmodule BrandoAdmin.Menu do
 
   use Gettext, backend: Brando.Gettext
 
+  alias Brando.Tenant
+
   defmacro __using__(_) do
     quote do
       import BrandoAdmin.Menu
@@ -243,7 +245,7 @@ defmodule BrandoAdmin.Menu do
     end
   end
 
-  def get_menu(current_user \\ nil) do
+  def get_menu(current_user \\ nil, current_site \\ nil) do
     content_menus = Brando.admin_module(Menus).__menus__()
 
     [
@@ -255,11 +257,7 @@ defmodule BrandoAdmin.Menu do
               name: gettext("Dashboard"),
               url: "/admin"
             },
-            Brando.Tenant.mode() == :multi && current_user && current_user.role == :superuser &&
-              %{
-                name: gettext("Sites"),
-                url: "/admin/sites"
-              },
+            sites_menu_item(current_user),
             %{
               name: gettext("Configuration"),
               url: nil,
@@ -285,16 +283,9 @@ defmodule BrandoAdmin.Menu do
                     name: gettext("Scheduled publishing"),
                     url: "/admin/config/scheduled_publishing"
                   },
-                  Brando.Tenant.enabled?() &&
-                    %{
-                      name: gettext("Environments"),
-                      url: "/admin/config/environments"
-                    },
-                  current_user && current_user.role == :superuser &&
-                    %{
-                      name: gettext("Frontend assets"),
-                      url: "/admin/config/assets"
-                    },
+                  environments_menu_item(),
+                  publishing_menu_item(current_site),
+                  frontend_assets_menu_item(current_user),
                   %{
                     name: gettext("Cache"),
                     url: "/admin/config/cache"
@@ -307,15 +298,7 @@ defmodule BrandoAdmin.Menu do
                     name: gettext("Block modules"),
                     url: "/admin/config/content/modules"
                   },
-                  Brando.Tenant.mode() == :multi && current_user &&
-                    %{
-                      name:
-                        if(current_user.role == :superuser,
-                          do: gettext("Shared content library"),
-                          else: gettext("Site content library")
-                        ),
-                      url: "/admin/config/content/shared_library"
-                    },
+                  shared_library_menu_item(current_user),
                   %{
                     name: gettext("Block module sets"),
                     url: "/admin/config/content/module_sets"
@@ -384,4 +367,35 @@ defmodule BrandoAdmin.Menu do
       }
     ]
   end
+
+  defp publishing_menu_item(%{delivery_mode: :static}) do
+    %{name: gettext("Publishing"), url: "/admin/config/publishing"}
+  end
+
+  defp publishing_menu_item(_site), do: nil
+
+  defp sites_menu_item(%{role: :superuser}) do
+    if Tenant.mode() == :multi, do: %{name: gettext("Sites"), url: "/admin/sites"}
+  end
+
+  defp sites_menu_item(_user), do: nil
+
+  defp environments_menu_item do
+    if Tenant.enabled?(), do: %{name: gettext("Environments"), url: "/admin/config/environments"}
+  end
+
+  defp frontend_assets_menu_item(%{role: :superuser}) do
+    %{name: gettext("Frontend assets"), url: "/admin/config/assets"}
+  end
+
+  defp frontend_assets_menu_item(_user), do: nil
+
+  defp shared_library_menu_item(%{role: role}) do
+    if Tenant.mode() == :multi do
+      name = if role == :superuser, do: gettext("Shared content library"), else: gettext("Site content library")
+      %{name: name, url: "/admin/config/content/shared_library"}
+    end
+  end
+
+  defp shared_library_menu_item(_user), do: nil
 end

--- a/lib/brando_admin/utils.ex
+++ b/lib/brando_admin/utils.ex
@@ -17,6 +17,15 @@ defmodule BrandoAdmin.Utils do
     send_update(module, Map.put(assigns, :id, id))
   end
 
+  @doc "Formats nested changeset errors as a compact, human-readable sentence."
+  @spec format_changeset_errors(Ecto.Changeset.t()) :: String.t()
+  def format_changeset_errors(%Ecto.Changeset{} = changeset) do
+    changeset
+    |> Ecto.Changeset.traverse_errors(fn {message, _opts} -> message end)
+    |> flatten_changeset_errors([])
+    |> Enum.join(", ")
+  end
+
   def prepare_subform_component(%{assigns: assigns} = socket) do
     schema = assigns.field.form.source.data.__struct__
 
@@ -40,6 +49,24 @@ defmodule BrandoAdmin.Utils do
       instructions: g(schema, Map.get(socket.assigns.subform, :instructions)),
       label: g(schema, Map.get(socket.assigns.subform, :label))
     )
+  end
+
+  defp flatten_changeset_errors(errors, path) when is_map(errors) do
+    Enum.flat_map(errors, fn {field, nested_errors} ->
+      flatten_changeset_errors(nested_errors, path ++ [field])
+    end)
+  end
+
+  defp flatten_changeset_errors(errors, path) when is_list(errors) do
+    if Enum.all?(errors, &is_binary/1) do
+      Enum.map(errors, &"#{Enum.join(path, ".")} #{&1}")
+    else
+      errors
+      |> Enum.with_index()
+      |> Enum.flat_map(fn {nested_errors, index} ->
+        flatten_changeset_errors(nested_errors, path ++ [index])
+      end)
+    end
   end
 
   def prepare_input_component(%{assigns: assigns} = socket) do

--- a/lib/mix/tasks/brando.install.ex
+++ b/lib/mix/tasks/brando.install.ex
@@ -68,6 +68,8 @@ defmodule Mix.Tasks.Brando.Install do
      "priv/repo/migrations/20260816002200_brando_162_add_site_asset_sets.exs"},
     {:eex, "../brando.upgrade/migrations/brando_163_add_shared_content_library.exs",
      "priv/repo/migrations/20260816002300_brando_163_add_shared_content_library.exs"},
+    {:eex, "../brando.upgrade/migrations/brando_164_add_ssg_builds.exs",
+     "priv/repo/migrations/20260816002400_brando_164_add_ssg_builds.exs"},
 
     # Etc. Various OS config files and log directory.
     {:keep, "log", "log"},

--- a/lib/mix/tasks/brando.install.ex
+++ b/lib/mix/tasks/brando.install.ex
@@ -544,7 +544,7 @@ defmodule Mix.Tasks.Brando.Install do
     Mix.shell().info("\nBrando finished copying.")
   end
 
-  @doc false
+  @doc "Resolves installer tenancy options, prompting when requested options are absent."
   def resolve_tenancy_options!(opts, default_site_key) do
     cond do
       Keyword.has_key?(opts, :tenancy_mode) or Keyword.has_key?(opts, :site_key) ->
@@ -558,7 +558,7 @@ defmodule Mix.Tasks.Brando.Install do
     end
   end
 
-  @doc false
+  @doc "Parses and validates non-interactive installer tenancy options."
   def parse_tenancy_options!(opts) do
     mode = opts |> Keyword.get(:tenancy_mode, "none") |> parse_tenancy_mode!()
     site_key = opts[:site_key]

--- a/lib/mix/tasks/brando.migrate.54.ex
+++ b/lib/mix/tasks/brando.migrate.54.ex
@@ -1177,6 +1177,10 @@ if Code.ensure_loaded?(Igniter) do
       `florist.config.exs`. It preserves the legacy single-release/nginx model,
       does not copy passwords, and leaves the legacy files untouched.
 
+      Tenancy remains opt-in. Applications adopting named environments can run
+      `mix brando.setup.tenancy` after this general source upgrade to prepare
+      their configuration, router pipelines, and tenant migration support.
+
       Continue in this order:
 
         1. Review the complete Igniter diff, then run `mix format` and

--- a/lib/mix/tasks/brando.migrate.ex
+++ b/lib/mix/tasks/brando.migrate.ex
@@ -14,12 +14,29 @@ defmodule Mix.Tasks.Brando.Migrate do
 
   use Mix.Task
 
+  alias Mix.Task
+
   @switches [tenants: :boolean, site: :string]
 
   @impl Mix.Task
   def run(args) do
     {opts, positional, invalid} = OptionParser.parse(args, strict: @switches)
+    validate_options!(opts, positional, invalid)
 
+    cond do
+      opts[:tenants] ->
+        Task.run("app.start")
+        Brando.Environments.migrate_all() |> report_tenant_result()
+
+      is_binary(opts[:site]) ->
+        migrate_site(opts[:site])
+
+      true ->
+        Task.run("ecto.migrate")
+    end
+  end
+
+  defp validate_options!(opts, positional, invalid) do
     if invalid != [] or positional != [] do
       Mix.raise("Invalid arguments: #{inspect(positional ++ invalid)}")
     end
@@ -27,24 +44,14 @@ defmodule Mix.Tasks.Brando.Migrate do
     if opts[:tenants] and opts[:site] do
       Mix.raise("Choose either --tenants or --site, not both")
     end
+  end
 
-    cond do
-      opts[:tenants] ->
-        Mix.Task.run("app.start")
-        Brando.Environments.migrate_all() |> report_tenant_result()
+  defp migrate_site(site_key) do
+    Task.run("app.start")
 
-      is_binary(opts[:site]) ->
-        Mix.Task.run("app.start")
-
-        opts[:site]
-        |> Brando.Tenant.Registry.get_site_by_key()
-        |> case do
-          nil -> Mix.raise("Unknown site key: #{opts[:site]}")
-          site -> Brando.Environments.migrate_site(site) |> report_tenant_result()
-        end
-
-      true ->
-        Mix.Task.run("ecto.migrate")
+    case Brando.Tenant.Registry.get_site_by_key(site_key) do
+      nil -> Mix.raise("Unknown site key: #{site_key}")
+      site -> Brando.Environments.migrate_site(site) |> report_tenant_result()
     end
   end
 

--- a/lib/mix/tasks/brando.setup.tenancy.ex
+++ b/lib/mix/tasks/brando.setup.tenancy.ex
@@ -1,0 +1,258 @@
+if Code.ensure_loaded?(Igniter) do
+  defmodule Mix.Tasks.Brando.Setup.Tenancy do
+    use Igniter.Mix.Task
+
+    alias Igniter.Code.Common
+    alias Igniter.Code.Function, as: CodeFunction
+    alias Igniter.Code.Keyword, as: CodeKeyword
+
+    @shortdoc "Prepares an existing Brando application for tenancy"
+    @moduledoc """
+    #{@shortdoc}.
+
+    This opt-in source migration configures tenancy, adds
+    `Brando.Plug.Tenant` to existing browser pipelines, and installs Brando's
+    tenant migration support. It does not infer application-owned tenant
+    tables, run migrations, provision sites, or copy production data.
+
+        mix brando.setup.tenancy --mode single --site-key my-site
+        mix brando.setup.tenancy --mode multi
+
+    Review the Igniter diff before applying it. Then follow the ordered tenant
+    migration and provisioning workflow printed by the task.
+    """
+
+    @pipelines [:browser, :browser_api]
+    @tenant_migration "20260816002300_add_shared_content_library.exs"
+    @tenant_plug Brando.Plug.Tenant
+    @content_plugs [Brando.Plug.Identity, Brando.Plug.Navigation, Brando.Plug.Fragment]
+
+    @impl Igniter.Mix.Task
+    def info(_argv, _source) do
+      %Igniter.Mix.Task.Info{
+        group: :brando,
+        example: "mix brando.setup.tenancy --mode single --site-key my-site",
+        schema: [mode: :string, site_key: :string],
+        required: [:mode]
+      }
+    end
+
+    @impl Igniter.Mix.Task
+    def igniter(igniter) do
+      case tenancy_options(igniter.args.options) do
+        {:ok, mode, site_key} ->
+          igniter
+          |> configure_tenancy(mode, site_key)
+          |> configure_routers()
+          |> install_tenant_migration()
+          |> add_instructions(mode, site_key)
+
+        {:error, message} ->
+          Igniter.add_issue(igniter, message)
+      end
+    end
+
+    defp tenancy_options(options) do
+      mode = options[:mode]
+      site_key = options[:site_key]
+
+      case {mode, site_key} do
+        {"single", site_key} when is_binary(site_key) ->
+          if Brando.Tenant.valid_key?(site_key) do
+            {:ok, :single, site_key}
+          else
+            {:error, "--site-key must be a lowercase, URL-safe key such as my-site"}
+          end
+
+        {"single", nil} ->
+          {:error, "--site-key is required with --mode single"}
+
+        {"multi", nil} ->
+          {:ok, :multi, nil}
+
+        {"multi", _site_key} ->
+          {:error, "--site-key can only be used with --mode single"}
+
+        {mode, _site_key} ->
+          {:error, "invalid --mode #{inspect(mode)}; expected single or multi"}
+      end
+    end
+
+    defp configure_tenancy(igniter, mode, site_key) do
+      igniter =
+        Igniter.Project.Config.configure(
+          igniter,
+          "brando.exs",
+          :brando,
+          [:tenancy_mode],
+          mode
+        )
+
+      case site_key do
+        nil ->
+          remove_site_key(igniter)
+
+        site_key ->
+          Igniter.Project.Config.configure(
+            igniter,
+            "brando.exs",
+            :brando,
+            [:site_key],
+            site_key
+          )
+      end
+    end
+
+    defp remove_site_key(igniter) do
+      Igniter.update_elixir_file(igniter, "config/brando.exs", fn zipper ->
+        Common.update_all_matches(
+          zipper,
+          &brando_config_with_site_key?/1,
+          &remove_site_key_from_config/1
+        )
+      end)
+    end
+
+    defp remove_site_key_from_config(config_zipper) do
+      with {:ok, options_zipper} <- CodeFunction.move_to_nth_argument(config_zipper, 1),
+           {:ok, options_zipper} <- CodeKeyword.remove_keyword_key(options_zipper, :site_key) do
+        {:ok, options_zipper}
+      else
+        _ -> {:ok, config_zipper}
+      end
+    end
+
+    defp brando_config_with_site_key?(zipper) do
+      CodeFunction.function_call?(zipper, :config, 2) &&
+        CodeFunction.argument_equals?(zipper, 0, :brando) &&
+        case CodeFunction.move_to_nth_argument(zipper, 1) do
+          {:ok, options_zipper} -> CodeKeyword.keyword_has_path?(options_zipper, [:site_key])
+          :error -> false
+        end
+    end
+
+    defp configure_routers(igniter) do
+      {igniter, routers} = Igniter.Libs.Phoenix.list_routers(igniter)
+
+      case routers do
+        [] ->
+          Igniter.add_warning(igniter, """
+          No Phoenix router could be found. Add `plug Brando.Plug.Tenant` to
+          every frontend pipeline before plugs that load tenant content.
+          """)
+
+        routers ->
+          Enum.reduce(routers, igniter, &configure_router(&2, &1))
+      end
+    end
+
+    defp configure_router(igniter, router) do
+      {igniter, _source, zipper} = Igniter.Project.Module.find_module!(igniter, router)
+
+      configured_pipelines =
+        case Common.move_to_do_block(zipper) do
+          {:ok, block_zipper} -> Enum.filter(@pipelines, &pipeline_present?(block_zipper, &1))
+          :error -> []
+        end
+
+      igniter =
+        Enum.reduce(configured_pipelines, igniter, fn pipeline, igniter ->
+          add_tenant_plug(igniter, router, pipeline)
+        end)
+
+      if :browser in configured_pipelines do
+        igniter
+      else
+        Igniter.add_warning(igniter, """
+        #{inspect(router)} has no `:browser` pipeline. Add
+        `plug Brando.Plug.Tenant` to every frontend pipeline before plugs that
+        load tenant content.
+        """)
+      end
+    end
+
+    defp pipeline_present?(zipper, pipeline), do: match?({:ok, _}, move_to_pipeline(zipper, pipeline))
+
+    defp add_tenant_plug(igniter, router, pipeline) do
+      Igniter.Project.Module.find_and_update_module!(igniter, router, fn zipper ->
+        with {:ok, pipeline_zipper} <- move_to_pipeline(zipper, pipeline),
+             {:ok, block_zipper} <- Common.move_to_do_block(pipeline_zipper) do
+          insert_tenant_plug(block_zipper)
+        else
+          _ -> {:ok, zipper}
+        end
+      end)
+    end
+
+    defp move_to_pipeline(zipper, pipeline) do
+      CodeFunction.move_to_function_call_in_current_scope(
+        zipper,
+        :pipeline,
+        2,
+        &CodeFunction.argument_equals?(&1, 0, pipeline)
+      )
+    end
+
+    defp insert_tenant_plug(block_zipper) do
+      case move_to_plug(block_zipper, [@tenant_plug]) do
+        {:ok, tenant_plug_zipper} ->
+          {:ok, tenant_plug_zipper}
+
+        :error ->
+          case move_to_plug(block_zipper, @content_plugs) do
+            {:ok, content_plug_zipper} ->
+              {:ok, Common.add_code(content_plug_zipper, "plug Brando.Plug.Tenant", placement: :before)}
+
+            :error ->
+              {:ok, Common.add_code(block_zipper, "plug Brando.Plug.Tenant")}
+          end
+      end
+    end
+
+    defp move_to_plug(zipper, plugs) do
+      CodeFunction.move_to_function_call_in_current_scope(zipper, :plug, [1, 2], fn zipper ->
+        Enum.any?(plugs, &CodeFunction.argument_equals?(zipper, 0, &1))
+      end)
+    end
+
+    defp install_tenant_migration(igniter) do
+      source =
+        :brando
+        |> Application.app_dir(["priv", "templates", "brando.install", "tenant_migrations"])
+        |> Path.join(@tenant_migration)
+
+      target = Path.join(["priv", "repo", "tenant_migrations", @tenant_migration])
+
+      Igniter.copy_template(igniter, source, target, [], on_exists: :skip)
+    end
+
+    defp add_instructions(igniter, mode, site_key) do
+      site_option = if mode == :single, do: " --site-key=#{site_key}", else: " --site-key=my-site"
+
+      Igniter.add_notice(igniter, """
+      Brando tenancy source setup prepared for `#{mode}` mode.
+
+      Igniter configured `config/brando.exs`, updated recognized browser
+      pipelines, and installed Brando's tenant migration support. It did not
+      infer application-owned tenant tables or change any database.
+
+      Continue in this order:
+
+        1. Review the complete Igniter diff, then run `mix format` and
+           `mix compile --warnings-as-errors`.
+        2. Run `mix brando.upgrade`, review its public registry migrations,
+           and apply the public migrations.
+        3. Create and review tenant migrations for every application content
+           table with `mix brando.gen.tenant_migration migration_name`.
+        4. Run tenant migrations against a disposable environment and verify
+           that every tenant-scoped query has a table.
+        5. Back up the database and media, then provision a new site or run
+           `mix brando.migrate_to_tenant#{site_option}` in a maintenance window.
+        6. Verify routing, authorization, media, assets, environment copy, and
+           rollback before directing production traffic to tenant schemas.
+
+      See `guides/tenancy_and_environments.md` for the complete workflow.
+      """)
+    end
+  end
+end

--- a/lib/mix/tasks/brando.ssg.ex
+++ b/lib/mix/tasks/brando.ssg.ex
@@ -1,25 +1,50 @@
 defmodule Mix.Tasks.Brando.Ssg do
-  @shortdoc "Static site generation"
+  @shortdoc "Build a static site interactively"
 
   @moduledoc """
-  Static site generation
+  Builds a static snapshot through the same callable API used by the publishing
+  worker.
 
       mix brando.ssg
       mix brando.ssg --force
-      mix brando.ssg --site acme --force
+      mix brando.ssg --site acme --environment staging --output ./ssg
+      mix brando.ssg --site acme --dry-run
 
   Options:
 
-    * `--force` - Skip all prompts and run all steps
-    * `--site` - Site key to export in multi-site mode
+    * `--force` - skip confirmation prompts
+    * `--site` - site key in multi-site mode
+    * `--environment` - environment key (defaults to the live environment)
+    * `--output` - output directory (defaults to the application's SSG path)
+    * `--dry-run` - resolve URLs without requesting or writing files
+    * `--no-compile-assets` - use existing release assets without running Vite
 
+  The task remains compatible with non-tenant applications. Tenant builds may
+  target any named environment, whether or not it has a public domain.
   """
+
   use Mix.Task
 
-  @default_host "http://localhost:4000"
+  alias Brando.Assets.SiteAssets
+  alias Brando.Environments.Environment
+  alias Brando.Sites.Site
+  alias Brando.SSG
+  alias Brando.Tenant
+  alias Brando.Tenant.Cache
+  alias Brando.Tenant.Registry
+
+  @switches [
+    force: :boolean,
+    site: :string,
+    environment: :string,
+    output: :string,
+    dry_run: :boolean,
+    compile_assets: :boolean
+  ]
+
+  @impl Mix.Task
   def run(args) do
-    {opts, _} = OptionParser.parse!(args, strict: [force: :boolean, site: :string])
-    force? = Keyword.get(opts, :force, false)
+    {opts, _argv} = OptionParser.parse!(args, strict: @switches)
     Application.put_env(:phoenix, :serve_endpoints, true)
     Application.put_env(:logger, :level, :error)
 
@@ -31,119 +56,100 @@ defmodule Mix.Tasks.Brando.Ssg do
     """)
 
     Mix.Tasks.Run.run([])
-    :inets.start()
-    site = select_tenant!(opts[:site])
 
-    ssg_path = Brando.SSG.get_root_path()
-    File.mkdir_p!(ssg_path)
-    {:ok, ssg_urls} = Brando.SSG.get_urls()
+    {site, environment} = select_context!(opts)
+    output_path = opts[:output] |> Kernel.||(SSG.get_root_path()) |> Path.expand()
 
-    Application.put_env(:brando, :ssg_run, :css)
-    Application.put_env(Brando.config(:otp_app), :hmr, false)
-    Application.put_env(Brando.config(:otp_app), :show_breakpoint_debug, false)
+    asset_set =
+      if site && Tenant.mode() == :multi,
+        do: SiteAssets.active_set(site),
+        else: SiteAssets.active_set()
 
-    uploaded_assets_path = Brando.Assets.SiteAssets.current_root()
+    dry_run? = Keyword.get(opts, :dry_run, false)
 
-    if force? or Mix.shell().yes?("\nGenerate static files?") do
-      copy_or_build_assets(uploaded_assets_path, ssg_path)
+    show_plan(site, environment, asset_set, output_path, dry_run?)
+
+    if Keyword.get(opts, :force, false) or Mix.shell().yes?("\nGenerate this static snapshot?") do
+      maybe_compile_assets(asset_set, opts, dry_run?)
+      result = run_build(site, environment, asset_set, output_path, dry_run?)
+      report_result!(result)
+    else
+      Mix.shell().info("Static generation cancelled.")
     end
-
-    if force? or Mix.shell().yes?("\nGenerate HTML?") do
-      Application.put_env(:brando, :ssg_run, :html)
-
-      for url <- ssg_urls do
-        # we just need to access the url to generate html
-        full_url = Path.join([@default_host, url])
-        :httpc.request(String.to_charlist(full_url))
-      end
-    end
-
-    Application.put_env(:brando, :ssg_run, :media)
-
-    if force? or Mix.shell().yes?("\nCopy media directory?") do
-      media_path = media_path(site)
-      File.cp_r!(media_path, Path.join([ssg_path, "media"]))
-    end
-
-    Application.put_env(:brando, :ssg_run, :normal)
   end
 
-  defp copy_or_build_assets(nil, ssg_path) do
-    static_path = Path.join([File.cwd!(), "priv", "static"])
-
-    IO.write([
-      IO.ANSI.blue(),
-      "* ",
-      IO.ANSI.reset(),
-      "Deleting static files... "
-    ])
-
-    File.rm_rf!(static_path)
-    IO.write([IO.ANSI.green(), "done!\n", IO.ANSI.reset()])
-    # generate static files
-    assets_path = Path.join([File.cwd!(), "assets", "frontend"])
-    vite_path = Path.join([File.cwd!(), "assets", "frontend", "node_modules", ".bin", "vite"])
-
-    IO.write([
-      IO.ANSI.blue(),
-      "* ",
-      IO.ANSI.reset(),
-      "Building static files... "
-    ])
-
-    System.cmd(vite_path, ["build"], cd: assets_path)
-    IO.write([IO.ANSI.green(), "done!\n", IO.ANSI.reset()])
-
-    IO.write([
-      IO.ANSI.blue(),
-      "* ",
-      IO.ANSI.reset(),
-      "Copying static files... "
-    ])
-
-    File.cp_r!(static_path, ssg_path)
-    IO.write([IO.ANSI.green(), "done!\n", IO.ANSI.reset()])
-  end
-
-  defp copy_or_build_assets(uploaded_assets_path, ssg_path) do
-    IO.write([
-      IO.ANSI.blue(),
-      "* ",
-      IO.ANSI.reset(),
-      "Copying active uploaded asset set... "
-    ])
-
-    File.cp_r!(uploaded_assets_path, ssg_path)
-    IO.write([IO.ANSI.green(), "done!\n", IO.ANSI.reset()])
-  end
-
-  defp select_tenant!(requested_site_key) do
-    case Brando.Tenant.mode() do
+  defp select_context!(opts) do
+    case Tenant.mode() do
       :none ->
-        nil
+        {nil, nil}
 
       mode when mode in [:single, :multi] ->
         site_key =
           if mode == :single,
             do: Brando.config(:site_key),
-            else: requested_site_key || Mix.raise("--site is required in multi-site mode")
+            else: opts[:site] || Mix.raise("--site is required in multi-site mode")
 
-        with %Brando.Sites.Site{} = site <- Brando.Tenant.Registry.get_site_by_key(site_key),
-             %Brando.Environments.Environment{} = environment <-
-               Brando.Tenant.Cache.get_live_env(site.key) do
-          Brando.Tenant.put_prefix(Brando.Tenant.prefix(site, environment))
-          site
+        with %Site{} = site <- Registry.get_site_by_key(site_key),
+             %Environment{} = environment <- select_environment(site, opts[:environment]) do
+          {site, environment}
         else
-          _ -> Mix.raise("Could not resolve an active site and live environment for #{inspect(site_key)}")
+          _ -> Mix.raise("Could not resolve site/environment for #{inspect(site_key)}")
         end
     end
   end
 
-  defp media_path(nil), do: Brando.config(:media_path)
+  defp select_environment(site, nil), do: Cache.get_live_env(site.key)
+  defp select_environment(site, key), do: Registry.get_environment_by_key(site, key)
 
-  defp media_path(site) do
-    if Brando.Tenant.mode() == :multi,
-      do: Brando.Tenant.Storage.media_root(site),
-      else: Brando.config(:media_path)
+  defp show_plan(site, environment, asset_set, output_path, dry_run?) do
+    Mix.shell().info("Mode: #{if dry_run?, do: "dry run", else: "build"}")
+    Mix.shell().info("Site: #{if site, do: site.name <> " (" <> site.key <> ")", else: "standalone"}")
+    Mix.shell().info("Environment: #{if environment, do: environment.name, else: "public"}")
+    Mix.shell().info("Assets: #{if asset_set, do: asset_set.name, else: "current release"}")
+    Mix.shell().info("Output: #{output_path}")
+  end
+
+  defp maybe_compile_assets(%{path: _uploaded_set}, _opts, _dry_run?), do: :ok
+  defp maybe_compile_assets(_asset_set, _opts, true), do: :ok
+
+  defp maybe_compile_assets(nil, opts, false) do
+    if Keyword.get(opts, :compile_assets, true) do
+      vite = Path.join([File.cwd!(), "assets", "frontend", "node_modules", ".bin", "vite"])
+      assets_path = Path.join([File.cwd!(), "assets", "frontend"])
+
+      unless File.regular?(vite) do
+        Mix.raise("Vite executable not found at #{vite}; pass --no-compile-assets to use existing priv/static")
+      end
+
+      Mix.shell().info("Building release frontend assets…")
+
+      case System.cmd(vite, ["build"], cd: assets_path, stderr_to_stdout: true) do
+        {_output, 0} -> :ok
+        {output, status} -> Mix.raise("Vite build failed (#{status}):\n#{output}")
+      end
+    end
+  end
+
+  defp run_build(nil, nil, asset_set, output_path, dry_run?) do
+    SSG.build(output_path: output_path, asset_set: asset_set, dry_run: dry_run?)
+  end
+
+  defp run_build(site, environment, asset_set, output_path, dry_run?) do
+    SSG.build(site, environment,
+      output_path: output_path,
+      asset_set: asset_set,
+      dry_run: dry_run?
+    )
+  end
+
+  defp report_result!({:ok, result}) do
+    Mix.shell().info(
+      "Generated #{result.url_count} URLs and #{result.file_count} files (#{result.total_size} bytes) in #{result.output_path}"
+    )
+  end
+
+  defp report_result!({:error, reason, result}) do
+    Enum.each(result.failed_urls, &Mix.shell().error("Failed: #{&1}"))
+    Mix.raise("Static generation failed: #{inspect(reason)}")
   end
 end

--- a/priv/repo/migrations/20260816002400_add_ssg_builds.exs
+++ b/priv/repo/migrations/20260816002400_add_ssg_builds.exs
@@ -1,0 +1,43 @@
+defmodule BrandoIntegration.Repo.Migrations.AddSsgBuilds do
+  use Ecto.Migration
+
+  def change do
+    create table(:ssg_builds, prefix: "public") do
+      add :site_id, references(:sites, prefix: "public", on_delete: :delete_all), null: false
+
+      add :environment_id, references(:environments, prefix: "public", on_delete: :nilify_all)
+      add :environment_name, :text, null: false
+      add :environment_key, :text, null: false
+
+      add :asset_set_id, references(:site_asset_sets, prefix: "public", on_delete: :nilify_all)
+      add :creator_id, references(:users, prefix: "public", on_delete: :nilify_all)
+      add :version, :text, null: false
+      add :build_number, :integer, null: false
+      add :status, :text, null: false, default: "queued"
+      add :build_path, :text, null: false
+      add :build_log, :text, null: false, default: ""
+      add :note, :text
+      add :file_count, :integer, null: false, default: 0
+      add :total_size, :bigint, null: false, default: 0
+      add :url_count, :integer, null: false, default: 0
+      add :processed_urls, :integer, null: false, default: 0
+      add :failed_urls, {:array, :text}, null: false, default: []
+      add :auto_deploy, :boolean, null: false, default: false
+      add :deploy_config, :map, null: false, default: %{}
+      add :preview_token, :text, null: false
+      add :preview_expires_at, :utc_datetime_usec, null: false
+      add :scheduled_at, :utc_datetime_usec
+      add :built_at, :utc_datetime_usec
+      add :deployed_at, :utc_datetime_usec
+      add :pruned_at, :utc_datetime_usec
+
+      timestamps(type: :utc_datetime_usec)
+    end
+
+    create unique_index(:ssg_builds, [:site_id, :build_number], prefix: "public")
+    create unique_index(:ssg_builds, [:preview_token], prefix: "public")
+    create index(:ssg_builds, [:site_id, :inserted_at], prefix: "public")
+    create index(:ssg_builds, [:site_id, :status], prefix: "public")
+    create index(:ssg_builds, [:scheduled_at], prefix: "public")
+  end
+end

--- a/priv/templates/brando.upgrade/migrations/brando_164_add_ssg_builds.exs
+++ b/priv/templates/brando.upgrade/migrations/brando_164_add_ssg_builds.exs
@@ -1,0 +1,43 @@
+defmodule Brando.Repo.Migrations.Brando164AddSsgBuilds do
+  use Ecto.Migration
+
+  def change do
+    create table(:ssg_builds, prefix: "public") do
+      add :site_id, references(:sites, prefix: "public", on_delete: :delete_all), null: false
+
+      add :environment_id, references(:environments, prefix: "public", on_delete: :nilify_all)
+      add :environment_name, :text, null: false
+      add :environment_key, :text, null: false
+
+      add :asset_set_id, references(:site_asset_sets, prefix: "public", on_delete: :nilify_all)
+      add :creator_id, references(:users, prefix: "public", on_delete: :nilify_all)
+      add :version, :text, null: false
+      add :build_number, :integer, null: false
+      add :status, :text, null: false, default: "queued"
+      add :build_path, :text, null: false
+      add :build_log, :text, null: false, default: ""
+      add :note, :text
+      add :file_count, :integer, null: false, default: 0
+      add :total_size, :bigint, null: false, default: 0
+      add :url_count, :integer, null: false, default: 0
+      add :processed_urls, :integer, null: false, default: 0
+      add :failed_urls, {:array, :text}, null: false, default: []
+      add :auto_deploy, :boolean, null: false, default: false
+      add :deploy_config, :map, null: false, default: %{}
+      add :preview_token, :text, null: false
+      add :preview_expires_at, :utc_datetime_usec, null: false
+      add :scheduled_at, :utc_datetime_usec
+      add :built_at, :utc_datetime_usec
+      add :deployed_at, :utc_datetime_usec
+      add :pruned_at, :utc_datetime_usec
+
+      timestamps(type: :utc_datetime_usec)
+    end
+
+    create unique_index(:ssg_builds, [:site_id, :build_number], prefix: "public")
+    create unique_index(:ssg_builds, [:preview_token], prefix: "public")
+    create index(:ssg_builds, [:site_id, :inserted_at], prefix: "public")
+    create index(:ssg_builds, [:site_id, :status], prefix: "public")
+    create index(:ssg_builds, [:scheduled_at], prefix: "public")
+  end
+end

--- a/test/brando/environments/copy_postgres_integration_test.exs
+++ b/test/brando/environments/copy_postgres_integration_test.exs
@@ -2,8 +2,10 @@ defmodule Brando.Environments.CopyPostgresIntegrationTest do
   use ExUnit.Case, async: false
 
   alias Brando.Environments
+  alias Brando.IntegrationRepo
   alias Brando.Tenant.Cache
   alias Brando.Tenant.Registry
+  alias Ecto.Adapters.SQL
 
   defmodule Repo do
     use Ecto.Repo,
@@ -12,28 +14,7 @@ defmodule Brando.Environments.CopyPostgresIntegrationTest do
   end
 
   setup_all do
-    integration_config = BrandoIntegration.Repo.config()
-
-    repo_options =
-      integration_config
-      |> Keyword.take([:database, :hostname, :password, :port, :socket_options, :ssl, :username])
-      |> Keyword.merge(pool: DBConnection.ConnectionPool, pool_size: 3)
-
-    previous_repo_config = Application.fetch_env(:brando, Repo)
-    Application.put_env(:brando, Repo, repo_options)
-    {:ok, repo} = Repo.start_link()
-
-    on_exit(fn ->
-      try do
-        GenServer.stop(repo)
-      catch
-        :exit, _ -> :ok
-      end
-
-      restore_env(Repo, previous_repo_config)
-    end)
-
-    :ok
+    IntegrationRepo.start(Repo)
   end
 
   setup do
@@ -46,7 +27,7 @@ defmodule Brando.Environments.CopyPostgresIntegrationTest do
     site_key = "copyint#{unique}"
 
     %{rows: [[site_id]]} =
-      Ecto.Adapters.SQL.query!(
+      SQL.query!(
         Repo,
         """
         INSERT INTO public.sites
@@ -59,7 +40,7 @@ defmodule Brando.Environments.CopyPostgresIntegrationTest do
       )
 
     for {name, key, live} <- [{"Source", "source", true}, {"Target", "target", false}] do
-      Ecto.Adapters.SQL.query!(
+      SQL.query!(
         Repo,
         """
         INSERT INTO public.environments
@@ -80,9 +61,9 @@ defmodule Brando.Environments.CopyPostgresIntegrationTest do
 
     on_exit(fn ->
       drop_site_schemas(site_key)
-      Ecto.Adapters.SQL.query!(Repo, "DELETE FROM public.sites WHERE id = $1", [site_id])
-      restore_env(:repo_module, previous_repo)
-      restore_env(:environment_schema_cloner, previous_cloner)
+      SQL.query!(Repo, "DELETE FROM public.sites WHERE id = $1", [site_id])
+      IntegrationRepo.restore_env(:repo_module, previous_repo)
+      IntegrationRepo.restore_env(:environment_schema_cloner, previous_cloner)
       Cache.clear()
     end)
 
@@ -104,16 +85,16 @@ defmodule Brando.Environments.CopyPostgresIntegrationTest do
   end
 
   defp create_records_schema(prefix, names) do
-    Ecto.Adapters.SQL.query!(Repo, ~s|CREATE SCHEMA "#{prefix}"|, [])
+    SQL.query!(Repo, ~s|CREATE SCHEMA "#{prefix}"|, [])
 
-    Ecto.Adapters.SQL.query!(
+    SQL.query!(
       Repo,
       ~s|CREATE TABLE "#{prefix}".records (id serial PRIMARY KEY, name text NOT NULL)|,
       []
     )
 
     Enum.each(names, fn name ->
-      Ecto.Adapters.SQL.query!(
+      SQL.query!(
         Repo,
         ~s|INSERT INTO "#{prefix}".records (name) VALUES ($1)|,
         [name]
@@ -122,7 +103,7 @@ defmodule Brando.Environments.CopyPostgresIntegrationTest do
   end
 
   defp records_in(prefix) do
-    Ecto.Adapters.SQL.query!(
+    SQL.query!(
       Repo,
       ~s|SELECT name FROM "#{prefix}".records ORDER BY id|,
       []
@@ -131,17 +112,14 @@ defmodule Brando.Environments.CopyPostgresIntegrationTest do
 
   defp drop_site_schemas(site_key) do
     %{rows: rows} =
-      Ecto.Adapters.SQL.query!(
+      SQL.query!(
         Repo,
         "SELECT nspname FROM pg_namespace WHERE nspname LIKE $1",
         ["tenant_#{site_key}_%"]
       )
 
     Enum.each(rows, fn [schema] ->
-      Ecto.Adapters.SQL.query!(Repo, ~s|DROP SCHEMA "#{schema}" CASCADE|, [])
+      SQL.query!(Repo, ~s|DROP SCHEMA "#{schema}" CASCADE|, [])
     end)
   end
-
-  defp restore_env(key, {:ok, value}), do: Application.put_env(:brando, key, value)
-  defp restore_env(key, :error), do: Application.delete_env(:brando, key)
 end

--- a/test/brando/plug/tenant_test.exs
+++ b/test/brando/plug/tenant_test.exs
@@ -5,6 +5,7 @@ defmodule Brando.Plug.TenantTest do
   alias Brando.Tenant
   alias Brando.Tenant.Cache
   alias Brando.Tenant.Registry
+  alias Brando.SSG.Context
 
   @site_attrs %{
     name: "Acme",
@@ -79,6 +80,43 @@ defmodule Brando.Plug.TenantTest do
     assert conn.halted
     assert conn.status == 404
     assert Tenant.current_prefix() == nil
+  end
+
+  test "a signed SSG header resolves a domainless working environment", context do
+    {:ok, staging} =
+      Registry.create_environment(context.site, %{
+        name: "Staging",
+        key: "staging",
+        live: false
+      })
+
+    token = Context.sign(context.site, staging)
+
+    conn =
+      :get
+      |> Plug.Test.conn("https://unknown.test/")
+      |> Plug.Conn.put_req_header(Context.header(), token)
+      |> Map.put(:host, "unknown.test")
+      |> Brando.Plug.Tenant.call([])
+
+    assert conn.assigns.current_site.id == context.site.id
+    assert conn.assigns.current_environment.id == staging.id
+    assert conn.assigns.tenant_prefix == "tenant_acme_staging"
+    refute conn.halted
+  end
+
+  test "a tampered SSG header cannot bypass unknown-host rejection", context do
+    token = Context.sign(context.site, context.environment) <> "tampered"
+
+    conn =
+      :get
+      |> Plug.Test.conn("https://unknown.test/")
+      |> Plug.Conn.put_req_header(Context.header(), token)
+      |> Map.put(:host, "unknown.test")
+      |> Brando.Plug.Tenant.call([])
+
+    assert conn.halted
+    assert conn.status == 404
   end
 
   test "suspended sites are no longer served by their domains", context do

--- a/test/brando/plug/tenant_test.exs
+++ b/test/brando/plug/tenant_test.exs
@@ -2,10 +2,10 @@ defmodule Brando.Plug.TenantTest do
   use ExUnit.Case, async: false
   use Brando.ConnCase
 
+  alias Brando.SSG.Context
   alias Brando.Tenant
   alias Brando.Tenant.Cache
   alias Brando.Tenant.Registry
-  alias Brando.SSG.Context
 
   @site_attrs %{
     name: "Acme",

--- a/test/brando/sites/site_test.exs
+++ b/test/brando/sites/site_test.exs
@@ -48,4 +48,31 @@ defmodule Brando.Sites.SiteTest do
       assert changeset.errors[:languages]
     end
   end
+
+  test "validates static deployment targets and optional notification URLs" do
+    missing_target = Site.changeset(%{@valid_attrs | deploy_config: %{strategy: :s3}})
+    refute missing_target.valid?
+
+    invalid_webhook =
+      Site.changeset(%{
+        @valid_attrs
+        | deploy_config: %{
+            strategy: :s3,
+            target: "s3://acme-site",
+            webhook_url: "javascript:alert(1)"
+          }
+      })
+
+    refute invalid_webhook.valid?
+
+    assert Site.changeset(%{
+             @valid_attrs
+             | deploy_config: %{
+                 strategy: :s3,
+                 target: "s3://acme-site/static",
+                 webhook_url: "https://hooks.example.test/published",
+                 retention_count: 25
+               }
+           }).valid?
+  end
 end

--- a/test/brando/ssg_builds_test.exs
+++ b/test/brando/ssg_builds_test.exs
@@ -1,0 +1,260 @@
+defmodule Brando.SSGBuildsTest do
+  use Brando.ConnCase
+
+  alias Brando.SSG.Builds
+  alias Brando.SSG.Deploy
+  alias Brando.Tenant.Cache
+  alias Brando.Tenant.Registry
+  alias Brando.Worker.SSGBuild
+
+  defmodule SuccessfulBuilder do
+    def build(_site, _environment, opts) do
+      File.mkdir_p!(opts[:output_path])
+      File.write!(Path.join(opts[:output_path], "index.html"), "built")
+
+      {:ok,
+       %{
+         file_count: 1,
+         total_size: 5,
+         url_count: 2,
+         processed_urls: 2,
+         failed_urls: []
+       }}
+    end
+  end
+
+  defmodule FailedBuilder do
+    def build(_site, _environment, _opts) do
+      {:error, :url_failures,
+       %{
+         file_count: 1,
+         total_size: 5,
+         url_count: 2,
+         processed_urls: 2,
+         failed_urls: ["/broken (HTTP 500)"]
+       }}
+    end
+  end
+
+  setup do
+    root = Path.join(System.tmp_dir!(), "brando-ssg-builds-#{System.unique_integer([:positive])}")
+    put_test_env(:tenancy_mode, :multi)
+    put_test_env(:sites_path, Path.join(root, "sites"))
+    put_test_env(:media_path, Path.join(root, "media"))
+    Cache.clear()
+
+    on_exit(fn ->
+      File.rm_rf(root)
+      Cache.clear()
+    end)
+
+    {:ok, site} =
+      Registry.create_site(%{
+        name: "Static Acme",
+        key: "static-acme-#{System.unique_integer([:positive])}",
+        languages: ["en"],
+        default_language: "en",
+        status: :active,
+        delivery_mode: :static,
+        deploy_config: %{
+          strategy: :rsync,
+          target: "deploy@example.test:/srv/www",
+          retention_count: 2
+        }
+      })
+
+    {:ok, environment} =
+      Registry.create_environment(site, %{
+        name: "Production",
+        key: "production",
+        live: true
+      })
+
+    %{site: Registry.get_site(site.id), environment: environment, root: root}
+  end
+
+  test "assigns monotonic versions and executes the successful worker lifecycle", context do
+    first = request_build(context.site, context.environment)
+    second = request_build(context.site, context.environment)
+
+    assert first.version == "v1"
+    assert second.version == "v2"
+    assert first.status == :queued
+    assert second.build_path == Path.join(Builds.build_root(context.site), "v2")
+
+    put_test_env(:ssg_builder, SuccessfulBuilder)
+    assert :ok = perform_job(SSGBuild, %{"build_id" => first.id})
+
+    ready = Builds.get_build(first.id)
+    assert ready.status == :ready
+    assert ready.file_count == 1
+    assert ready.processed_urls == 2
+    assert ready.built_at
+    assert ready.build_log =~ "Build completed"
+    assert File.read!(Path.join(ready.build_path, "index.html")) == "built"
+  end
+
+  test "persists failed URLs and a terminal failure log", context do
+    build = request_build(context.site, context.environment)
+    put_test_env(:ssg_builder, FailedBuilder)
+
+    assert {:error, :url_failures} = perform_job(SSGBuild, %{"build_id" => build.id})
+
+    failed = Builds.get_build(build.id)
+    assert failed.status == :failed
+    assert failed.failed_urls == ["/broken (HTTP 500)"]
+    assert failed.build_log =~ "Build failed"
+  end
+
+  test "schedules the Oban job for a future build", context do
+    scheduled_at = DateTime.add(DateTime.utc_now(), 3_600, :second)
+    build = request_build(context.site, context.environment, scheduled_at: scheduled_at)
+
+    assert DateTime.diff(build.scheduled_at, scheduled_at, :second) == 0
+    assert [job] = all_enqueued(worker: SSGBuild, args: %{"build_id" => build.id})
+    assert abs(DateTime.diff(job.scheduled_at, scheduled_at, :second)) <= 1
+  end
+
+  test "keeps a successful artifact ready when automatic deployment fails", context do
+    {:ok, site} = Registry.update_site(context.site, %{deploy_config: %{strategy: nil, target: nil}})
+    build = request_build(site, context.environment, auto_deploy: true)
+    put_test_env(:ssg_builder, SuccessfulBuilder)
+
+    assert {:error, {:deploy_failed, :deploy_strategy_not_configured}} =
+             perform_job(SSGBuild, %{"build_id" => build.id})
+
+    ready = Builds.get_build(build.id)
+    assert ready.status == :ready
+    assert ready.build_log =~ "Automatic deployment failed"
+  end
+
+  test "deploys a build, archives its predecessor, and rolls back safely", context do
+    first = ready_build(context.site, context.environment)
+    second = ready_build(context.site, context.environment)
+    test_pid = self()
+
+    runner = fn command, args, _opts ->
+      send(test_pid, {:command, command, args})
+      {"deployed", 0}
+    end
+
+    assert {:ok, deployed_first} = Deploy.deploy(first, runner: runner)
+    assert deployed_first.status == :deployed
+    assert_receive {:command, "rsync", ["-az", "--delete", _, "deploy@example.test:/srv/www"]}
+
+    assert {:ok, deployed_second} = Deploy.deploy(second, runner: runner)
+    assert deployed_second.status == :deployed
+    assert Builds.get_build(first.id).status == :archived
+
+    assert {:ok, rolled_back} = Deploy.rollback(context.site, first, runner: runner)
+    assert rolled_back.status == :deployed
+    assert Builds.get_build(second.id).status == :archived
+  end
+
+  test "S3 deployment removes stale target keys before uploading the artifact", context do
+    build = ready_build(context.site, context.environment)
+
+    {:ok, build} =
+      Builds.update(build, %{
+        deploy_config: %{
+          "strategy" => "s3",
+          "target" => "s3://static-bucket/sites/acme",
+          "retention_count" => 2
+        }
+      })
+
+    test_pid = self()
+
+    request = fn
+      %ExAws.Operation.S3{http_method: :get} ->
+        {:ok,
+         %{
+           body: %{
+             contents: [%{key: "sites/acme/stale.js"}],
+             is_truncated: "false"
+           }
+         }}
+
+      %ExAws.Operation.S3DeleteAllObjects{objects: objects} ->
+        send(test_pid, {:deleted, objects})
+        {:ok, %{}}
+
+      %ExAws.Operation.S3{http_method: :put, path: path} ->
+        send(test_pid, {:uploaded, path})
+        {:ok, %{}}
+    end
+
+    assert {:ok, deployed} = Deploy.deploy(build, s3_request: request)
+    assert deployed.status == :deployed
+    assert_receive {:deleted, ["sites/acme/stale.js"]}
+    assert_receive {:uploaded, "sites/acme/index.html"}
+  end
+
+  test "serves ready previews and rejects pruned artifacts", context do
+    build = ready_build(context.site, context.environment)
+
+    conn = get(Phoenix.ConnTest.build_conn(), "/__ssg_preview__/#{build.preview_token}/")
+    assert response(conn, 200) == build.version
+    assert get_resp_header(conn, "cache-control") == ["private, no-store"]
+
+    {:ok, _pruned} = Builds.update(build, %{pruned_at: DateTime.utc_now()})
+
+    missing = get(Phoenix.ConnTest.build_conn(), "/__ssg_preview__/#{build.preview_token}/")
+    assert response(missing, 404) == "Static preview not found"
+  end
+
+  test "retains environment history after the source environment is deleted", context do
+    build = request_build(context.site, context.environment)
+    assert {:ok, _environment} = Registry.delete_environment(context.environment)
+
+    historical = Builds.get_build(build.id)
+    assert historical.environment == nil
+    assert historical.environment_name == "Production"
+    assert historical.environment_key == "production"
+
+    assert {:cancel, :environment_not_found} = perform_job(SSGBuild, %{"build_id" => build.id})
+    assert Builds.get_build(build.id).status == :failed
+  end
+
+  test "prunes old artifact directories but retains build history", context do
+    first = ready_build(context.site, context.environment)
+    second = ready_build(context.site, context.environment)
+    newest = ready_build(context.site, context.environment)
+
+    assert {:ok, pruned} = Deploy.prune(context.site, 1)
+    assert Enum.map(pruned, & &1.id) == [second.id, first.id]
+    refute File.exists?(first.build_path)
+    refute File.exists?(second.build_path)
+    assert File.exists?(newest.build_path)
+    assert Builds.get_build(first.id).pruned_at
+  end
+
+  test "rejects lifecycle requests for dynamically delivered sites", context do
+    {:ok, dynamic_site} = Registry.update_site(context.site, %{delivery_mode: :dynamic})
+
+    assert {:error, :dynamic_site} =
+             Builds.request_build(dynamic_site, context.environment)
+  end
+
+  test "rejects lifecycle requests for inactive sites", context do
+    {:ok, suspended_site} = Registry.update_site(context.site, %{status: :suspended})
+
+    assert {:error, :inactive_site} =
+             Builds.request_build(suspended_site, context.environment)
+  end
+
+  defp request_build(site, environment, opts \\ []) do
+    Oban.Testing.with_testing_mode(:manual, fn ->
+      assert {:ok, build} = Builds.request_build(site, environment, opts)
+      build
+    end)
+  end
+
+  defp ready_build(site, environment) do
+    build = request_build(site, environment)
+    File.mkdir_p!(build.build_path)
+    File.write!(Path.join(build.build_path, "index.html"), build.version)
+    {:ok, ready} = Builds.update(build, %{status: :ready, built_at: DateTime.utc_now()})
+    ready
+  end
+end

--- a/test/brando/ssg_test.exs
+++ b/test/brando/ssg_test.exs
@@ -1,0 +1,123 @@
+defmodule Brando.SSGTest do
+  use Brando.ConnCase
+
+  alias Brando.SSG
+
+  defmodule Fixture do
+    import Brando.SSG
+
+    urls :pages do
+      ["/", "/about", "/feed.xml", "https://example.com/absolute"]
+    end
+  end
+
+  setup do
+    root = Path.join(System.tmp_dir!(), "brando-ssg-#{System.unique_integer([:positive])}")
+    static_path = Path.join(root, "static")
+    media_path = Path.join(root, "media")
+    output_path = Path.join(root, "output")
+
+    File.mkdir_p!(Path.join(static_path, "assets"))
+    File.write!(Path.join([static_path, "assets", "app.css"]), "body{}")
+    File.mkdir_p!(Path.join(media_path, "images"))
+    File.write!(Path.join([media_path, "images", "logo.txt"]), "logo")
+
+    put_test_env(:tenancy_mode, :none)
+    put_test_env(:media_path, media_path)
+
+    on_exit(fn -> File.rm_rf(root) end)
+
+    %{static_path: static_path, media_path: media_path, output_path: output_path}
+  end
+
+  test "builds declared URLs, release assets, and media through the callable API", context do
+    test_pid = self()
+
+    fetcher = fn url, opts ->
+      send(test_pid, {:fetched, URI.parse(url).path, opts[:headers]})
+      {:ok, %{status: 200, body: "<main>#{URI.parse(url).path}</main>"}}
+    end
+
+    assert {:ok, result} =
+             SSG.build(
+               output_path: context.output_path,
+               static_path: context.static_path,
+               media_path: context.media_path,
+               ssg_module: Fixture,
+               fetcher: fetcher
+             )
+
+    assert result.url_count == 4
+    assert result.processed_urls == 4
+    assert result.failed_urls == []
+    assert result.file_count == 6
+    assert result.total_size > 0
+
+    assert File.read!(Path.join(context.output_path, "index.html")) =~ "<main>/</main>"
+    assert File.read!(Path.join([context.output_path, "about", "index.html"])) =~ "/about"
+    assert File.read!(Path.join(context.output_path, "feed.xml")) =~ "/feed.xml"
+    assert File.read!(Path.join([context.output_path, "absolute", "index.html"])) =~ "/absolute"
+    assert File.read!(Path.join([context.output_path, "assets", "app.css"])) == "body{}"
+    assert File.read!(Path.join([context.output_path, "media", "images", "logo.txt"])) == "logo"
+
+    assert_receive {:fetched, "/", []}
+    assert_receive {:fetched, "/about", []}
+  end
+
+  test "returns failed URLs with partial build statistics", context do
+    fetcher = fn url, _opts ->
+      if URI.parse(url).path == "/about",
+        do: {:ok, %{status: 503, body: "unavailable"}},
+        else: {:ok, %{status: 200, body: "ok"}}
+    end
+
+    assert {:error, :url_failures, result} =
+             SSG.build(
+               output_path: context.output_path,
+               static_path: context.static_path,
+               media_path: context.media_path,
+               ssg_module: Fixture,
+               fetcher: fetcher
+             )
+
+    assert result.processed_urls == 4
+    assert result.failed_urls == ["/about (HTTP 503)"]
+    refute File.exists?(Path.join([context.output_path, "about", "index.html"]))
+    assert File.exists?(Path.join(context.output_path, "index.html"))
+  end
+
+  test "dry run resolves URLs without touching the filesystem", context do
+    assert {:ok, result} =
+             SSG.build(
+               output_path: context.output_path,
+               static_path: context.static_path,
+               media_path: context.media_path,
+               ssg_module: Fixture,
+               dry_run: true,
+               fetcher: fn _url, _opts -> flunk("dry run must not fetch") end
+             )
+
+    assert result.url_count == 4
+    assert result.file_count == 0
+    refute File.exists?(context.output_path)
+  end
+
+  test "rejects symlinks in copied assets", context do
+    outside = Path.join(context.output_path <> "-outside", "secret.txt")
+    File.mkdir_p!(Path.dirname(outside))
+    File.write!(outside, "secret")
+    File.ln_s!(outside, Path.join(context.static_path, "linked-secret.txt"))
+
+    assert {:error, {:unsupported_source_file, linked_path}, _result} =
+             SSG.build(
+               output_path: context.output_path,
+               static_path: context.static_path,
+               media_path: context.media_path,
+               ssg_module: Fixture,
+               fetcher: fn _url, _opts -> {:ok, %{status: 200, body: "ok"}} end
+             )
+
+    assert linked_path == Path.join(context.static_path, "linked-secret.txt")
+    refute File.exists?(Path.join(context.output_path, "linked-secret.txt"))
+  end
+end

--- a/test/brando/tenant_public_data_migrator_postgres_test.exs
+++ b/test/brando/tenant_public_data_migrator_postgres_test.exs
@@ -1,6 +1,7 @@
 defmodule Brando.TenantPublicDataMigratorPostgresTest do
   use ExUnit.Case, async: false
 
+  alias Brando.IntegrationRepo
   alias Brando.Tenant.PublicDataMigrator.Postgres
 
   defmodule Repo do
@@ -10,28 +11,7 @@ defmodule Brando.TenantPublicDataMigratorPostgresTest do
   end
 
   setup_all do
-    integration_config = BrandoIntegration.Repo.config()
-
-    repo_options =
-      integration_config
-      |> Keyword.take([:database, :hostname, :password, :port, :socket_options, :ssl, :username])
-      |> Keyword.merge(pool: DBConnection.ConnectionPool, pool_size: 3)
-
-    previous_repo_config = Application.fetch_env(:brando, Repo)
-    Application.put_env(:brando, Repo, repo_options)
-    {:ok, repo} = Repo.start_link()
-
-    on_exit(fn ->
-      try do
-        GenServer.stop(repo)
-      catch
-        :exit, _ -> :ok
-      end
-
-      restore_env(Repo, previous_repo_config)
-    end)
-
-    :ok
+    IntegrationRepo.start(Repo)
   end
 
   setup do
@@ -55,7 +35,7 @@ defmodule Brando.TenantPublicDataMigratorPostgresTest do
     on_exit(fn ->
       Ecto.Adapters.SQL.query!(Repo, ~s|DROP SCHEMA IF EXISTS "#{target}" CASCADE|, [])
       Ecto.Adapters.SQL.query!(Repo, ~s|DROP TABLE IF EXISTS public."#{table}" CASCADE|, [])
-      restore_env(:repo_module, previous_repo)
+      IntegrationRepo.restore_env(:repo_module, previous_repo)
     end)
 
     %{table: table, target: target}
@@ -71,7 +51,4 @@ defmodule Brando.TenantPublicDataMigratorPostgresTest do
                []
              )
   end
-
-  defp restore_env(key, {:ok, value}), do: Application.put_env(:brando, key, value)
-  defp restore_env(key, :error), do: Application.delete_env(:brando, key)
 end

--- a/test/brando_admin/live/publishing_live_test.exs
+++ b/test/brando_admin/live/publishing_live_test.exs
@@ -1,0 +1,113 @@
+defmodule BrandoAdmin.Sites.PublishingLiveTest do
+  use Brando.LiveCase
+
+  alias Brando.SSG.Builds
+  alias Brando.Tenant.Cache
+  alias Brando.Tenant.Registry
+
+  setup do
+    root = Path.join(System.tmp_dir!(), "brando-publishing-live-#{System.unique_integer([:positive])}")
+    put_test_env(:tenancy_mode, :multi)
+    put_test_env(:sites_path, Path.join(root, "sites"))
+    put_test_env(:media_path, Path.join(root, "media"))
+    Cache.clear()
+
+    on_exit(fn ->
+      File.rm_rf(root)
+      Cache.clear()
+    end)
+
+    {:ok, site} =
+      Registry.create_site(%{
+        name: "Publishing Acme",
+        key: "publishing-acme-#{System.unique_integer([:positive])}",
+        languages: ["en"],
+        default_language: "en",
+        status: :active,
+        delivery_mode: :static,
+        deploy_config: %{strategy: :rsync, target: "deploy@example.test:/srv/www"}
+      })
+
+    {:ok, environment} =
+      Registry.create_environment(site, %{
+        name: "Production",
+        key: "production",
+        live: true
+      })
+
+    %{site: Registry.get_site(site.id), environment: environment}
+  end
+
+  test "queues and renders a static build from the selected environment", context do
+    {:ok, view, html} = live(context.conn, "/admin/config/publishing")
+
+    assert html =~ "Publishing"
+    assert html =~ "Publishing Acme"
+    assert has_element?(view, "#build-static-site")
+
+    Oban.Testing.with_testing_mode(:manual, fn ->
+      view
+      |> form("#build-static-site",
+        build: %{
+          environment_id: context.environment.id,
+          note: "Campaign release"
+        }
+      )
+      |> render_submit()
+    end)
+
+    assert [build] = Builds.list_builds(context.site)
+    assert build.version == "v1"
+    assert build.note == "Campaign release"
+    assert build.environment_id == context.environment.id
+    assert has_element?(view, "#ssg-build-#{build.id}", "Campaign release")
+  end
+
+  test "hides publishing from dynamically delivered sites", context do
+    {:ok, _dynamic_site} = Registry.update_site(context.site, %{delivery_mode: :dynamic})
+    Cache.clear()
+
+    assert {:error, {:redirect, %{to: "/admin"}}} =
+             live(context.conn, "/admin/config/publishing")
+  end
+
+  test "updates the static deployment configuration", context do
+    {:ok, view, _html} = live(context.conn, "/admin/config/publishing")
+
+    view
+    |> form("#static-deploy-config",
+      deploy: %{
+        strategy: "s3",
+        target: "s3://publishing-site/releases",
+        cdn_url: "https://static.example.test",
+        webhook_url: "https://hooks.example.test/published",
+        retention_count: "20",
+        auto_deploy: "true"
+      }
+    )
+    |> render_submit()
+
+    updated = Registry.get_site(context.site.id)
+    assert updated.deploy_config.strategy == :s3
+    assert updated.deploy_config.target == "s3://publishing-site/releases"
+    assert updated.deploy_config.auto_deploy
+    assert updated.deploy_config.retention_count == 20
+  end
+
+  test "renders nested deployment validation errors without crashing", context do
+    {:ok, view, _html} = live(context.conn, "/admin/config/publishing")
+
+    assert render_submit(form(view, "#static-deploy-config"), %{
+             "deploy" => %{
+               "strategy" => "s3",
+               "target" => "not-an-s3-target",
+               "webhook_url" => "javascript:alert(1)",
+               "retention_count" => "10"
+             }
+           })
+
+    unchanged = Registry.get_site(context.site.id)
+    assert unchanged.deploy_config.strategy == :rsync
+    assert unchanged.deploy_config.target == "deploy@example.test:/srv/www"
+  end
+end

--- a/test/brando_admin/menu_test.exs
+++ b/test/brando_admin/menu_test.exs
@@ -55,4 +55,18 @@ defmodule BrandoAdmin.MenuTest do
              }
            ]
   end
+
+  test "publishing is only present for the selected static site" do
+    static_menu = BrandoAdmin.Menu.get_menu(nil, %Brando.Sites.Site{delivery_mode: :static})
+    dynamic_menu = BrandoAdmin.Menu.get_menu(nil, %Brando.Sites.Site{delivery_mode: :dynamic})
+
+    assert menu_urls(static_menu) =~ "/admin/config/publishing"
+    refute menu_urls(dynamic_menu) =~ "/admin/config/publishing"
+  end
+
+  defp menu_urls(menus) do
+    menus
+    |> Enum.flat_map(fn menu -> List.wrap(menu[:url]) ++ List.wrap(menu[:items] && menu_urls(menu.items)) end)
+    |> Enum.join(" ")
+  end
 end

--- a/test/mix/tasks/brando/brando.install_test.exs
+++ b/test/mix/tasks/brando/brando.install_test.exs
@@ -45,6 +45,7 @@ defmodule Mix.Tasks.Brando.GenerateTest do
     assert_file("lib/brando_web/villain/parser.ex")
     assert File.dir?("priv/repo/tenant_migrations")
     assert_file("priv/repo/migrations/20260816002300_brando_163_add_shared_content_library.exs")
+    assert_file("priv/repo/migrations/20260816002400_brando_164_add_ssg_builds.exs")
     assert_file("priv/repo/tenant_migrations/20260816002300_add_shared_content_library.exs")
 
     assert_file("config/runtime.exs", fn file ->

--- a/test/mix/tasks/brando_gen_tenant_migration_test.exs
+++ b/test/mix/tasks/brando_gen_tenant_migration_test.exs
@@ -7,7 +7,7 @@ defmodule Mix.Tasks.Brando.GenTenantMigrationTest do
 
   test "generates migrations in the tenant migration path" do
     in_tmp("tenant_migration_generator", fn ->
-      path = Path.expand("priv/repo/tenant_migrations")
+      path = Path.join(File.cwd!(), "priv/repo/tenant_migrations")
 
       Mix.Tasks.Brando.Gen.TenantMigration.run([
         "add_projects",

--- a/test/mix/tasks/brando_setup_tenancy_test.exs
+++ b/test/mix/tasks/brando_setup_tenancy_test.exs
@@ -1,0 +1,168 @@
+defmodule Mix.Tasks.BrandoSetupTenancyTest do
+  use ExUnit.Case, async: true
+
+  import Igniter.Test
+
+  alias Mix.Tasks.Brando.Setup.Tenancy
+
+  @config_path "config/brando.exs"
+  @router_path "lib/legacy_app_web/router.ex"
+  @tenant_migration_path "priv/repo/tenant_migrations/20260816002300_add_shared_content_library.exs"
+
+  @config """
+  import Config
+
+  config :brando,
+    app_module: LegacyApp,
+    repo_module: LegacyApp.Repo
+  """
+
+  @router """
+  defmodule LegacyAppWeb.Router do
+    use LegacyAppWeb, :router
+
+    pipeline :browser do
+      plug :accepts, ["html"]
+      plug :fetch_session
+      plug :put_secure_browser_headers
+      plug Brando.Plug.Identity
+      plug Brando.Plug.Navigation, key: "main", as: :navigation
+    end
+
+    pipeline :browser_api do
+      plug :accepts, ["html"]
+      plug :fetch_session
+      plug :put_secure_browser_headers
+    end
+  end
+  """
+
+  test "configures single-site tenancy and recognized browser pipelines" do
+    igniter = setup_tenancy(["--mode", "single", "--site-key", "legacy-site"])
+    config = source(igniter, @config_path)
+    router = source(igniter, @router_path)
+
+    assert config =~ "tenancy_mode: :single"
+    assert config =~ ~s(site_key: "legacy-site")
+    assert count(router, "plug(Brando.Plug.Tenant)") == 2
+    assert before?(router, "plug(Brando.Plug.Tenant)", "plug(Brando.Plug.Identity)")
+
+    assert_creates(igniter, @tenant_migration_path, fn migration ->
+      assert migration =~ "defmodule Brando.Repo.TenantMigrations.AddSharedContentLibrary"
+    end)
+
+    assert_has_notice(igniter, &String.contains?(&1, "infer application-owned tenant tables"))
+    assert_has_notice(igniter, &String.contains?(&1, "mix brando.migrate_to_tenant --site-key=legacy-site"))
+  end
+
+  test "configures multi-site tenancy without a site key" do
+    existing_single_config =
+      @config <>
+        """
+
+        config :brando,
+          tenancy_mode: :single,
+          site_key: "legacy-site"
+        """
+
+    igniter = setup_tenancy(["--mode", "multi"], %{@config_path => existing_single_config})
+    config = source(igniter, @config_path)
+
+    assert config =~ "tenancy_mode: :multi"
+    refute config =~ "site_key:"
+    assert_has_notice(igniter, &String.contains?(&1, "prepared for `multi` mode"))
+    assert_has_notice(igniter, &String.contains?(&1, "mix brando.migrate_to_tenant --site-key=my-site"))
+  end
+
+  test "is idempotent" do
+    second_pass =
+      ["--mode", "single", "--site-key", "legacy-site"]
+      |> setup_tenancy()
+      |> apply_igniter!()
+      |> include_test_files()
+      |> run_task(["--mode", "single", "--site-key", "legacy-site"])
+
+    assert_unchanged(second_pass)
+  end
+
+  test "warns when no Phoenix router can be found" do
+    igniter =
+      [app_name: :legacy_app, files: %{@config_path => @config}]
+      |> test_project_with_files()
+      |> run_task(["--mode", "multi"])
+
+    assert_has_warning(igniter, &String.contains?(&1, "No Phoenix router could be found"))
+  end
+
+  test "warns when a router has no browser pipeline" do
+    router = """
+    defmodule LegacyAppWeb.Router do
+      use LegacyAppWeb, :router
+
+      pipeline :api do
+        plug :accepts, ["json"]
+      end
+    end
+    """
+
+    igniter = setup_tenancy(["--mode", "multi"], %{@router_path => router})
+
+    assert_has_warning(igniter, &String.contains?(&1, "has no `:browser` pipeline"))
+  end
+
+  test "rejects incomplete and contradictory tenancy options" do
+    missing_key = setup_tenancy(["--mode", "single"])
+    invalid_key = setup_tenancy(["--mode", "single", "--site-key", "Not Valid"])
+    multi_key = setup_tenancy(["--mode", "multi", "--site-key", "legacy-site"])
+    invalid_mode = setup_tenancy(["--mode", "none"])
+
+    assert_has_issue(missing_key, &String.contains?(&1, "--site-key is required"))
+    assert_has_issue(invalid_key, &String.contains?(&1, "lowercase, URL-safe key"))
+    assert_has_issue(multi_key, &String.contains?(&1, "can only be used with --mode single"))
+    assert_has_issue(invalid_mode, &String.contains?(&1, "expected single or multi"))
+  end
+
+  defp setup_tenancy(argv, overrides \\ %{}) do
+    files =
+      %{
+        @config_path => @config,
+        @router_path => @router
+      }
+      |> Map.merge(overrides)
+
+    [
+      app_name: :legacy_app,
+      files: files
+    ]
+    |> test_project_with_files()
+    |> run_task(argv)
+  end
+
+  defp test_project_with_files(opts) do
+    opts
+    |> test_project()
+    |> include_test_files()
+  end
+
+  defp include_test_files(igniter) do
+    Enum.reduce(Map.keys(igniter.assigns.test_files), igniter, fn path, igniter ->
+      Igniter.include_existing_file(igniter, path)
+    end)
+  end
+
+  defp run_task(igniter, argv) do
+    Igniter.Mix.Task.configure_and_run(igniter, Tenancy, argv)
+  end
+
+  defp source(igniter, path) do
+    igniter.rewrite
+    |> Rewrite.source!(path)
+    |> Rewrite.Source.get(:content)
+  end
+
+  defp count(content, pattern), do: content |> String.split(pattern) |> length() |> Kernel.-(1)
+
+  defp before?(content, left, right) do
+    :binary.match(content, left) < :binary.match(content, right)
+  end
+end

--- a/test/mix/tasks/brando_ssg_test.exs
+++ b/test/mix/tasks/brando_ssg_test.exs
@@ -1,0 +1,33 @@
+defmodule BrandoIntegrationWeb.SSG do
+  import Brando.SSG
+
+  urls :pages do
+    ["/"]
+  end
+end
+
+defmodule Mix.Tasks.Brando.SsgTest do
+  use Brando.ConnCase
+
+  setup do
+    put_test_env(:tenancy_mode, :none)
+    Mix.Task.reenable("brando.ssg")
+    Mix.Task.reenable("run")
+    :ok
+  end
+
+  test "retains a non-tenant, non-interactive dry-run workflow" do
+    output = Path.join(System.tmp_dir!(), "brando-ssg-task-#{System.unique_integer([:positive])}")
+    refute File.exists?(output)
+
+    assert :ok =
+             Mix.Tasks.Brando.Ssg.run([
+               "--force",
+               "--dry-run",
+               "--output",
+               output
+             ])
+
+    refute File.exists?(output)
+  end
+end

--- a/test/support/integration_repo.ex
+++ b/test/support/integration_repo.ex
@@ -1,0 +1,37 @@
+defmodule Brando.IntegrationRepo do
+  @moduledoc """
+  Starts an isolated PostgreSQL repo for integration tests and restores its
+  application configuration when the test module exits.
+  """
+
+  @doc "Starts `repo` with the integration database connection options."
+  @spec start(module()) :: :ok
+  def start(repo) do
+    repo_options =
+      BrandoIntegration.Repo.config()
+      |> Keyword.take([:database, :hostname, :password, :port, :socket_options, :ssl, :username])
+      |> Keyword.merge(pool: DBConnection.ConnectionPool, pool_size: 3)
+
+    previous_repo_config = Application.fetch_env(:brando, repo)
+    Application.put_env(:brando, repo, repo_options)
+    {:ok, repo_pid} = repo.start_link()
+
+    ExUnit.Callbacks.on_exit(fn ->
+      stop(repo_pid)
+      restore_env(repo, previous_repo_config)
+    end)
+
+    :ok
+  end
+
+  @doc "Restores a previously captured Brando application environment value."
+  @spec restore_env(atom() | module(), {:ok, term()} | :error) :: :ok
+  def restore_env(key, {:ok, value}), do: Application.put_env(:brando, key, value)
+  def restore_env(key, :error), do: Application.delete_env(:brando, key)
+
+  defp stop(repo_pid) do
+    GenServer.stop(repo_pid)
+  catch
+    :exit, _reason -> :ok
+  end
+end


### PR DESCRIPTION
## Summary

- add public, versioned SSG build records with snapshotted environment, asset-set, and deploy configuration
- make `Brando.SSG` callable for standalone and tenant-aware builds, including signed domainless-environment rendering
- add serial Oban build/deploy workers, progress, logs, failed URLs, previews, notifications, scheduling, pruning, and rollback
- support rsync and S3 artifact deployment with optional auto-deploy, webhooks, CDN links, and retention
- add the static-only Publishing admin screen and document the static artifact lifecycle separately from Florist releases
- keep `mix brando.ssg` compatible with standalone applications while making its plan/confirmation UX interactive by default

## Stack

This is Phase 5 of the multi-tenancy stack and is intentionally based on #2741 (`codex/multitenancy-phase-4`).

Closes #2686

## Validation

- `mix format --check-formatted`
- `mix compile --force --warnings-as-errors`
- `mix test --warnings-as-errors` — 1694 passed (135 doctests, 1559 tests)
- focused Phase 5 suite — 43 passed
- scoped strict Credo on all new and changed publishing modules — no issues
- `mix xref graph --format cycles --label compile-connected --fail-above 1`
- `MIX_ENV=docs mix docs --warnings-as-errors`

No JavaScript or CSS changed, so the consumer asset build is not applicable.
