### PR TITLE
Credo cleanup, minus the four places the check is wrong

### DIFF
--- a/lib/brando/cache/globals.ex
+++ b/lib/brando/cache/globals.ex
@@ -6,6 +6,7 @@ defmodule Brando.Cache.Globals do
   """
   alias Brando.Cache
   alias Brando.Sites
+  alias Brando.Utils
 
   @type changeset :: Ecto.Changeset.t()
 
@@ -55,8 +56,8 @@ defmodule Brando.Cache.Globals do
         put_in(
           acc,
           [
-            Brando.Utils.access_map(to_string(language)),
-            Brando.Utils.access_map(set.key)
+            Utils.access_map(to_string(language)),
+            Utils.access_map(set.key)
           ],
           []
         )
@@ -70,8 +71,8 @@ defmodule Brando.Cache.Globals do
         put_in(
           acc,
           [
-            Brando.Utils.access_map(to_string(language)),
-            Brando.Utils.access_map(set.key)
+            Utils.access_map(to_string(language)),
+            Utils.access_map(set.key)
           ],
           set_globals
         )

--- a/lib/brando/content/identifier/sync.ex
+++ b/lib/brando/content/identifier/sync.ex
@@ -8,6 +8,7 @@ defmodule Brando.Content.Identifier.Sync do
 
   import Ecto.Query
 
+  alias Brando.Content
   alias Brando.Content.Identifier
   alias Brando.Content.Identifier.Queries
   alias Brando.Content.Identifier.Registry
@@ -36,7 +37,7 @@ defmodule Brando.Content.Identifier.Sync do
     log_red("[-] Removing irrelevant identifiers")
 
     # Process each existing identifier
-    {:ok, identifiers} = Brando.Content.list_identifiers()
+    {:ok, identifiers} = Content.list_identifiers()
 
     for identifier <- identifiers do
       process_identifier(identifier)
@@ -81,7 +82,7 @@ defmodule Brando.Content.Identifier.Sync do
     entries = Brando.Repo.all(entries_query)
 
     for entry <- entries do
-      {:ok, identifier} = Brando.Content.create_identifier(module, entry)
+      {:ok, identifier} = Content.create_identifier(module, entry)
 
       if identifier do
         log_green(
@@ -96,28 +97,28 @@ defmodule Brando.Content.Identifier.Sync do
       {:error, :module_does_not_exist} ->
         log_red("[-] Could not find schema #{inspect(identifier.schema)} in application. Deleting identifier")
 
-        Brando.Content.delete_identifier(identifier)
+        Content.delete_identifier(identifier)
 
       {:error, _} ->
         log_red(
           "[-] Could not find entry for identifier #{inspect(identifier.id)} in schema #{inspect(identifier.schema)}. Deleting identifier"
         )
 
-        Brando.Content.delete_identifier(identifier)
+        Content.delete_identifier(identifier)
 
       {:ok, %{deleted_at: deleted_at}} when not is_nil(deleted_at) ->
         log_red(
           "[-] Entry for identifier #{inspect(identifier.id)} in schema #{inspect(identifier.schema)} is marked as deleted. Deleting identifier"
         )
 
-        Brando.Content.delete_identifier(identifier)
+        Content.delete_identifier(identifier)
 
       {:ok, entry} ->
         log_green(
           "[+] Updating identifier for identifier #{inspect(identifier.id)} in schema #{inspect(identifier.schema)}"
         )
 
-        Brando.Content.update_identifier(entry.__struct__, entry)
+        Content.update_identifier(entry.__struct__, entry)
     end
   end
 

--- a/lib/brando/content/module.ex
+++ b/lib/brando/content/module.ex
@@ -36,6 +36,7 @@ defmodule Brando.Content.Module do
   import Brando.Blueprint.Listings.Components.Children, only: [children_button: 1]
   import Brando.Blueprint.Listings.Components.Core
 
+  alias Ecto.Changeset
   alias Phoenix.LiveView.JS
 
   @type t :: %__MODULE__{}
@@ -274,10 +275,10 @@ defmodule Brando.Content.Module do
   Only applies when the module type is `:heex`.
   """
   def validate_var_keys(changeset) do
-    type = Ecto.Changeset.get_field(changeset, :type)
+    type = Changeset.get_field(changeset, :type)
 
     if type == :heex do
-      vars = Ecto.Changeset.get_field(changeset, :vars) || []
+      vars = Changeset.get_field(changeset, :vars) || []
 
       collisions =
         vars
@@ -287,7 +288,7 @@ defmodule Brando.Content.Module do
       if collisions == [] do
         changeset
       else
-        Ecto.Changeset.add_error(
+        Changeset.add_error(
           changeset,
           :vars,
           "var keys conflict with reserved HEEx assigns: #{Enum.join(collisions, ", ")}"

--- a/lib/brando/images/operations/info.ex
+++ b/lib/brando/images/operations/info.ex
@@ -9,6 +9,6 @@ defmodule Brando.Images.Operations.Info do
   """
   def get_dominant_color(image_path) do
     module = Brando.config(Images, :processor_module) || Images.Processor.Vix
-    apply(module, :get_dominant_color, [image_path])
+    module.get_dominant_color(image_path)
   end
 end

--- a/lib/brando/images/operations/sizing.ex
+++ b/lib/brando/images/operations/sizing.ex
@@ -15,7 +15,7 @@ defmodule Brando.Images.Operations.Sizing do
   """
   def delegate_processor(conversion_parameters) do
     module = Brando.config(Brando.Images, :processor_module) || Brando.Images.Processor.Vix
-    apply(module, :process_image, [conversion_parameters])
+    module.process_image(conversion_parameters)
   end
 
   @doc """

--- a/lib/brando/meta/html.ex
+++ b/lib/brando/meta/html.ex
@@ -6,6 +6,7 @@ defmodule Brando.Meta.HTML do
   import Phoenix.Component
 
   alias Brando.Cache
+  alias Brando.Utils
 
   @type conn :: Plug.Conn.t()
 
@@ -41,7 +42,7 @@ defmodule Brando.Meta.HTML do
       |> put_meta_if_missing("og:title", seo.fallback_meta_title)
       |> put_meta_if_missing("og:site_name", app_name)
       |> put_meta_if_missing("og:type", "website")
-      |> put_meta_if_missing("og:url", Brando.Utils.current_url(conn))
+      |> put_meta_if_missing("og:url", Utils.current_url(conn))
       |> maybe_put_meta_description(seo.fallback_meta_description)
       |> maybe_put_meta_image(seo.fallback_meta_image)
       |> maybe_add_see_also()
@@ -118,7 +119,7 @@ defmodule Brando.Meta.HTML do
   defp put_meta_image(conn, meta_image) when is_binary(meta_image) do
     img =
       (String.contains?(meta_image, "://") && meta_image) ||
-        Brando.Utils.hostname(meta_image)
+        Utils.hostname(meta_image)
 
     type =
       meta_image
@@ -135,8 +136,8 @@ defmodule Brando.Meta.HTML do
 
   defp put_meta_image(conn, meta_image) when is_map(meta_image) do
     # grab xlarge from img
-    img_src = Brando.Utils.img_url(meta_image, :largest, prefix: Brando.Utils.media_url())
-    img = Brando.Utils.hostname(img_src)
+    img_src = Utils.img_url(meta_image, :largest, prefix: Utils.media_url())
+    img = Utils.hostname(img_src)
 
     type =
       meta_image.path
@@ -192,7 +193,7 @@ defmodule Brando.Meta.HTML do
         Map.get(record, :meta_image) ->
           Enum.join(
             [
-              Brando.Utils.host_and_media_url(),
+              Utils.host_and_media_url(),
               record.meta_image.sizes[img_field_size]
             ],
             "/"
@@ -203,7 +204,7 @@ defmodule Brando.Meta.HTML do
 
           Enum.join(
             [
-              Brando.Utils.host_and_media_url(),
+              Utils.host_and_media_url(),
               img.sizes[img_field_size]
             ],
             "/"

--- a/lib/brando/pages/pages.ex
+++ b/lib/brando/pages/pages.ex
@@ -325,7 +325,7 @@ defmodule Brando.Pages do
     view_module = Brando.web_module(PageView)
 
     if Code.ensure_loaded?(view_module) do
-      {_, _, templates} = apply(view_module, :__templates__, [])
+      {_, _, templates} = view_module.__templates__()
 
       main_templates = Enum.filter(templates, &(not String.starts_with?(&1, "_")))
 

--- a/lib/brando/system.ex
+++ b/lib/brando/system.ex
@@ -163,7 +163,7 @@ defmodule Brando.System do
 
       module ->
         module = module || Brando.Images.Processor.Vix
-        apply(module, :confirm_executable_exists, [])
+        module.confirm_executable_exists()
     end
   end
 

--- a/lib/brando/traits/blocks/prevent_circular_references.ex
+++ b/lib/brando/traits/blocks/prevent_circular_references.ex
@@ -5,13 +5,15 @@ defmodule Brando.Trait.Blocks.PreventCircularReferences do
   use Brando.Trait
   use Gettext, backend: Brando.Gettext
 
+  alias Ecto.Changeset
+
   def changeset_mutator(_module, _config, %{changes: %{data: data}} = changeset, _user, _) do
     json = inspect(data)
 
     # we need the keys
-    key = Ecto.Changeset.get_field(changeset, :key)
-    parent_key = Ecto.Changeset.get_field(changeset, :parent_key)
-    language = Ecto.Changeset.get_field(changeset, :language)
+    key = Changeset.get_field(changeset, :key)
+    parent_key = Changeset.get_field(changeset, :parent_key)
+    language = Changeset.get_field(changeset, :language)
 
     # build a fragment ref string
     ref_string = "{% fragment #{parent_key} #{key} #{language} %}"
@@ -22,7 +24,7 @@ defmodule Brando.Trait.Blocks.PreventCircularReferences do
           ref_string: ref_string
         )
 
-      Ecto.Changeset.add_error(
+      Changeset.add_error(
         changeset,
         :data,
         error_msg

--- a/lib/brando/traits/protect_role.ex
+++ b/lib/brando/traits/protect_role.ex
@@ -3,6 +3,7 @@ defmodule Brando.Trait.ProtectRole do
   Protect user role changes from other users than superusers
   """
   use Brando.Trait
+  alias Brando.Type.Role
   alias Ecto.Changeset
   import Ecto.Changeset
   use Gettext, backend: Brando.Gettext
@@ -24,9 +25,9 @@ defmodule Brando.Trait.ProtectRole do
   def changeset_mutator(_, _, %{changes: %{role: new_role}} = changeset, current_user, _opts) do
     old_role = changeset.data.role
     # check if the user has the right to change the role
-    {:ok, user_role_val} = Brando.Type.Role.dump(current_user.role)
-    {:ok, new_role_val} = Brando.Type.Role.dump(new_role)
-    {:ok, old_role_val} = Brando.Type.Role.dump(old_role || :user)
+    {:ok, user_role_val} = Role.dump(current_user.role)
+    {:ok, new_role_val} = Role.dump(new_role)
+    {:ok, old_role_val} = Role.dump(old_role || :user)
 
     cond do
       current_user.role == :superuser ->

--- a/lib/brando/utils.ex
+++ b/lib/brando/utils.ex
@@ -653,10 +653,9 @@ defmodule Brando.Utils do
   end
 
   defp do_active_path?(current_path, url_to_match) do
-    chunks = String.split(url_to_match, "/")
-
     {url, current_path} =
-      if List.last(chunks) == "*" do
+      if wildcard_path?(url_to_match) do
+        chunks = String.split(url_to_match, "/")
         normalize_wildcard_paths(chunks, current_path)
       else
         {url_to_match, current_path}
@@ -664,6 +663,9 @@ defmodule Brando.Utils do
 
     current_path == url
   end
+
+  defp wildcard_path?("*"), do: true
+  defp wildcard_path?(path), do: String.ends_with?(path, "/*")
 
   defp normalize_wildcard_paths(chunks, current_path) do
     url_without_star =

--- a/lib/brando/villain/components.ex
+++ b/lib/brando/villain/components.ex
@@ -20,6 +20,7 @@ defmodule Brando.Villain.Components do
 
   use Phoenix.Component
   import Phoenix.HTML, only: [raw: 1]
+  alias Brando.Villain.RenderSourceQuery
   alias Ecto.Changeset
 
   # -- ref component --
@@ -157,9 +158,9 @@ defmodule Brando.Villain.Components do
   end
 
   defp build_parser_opts(assigns) do
-    {:ok, modules} = Brando.Villain.RenderSourceQuery.list_modules(cache_opts())
-    {:ok, containers} = Brando.Villain.RenderSourceQuery.list_containers(cache_opts())
-    {:ok, palettes} = Brando.Villain.RenderSourceQuery.list_palettes(cache_opts())
+    {:ok, modules} = RenderSourceQuery.list_modules(cache_opts())
+    {:ok, containers} = RenderSourceQuery.list_containers(cache_opts())
+    {:ok, palettes} = RenderSourceQuery.list_palettes(cache_opts())
 
     %{
       context: assigns[:liquex_context] || build_empty_context(),

--- a/lib/brando/villain/parser.ex
+++ b/lib/brando/villain/parser.ex
@@ -207,6 +207,7 @@ defmodule Brando.Villain.Parser do
   alias Brando.RuntimeConfig
   alias Brando.Utils
   alias Brando.Villain.TemplateAdapter
+  alias Ecto.Changeset
 
   # ⚠ Never call one of the callbacks below by bare name from this module.
   #
@@ -480,15 +481,13 @@ defmodule Brando.Villain.Parser do
   defp parse_youtube_time(nil), do: nil
 
   defp parse_youtube_time(t) do
-    cond do
-      # e.g. "2m45s"
-      Regex.match?(~r/^\d+m\d+s$/, t) ->
-        [m, s] = Regex.run(~r/^(\d+)m(\d+)s$/, t, capture: :all_but_first)
-        String.to_integer(m) * 60 + String.to_integer(s)
-
+    # e.g. "2m45s"
+    if Regex.match?(~r/^\d+m\d+s$/, t) do
+      [m, s] = Regex.run(~r/^(\d+)m(\d+)s$/, t, capture: :all_but_first)
+      String.to_integer(m) * 60 + String.to_integer(s)
+    else
       # e.g. "165s" or "165"
-      true ->
-        t |> String.trim_trailing("s") |> String.to_integer()
+      t |> String.trim_trailing("s") |> String.to_integer()
     end
   rescue
     _ -> nil
@@ -1842,8 +1841,8 @@ defmodule Brando.Villain.Parser do
     end
   end
 
-  defp override_object_id(%Ecto.Changeset{} = override) do
-    Ecto.Changeset.get_field(override, :object_id)
+  defp override_object_id(%Changeset{} = override) do
+    Changeset.get_field(override, :object_id)
   end
 
   defp override_object_id(%{object_id: object_id}) do
@@ -1852,22 +1851,22 @@ defmodule Brando.Villain.Parser do
 
   defp override_object_id(_), do: nil
 
-  defp apply_caption_overrides(media_object, %Ecto.Changeset{} = override) do
+  defp apply_caption_overrides(media_object, %Changeset{} = override) do
     media_object
     |> maybe_apply_override(
       :title,
-      Ecto.Changeset.get_field(override, :title),
-      Ecto.Changeset.get_field(override, :use_default_title)
+      Changeset.get_field(override, :title),
+      Changeset.get_field(override, :use_default_title)
     )
     |> maybe_apply_override(
       :credits,
-      Ecto.Changeset.get_field(override, :credits),
-      Ecto.Changeset.get_field(override, :use_default_credits)
+      Changeset.get_field(override, :credits),
+      Changeset.get_field(override, :use_default_credits)
     )
     |> maybe_apply_override(
       :alt,
-      Ecto.Changeset.get_field(override, :alt),
-      Ecto.Changeset.get_field(override, :use_default_alt)
+      Changeset.get_field(override, :alt),
+      Changeset.get_field(override, :use_default_alt)
     )
   end
 
@@ -1902,10 +1901,10 @@ defmodule Brando.Villain.Parser do
     end
   end
 
-  defp apply_playback_overrides(video, %Ecto.Changeset{} = override) do
+  defp apply_playback_overrides(video, %Changeset{} = override) do
     Enum.reduce(~w(autoplay loop muted controls preload)a, video, fn field, acc ->
-      value = Ecto.Changeset.get_field(override, field)
-      use_default = Ecto.Changeset.get_field(override, :"use_default_#{field}")
+      value = Changeset.get_field(override, field)
+      use_default = Changeset.get_field(override, :"use_default_#{field}")
       maybe_apply_override(acc, field, value, use_default)
     end)
   end

--- a/lib/brando/villain/schema.ex
+++ b/lib/brando/villain/schema.ex
@@ -31,6 +31,9 @@ defmodule Brando.Villain.Schema do
       config :brando, Brando.Villain, :parser
 
   """
+
+  alias Ecto.Changeset
+
   defmacro __using__(opts) do
     quote do
       Module.register_attribute(__MODULE__, :villain_fields, accumulate: true)
@@ -88,16 +91,16 @@ defmodule Brando.Villain.Schema do
   """
   def generate_html(changeset, data_field \\ :data)
 
-  def generate_html(%Ecto.Changeset{valid?: true} = changeset, data_field) do
+  def generate_html(%Changeset{valid?: true} = changeset, data_field) do
     html_field =
       data_field
       |> to_string()
       |> String.replace("data", "html")
       |> String.to_atom()
 
-    existing_html = Ecto.Changeset.get_field(changeset, html_field)
+    existing_html = Changeset.get_field(changeset, html_field)
 
-    applied_changes = Ecto.Changeset.apply_changes(changeset)
+    applied_changes = Changeset.apply_changes(changeset)
     data_src = Map.get(applied_changes, data_field)
 
     parsed_data =
@@ -107,7 +110,7 @@ defmodule Brando.Villain.Schema do
       )
 
     if parsed_data != existing_html do
-      Ecto.Changeset.put_change(changeset, html_field, parsed_data)
+      Changeset.put_change(changeset, html_field, parsed_data)
     else
       changeset
     end

--- a/lib/brando_admin/components/content/list.ex
+++ b/lib/brando_admin/components/content/list.ex
@@ -5,6 +5,7 @@ defmodule BrandoAdmin.Components.Content.List do
   use Gettext, backend: Brando.Gettext
 
   alias Brando.Blueprint.Listings
+  alias Brando.Query
   alias Brando.Trait.Creator
   alias Brando.Trait.Sequenced
   alias Brando.Trait.SoftDelete
@@ -188,7 +189,7 @@ defmodule BrandoAdmin.Components.Content.List do
   def handle_event("update_sort", %{"sort_key" => sort_key}, socket) do
     sorts = socket.assigns.listing.sorts
     sort = Enum.find(sorts, &(&1.key == String.to_existing_atom(sort_key)))
-    sort_string = Brando.Query.order_string_to_list(sort.order)
+    sort_string = Query.order_string_to_list(sort.order)
 
     {:noreply,
      socket
@@ -374,15 +375,15 @@ defmodule BrandoAdmin.Components.Content.List do
           # find matching sort
 
           Enum.find(sorts, default_sort, fn sort ->
-            Brando.Query.order_string_to_list(sort.order) ==
-              Brando.Query.order_string_to_list(param_order)
+            Query.order_string_to_list(sort.order) ==
+              Query.order_string_to_list(param_order)
           end)
 
         # param order is a keyword list
         is_list(param_order) ->
           # find matching sort
           Enum.find(sorts, default_sort, fn sort ->
-            Brando.Query.order_string_to_list(sort.order) == param_order
+            Query.order_string_to_list(sort.order) == param_order
           end)
 
         is_map(param_order) ->
@@ -393,7 +394,7 @@ defmodule BrandoAdmin.Components.Content.List do
             end)
 
           Enum.find(sorts, default_sort, fn sort ->
-            Brando.Query.order_string_to_list(sort.order) == Map.to_list(parsed_order)
+            Query.order_string_to_list(sort.order) == Map.to_list(parsed_order)
           end)
       end
     end)
@@ -436,7 +437,7 @@ defmodule BrandoAdmin.Components.Content.List do
   defp sanitize_list_opts(%{filter: filters} = list_opts) do
     sanitized_filters =
       Map.new(filters, fn {k, v} ->
-        {k, Brando.Query.sanitize_ilike_pattern(v)}
+        {k, Query.sanitize_ilike_pattern(v)}
       end)
 
     Map.put(list_opts, :filter, sanitized_filters)

--- a/lib/brando_admin/components/form.ex
+++ b/lib/brando_admin/components/form.ex
@@ -34,6 +34,7 @@ defmodule BrandoAdmin.Components.Form do
 
   alias Brando.Blueprint.Callback
   alias Brando.Blueprint.Forms, as: BlueprintForms
+  alias Brando.Images
   alias Brando.Villain
   alias BrandoAdmin.Components.Button
   alias BrandoAdmin.Components.Content
@@ -245,7 +246,7 @@ defmodule BrandoAdmin.Components.Form do
         %{action: :update_edit_image, edit_image: %{image: nil} = edit_image},
         socket
       ) do
-    image_changeset = change(%Brando.Images.Image{})
+    image_changeset = change(%Images.Image{})
 
     {:ok,
      socket
@@ -1529,7 +1530,7 @@ defmodule BrandoAdmin.Components.Form do
   defp build_asset_fk_map(schema) do
     image_fields =
       if function_exported?(schema, :__image_fields__, 0),
-        do: Enum.map(schema.__image_fields__(), &{:"#{&1.name}_id", {&1.name, Brando.Images.Image}}),
+        do: Enum.map(schema.__image_fields__(), &{:"#{&1.name}_id", {&1.name, Images.Image}}),
         else: []
 
     video_fields =
@@ -2877,7 +2878,7 @@ defmodule BrandoAdmin.Components.Form do
         %{"image_id" => image_id},
         %{assigns: %{singular: singular, current_user: current_user}} = socket
       ) do
-    {:ok, image} = Brando.Images.duplicate_image(image_id, current_user)
+    {:ok, image} = Images.duplicate_image(image_id, current_user)
 
     send_update(__MODULE__,
       id: "#{singular}_form",
@@ -2909,7 +2910,7 @@ defmodule BrandoAdmin.Components.Form do
         # Crop was already applied via the HTTP replace_crop endpoint.
         # The controller's Crop.save_replace already queued processing.
         image_id = params["image_id"] || edit_image.image.id
-        {:ok, img} = Brando.Images.get_image(image_id)
+        {:ok, img} = Images.get_image(image_id)
         img
       else
         # No crop — just update focal point and reprocess from the original file.
@@ -2919,7 +2920,7 @@ defmodule BrandoAdmin.Components.Form do
               image
 
             _ ->
-              {:ok, img} = Brando.Images.get_image(params["image_id"])
+              {:ok, img} = Images.get_image(params["image_id"])
               img
           end
 
@@ -2928,7 +2929,7 @@ defmodule BrandoAdmin.Components.Form do
 
         changeset =
           image
-          |> Brando.Images.Image.changeset(
+          |> Images.Image.changeset(
             %{focal: %{x: x, y: y}, status: :unprocessed},
             current_user
           )
@@ -2949,7 +2950,7 @@ defmodule BrandoAdmin.Components.Form do
 
     # For non-crop case, queue processing after subscribing.
     unless params["crop_applied"] do
-      Brando.Images.Processing.queue_processing(updated_image, current_user)
+      Images.Processing.queue_processing(updated_image, current_user)
     end
 
     # For crop_applied, processing was already queued by the controller.
@@ -2957,7 +2958,7 @@ defmodule BrandoAdmin.Components.Form do
     # Re-fetch to get the latest state (may already be processed).
     updated_image =
       if params["crop_applied"] do
-        {:ok, fresh} = Brando.Images.get_image(updated_image.id)
+        {:ok, fresh} = Images.get_image(updated_image.id)
         fresh
       else
         updated_image
@@ -3275,25 +3276,25 @@ defmodule BrandoAdmin.Components.Form do
     new_image_params = Map.put(image_params, "config_target", original_image.config_target)
 
     validated_changeset =
-      %Brando.Images.Image{}
-      |> Brando.Images.Image.changeset(new_image_params, current_user)
+      %Images.Image{}
+      |> Images.Image.changeset(new_image_params, current_user)
       |> Map.put(:action, :insert)
       |> Brando.Trait.run_trait_before_save_callbacks(
-        Brando.Images.Image,
+        Images.Image,
         current_user
       )
 
     {:ok, new_image} = Brando.Repo.insert(validated_changeset)
 
     Brando.Trait.run_trait_after_save_callbacks(
-      Brando.Images.Image,
+      Images.Image,
       new_image,
       validated_changeset,
       current_user
     )
 
     if new_image.status !== :processed do
-      Brando.Images.Processing.queue_processing(new_image, current_user)
+      Images.Processing.queue_processing(new_image, current_user)
     end
 
     if block_target do
@@ -3336,21 +3337,21 @@ defmodule BrandoAdmin.Components.Form do
 
     validated_changeset =
       image
-      |> Brando.Images.Image.changeset(image_params, current_user)
+      |> Images.Image.changeset(image_params, current_user)
       |> Map.put(:action, :update)
       |> Brando.Trait.run_trait_before_save_callbacks(
-        Brando.Images.Image,
+        Images.Image,
         current_user
       )
 
-    {:ok, _} = Brando.Images.update_image(validated_changeset, current_user)
+    {:ok, _} = Images.update_image(validated_changeset, current_user)
 
     # Reload from DB — the Oban processing job may have updated
     # status/sizes since the drawer was opened.
-    {:ok, updated_image} = Brando.Images.get_image(image.id)
+    {:ok, updated_image} = Images.get_image(image.id)
 
     Brando.Trait.run_trait_after_save_callbacks(
-      Brando.Images.Image,
+      Images.Image,
       updated_image,
       validated_changeset,
       current_user
@@ -3387,7 +3388,7 @@ defmodule BrandoAdmin.Components.Form do
     Phoenix.PubSub.subscribe(Brando.pubsub(), "brando:image:#{image.id}")
 
     if requeue_processing?(validated_changeset, updated_image) do
-      Brando.Images.Processing.queue_processing(updated_image, current_user, field_full_path)
+      Images.Processing.queue_processing(updated_image, current_user, field_full_path)
     end
 
     target_field_name =
@@ -4045,7 +4046,7 @@ defmodule BrandoAdmin.Components.Form do
 
   defp loaded_image?(nil), do: false
   defp loaded_image?(%Ecto.Association.NotLoaded{}), do: false
-  defp loaded_image?(%Brando.Images.Image{}), do: true
+  defp loaded_image?(%Images.Image{}), do: true
 
   defp push_errors(socket, changeset, form, schema, env \\ :save) do
     error_title = gettext("Error")
@@ -4195,7 +4196,7 @@ defmodule BrandoAdmin.Components.Form do
           # Apply focal and mark for reprocessing
           changeset =
             new_image
-            |> Brando.Images.Image.changeset(
+            |> Images.Image.changeset(
               %{focal: %{x: focal.x, y: focal.y}, status: :unprocessed},
               current_user
             )
@@ -4209,7 +4210,7 @@ defmodule BrandoAdmin.Components.Form do
                 send(self(), {:register_pending_block_image, updated_image.id, block_target})
               end
 
-              Brando.Images.Processing.queue_processing(updated_image, current_user)
+              Images.Processing.queue_processing(updated_image, current_user)
 
               if block_target = Map.get(edit_image, :block_target) do
                 {module, id} = block_target
@@ -4255,13 +4256,13 @@ defmodule BrandoAdmin.Components.Form do
   defp resolve_block_image_config(config_target) do
     resolved_target = normalize_upload_config_target(config_target) || "default"
 
-    case Brando.Images.get_config_for(resolved_target) do
+    case Images.get_config_for(resolved_target) do
       {:ok, cfg} ->
         {cfg, resolved_target}
 
       _ ->
         default_config =
-          Brando.config(Brando.Images)[:default_config] ||
+          Brando.config(Images)[:default_config] ||
             Brando.Type.ImageConfig.default_config()
 
         cfg =
@@ -4620,9 +4621,7 @@ defmodule BrandoAdmin.Components.Form do
     with [root | field_segments] <- segments,
          true <- root == singular,
          false <- field_segments == [],
-         {:ok, typed_segments} <- cast_form_path_segments(field_segments),
-         key when is_atom(key) <- List.last(typed_segments) do
-      path = Enum.drop(typed_segments, -1)
+         {:ok, path, key} when is_atom(key) <- cast_form_path_segments(field_segments) do
       {:ok, path, key, field_segments}
     else
       _ -> {:error, :invalid_field_name}
@@ -4630,15 +4629,17 @@ defmodule BrandoAdmin.Components.Form do
   end
 
   defp cast_form_path_segments(segments) do
-    Enum.reduce_while(segments, {:ok, []}, fn segment, {:ok, acc} ->
+    segments
+    |> Enum.reduce_while({:ok, []}, fn segment, {:ok, reversed} ->
       case cast_form_path_segment(segment) do
-        {:ok, casted} ->
-          {:cont, {:ok, acc ++ [casted]}}
-
-        {:error, _reason} = error ->
-          {:halt, error}
+        {:ok, casted} -> {:cont, {:ok, [casted | reversed]}}
+        {:error, _reason} = error -> {:halt, error}
       end
     end)
+    |> case do
+      {:ok, [key | reversed_path]} -> {:ok, Enum.reverse(reversed_path), key}
+      error -> error
+    end
   end
 
   defp cast_form_path_segment(segment) do
@@ -4931,7 +4932,7 @@ defmodule BrandoAdmin.Components.Form do
       # the upload that created it may never have processed, and the drawer is
       # the only place the editor can recover that from — but not if a pass is
       # already in flight, which is the case the old gate kept restarting.
-      image.status != :processed and not Brando.Images.Processing.processing_queued?(image)
+      image.status != :processed and not Images.Processing.processing_queued?(image)
     end
   end
 
@@ -5083,7 +5084,7 @@ defmodule BrandoAdmin.Components.Form do
   defp restore_image_drawer(socket, params) do
     resource_id = String.to_integer(params["resource_id"])
 
-    case Brando.Images.get_image(resource_id) do
+    case Images.get_image(resource_id) do
       {:ok, image} ->
         edit_image = %{
           id: resource_id,
@@ -5247,7 +5248,7 @@ defmodule BrandoAdmin.Components.Form do
 
   defp image_editor_payload(image) do
     crop_groups =
-      case Brando.Images.get_config_for(image) do
+      case Images.get_config_for(image) do
         {:ok, config} -> build_crop_groups(config.sizes)
         _ -> []
       end
@@ -5278,7 +5279,7 @@ defmodule BrandoAdmin.Components.Form do
       is_map(cfg) and cfg["crop"] == true and to_string(key) != "thumb"
     end)
     |> Enum.map(fn {key, cfg} ->
-      {w, h} = Brando.Images.Operations.Sizing.get_crop_dimensions_from_cfg(cfg)
+      {w, h} = Images.Operations.Sizing.get_crop_dimensions_from_cfg(cfg)
       ratio = w / h
       %{key: to_string(key), width: w, height: h, ratio: ratio}
     end)
@@ -5303,7 +5304,7 @@ defmodule BrandoAdmin.Components.Form do
   struct rather than a size config.
   """
   def build_crop_groups_for(image) do
-    case Brando.Images.get_config_for(image) do
+    case Images.get_config_for(image) do
       {:ok, config} -> build_crop_groups(config.sizes)
       _ -> []
     end

--- a/lib/brando_admin/components/form/block.ex
+++ b/lib/brando_admin/components/form/block.ex
@@ -42,6 +42,7 @@ defmodule BrandoAdmin.Components.Form.Block do
   """
   use BrandoAdmin, :live_component
   use Gettext, backend: Brando.Gettext
+  alias Brando.Cache
   alias Brando.Content.Blocks, as: ContentBlocks
   alias BrandoAdmin.Components.Form.Block.Events
   alias BrandoAdmin.Components.Form.BlockField
@@ -2407,11 +2408,11 @@ defmodule BrandoAdmin.Components.Form.Block do
           image == %Ecto.Association.NotLoaded{} ->
             image_id = Changeset.get_field(var_cs, :image_id)
 
-            case Brando.Cache.get("var_image_#{image_id}") do
+            case Cache.get("var_image_#{image_id}") do
               nil ->
                 image = Brando.Images.get_image!(image_id)
                 media_path = Brando.Utils.media_url(image.path)
-                Brando.Cache.put("var_image_#{image_id}", media_path, :timer.minutes(3))
+                Cache.put("var_image_#{image_id}", media_path, :timer.minutes(3))
                 media_path
 
               media_path ->
@@ -2421,7 +2422,7 @@ defmodule BrandoAdmin.Components.Form.Block do
           is_struct(image, Brando.Images.Image) ->
             path = image.path
             media_path = Brando.Utils.media_url(path)
-            Brando.Cache.put("var_image_#{image_id}", media_path, :timer.minutes(3))
+            Cache.put("var_image_#{image_id}", media_path, :timer.minutes(3))
             media_path
 
           true ->

--- a/lib/brando_admin/components/form/block/render.ex
+++ b/lib/brando_admin/components/form/block/render.ex
@@ -10,6 +10,7 @@ defmodule BrandoAdmin.Components.Form.Block.Render do
 
   alias Brando.Content.Block, as: ContentBlock
   alias Brando.Content.Var.Layout
+  alias Brando.Villain.Parser
   alias BrandoAdmin.Components.Content
   alias BrandoAdmin.Components.Form.Block
   alias BrandoAdmin.Components.Form.Input
@@ -2761,7 +2762,7 @@ defmodule BrandoAdmin.Components.Form.Block.Render do
       if block_form[:vars] do
         block_cs
         |> Changeset.get_assoc(:vars, :struct)
-        |> Brando.Villain.Parser.process_vars()
+        |> Parser.process_vars()
       else
         %{}
       end
@@ -2770,7 +2771,7 @@ defmodule BrandoAdmin.Components.Form.Block.Render do
       if block_form[:refs] do
         block_cs
         |> Changeset.get_assoc(:refs, :struct)
-        |> Brando.Villain.Parser.process_refs()
+        |> Parser.process_refs()
       else
         %{}
       end
@@ -2800,7 +2801,7 @@ defmodule BrandoAdmin.Components.Form.Block.Render do
       system_assigns
       |> Map.merge(%{
         render_context: :admin,
-        parser_module: Brando.Villain.Parser.parser_module(),
+        parser_module: Parser.parser_module(),
         module_id: block.module_id,
         block: block,
         refs: processed_refs,

--- a/lib/brando_admin/components/form/block_field.ex
+++ b/lib/brando_admin/components/form/block_field.ex
@@ -65,6 +65,7 @@ defmodule BrandoAdmin.Components.Form.BlockField do
   alias BrandoAdmin.Components.Form.BlockField.Ops
   alias BrandoAdmin.Components.Form.BlockField.Outline
   alias Ecto.Changeset
+  alias Phoenix.PubSub
 
   require Logger
 
@@ -212,7 +213,7 @@ defmodule BrandoAdmin.Components.Form.BlockField do
   def update(%{event: "delete_block", uid: uid}, socket) do
     # Broadcast to other users
     if topic = socket.assigns[:blocks_topic] do
-      Phoenix.PubSub.broadcast(
+      PubSub.broadcast(
         Brando.pubsub(),
         topic,
         {:block_deleted, %{uid: uid, user_id: socket.assigns.current_user.id}}
@@ -326,7 +327,7 @@ defmodule BrandoAdmin.Components.Form.BlockField do
 
     # Broadcast to other users
     if topic = socket.assigns[:blocks_topic] do
-      Phoenix.PubSub.broadcast(
+      PubSub.broadcast(
         Brando.pubsub(),
         topic,
         {:block_added,
@@ -591,7 +592,7 @@ defmodule BrandoAdmin.Components.Form.BlockField do
              module_id when not is_nil(module_id) <- get_in(ops.diffs, [uid, "block", "module_id"]) do
           module_origin = get_in(ops.diffs, [uid, "block", "module_origin"]) || "local"
 
-          Phoenix.PubSub.broadcast(
+          PubSub.broadcast(
             Brando.pubsub(),
             topic,
             {:block_added,
@@ -620,10 +621,10 @@ defmodule BrandoAdmin.Components.Form.BlockField do
         end)
 
       Enum.each(ops.deleted_roots, fn uid ->
-        Phoenix.PubSub.broadcast(Brando.pubsub(), topic, {:block_deleted, %{uid: uid, user_id: user_id}})
+        PubSub.broadcast(Brando.pubsub(), topic, {:block_deleted, %{uid: uid, user_id: user_id}})
       end)
 
-      Phoenix.PubSub.broadcast(
+      PubSub.broadcast(
         Brando.pubsub(),
         topic,
         {:blocks_reordered, %{block_list: ops.order, user_id: user_id}}
@@ -673,7 +674,7 @@ defmodule BrandoAdmin.Components.Form.BlockField do
   # process and subscribes there, which is the subscription that matters.
   defp subscribe_to_blocks(socket, topic) do
     if connected?(socket) do
-      Phoenix.PubSub.subscribe(Brando.pubsub(), topic)
+      PubSub.subscribe(Brando.pubsub(), topic)
     end
 
     socket
@@ -690,7 +691,7 @@ defmodule BrandoAdmin.Components.Form.BlockField do
   # the waste lands in other processes, once per page load, per editor.
   defp request_blocks_sync(socket) do
     if socket.assigns[:blocks_topic] && connected?(socket) do
-      Phoenix.PubSub.broadcast(
+      PubSub.broadcast(
         Brando.pubsub(),
         socket.assigns.blocks_topic,
         {:blocks_sync_request, %{block_field: socket.assigns.block_field, user_id: socket.assigns.current_user.id}}
@@ -899,7 +900,7 @@ defmodule BrandoAdmin.Components.Form.BlockField do
 
   defp broadcast_snapshot(socket, root_uid, snapshot) do
     if topic = socket.assigns[:blocks_topic] do
-      Phoenix.PubSub.broadcast(Brando.pubsub(), topic, {
+      PubSub.broadcast(Brando.pubsub(), topic, {
         :block_ops_shipped,
         %{uid: root_uid, snapshot: snapshot, user_id: socket.assigns.current_user.id}
       })
@@ -1054,7 +1055,7 @@ defmodule BrandoAdmin.Components.Form.BlockField do
 
     # Broadcast the store's order to other users
     if topic = socket.assigns[:blocks_topic] do
-      Phoenix.PubSub.broadcast(
+      PubSub.broadcast(
         Brando.pubsub(),
         topic,
         {:blocks_reordered, %{block_list: socket.assigns.block_ops.order, user_id: socket.assigns.current_user.id}}
@@ -1093,7 +1094,7 @@ defmodule BrandoAdmin.Components.Form.BlockField do
         case restore_from_snapshot(socket, snapshot) do
           {:ok, socket} ->
             if topic = socket.assigns[:blocks_topic] do
-              Phoenix.PubSub.broadcast(
+              PubSub.broadcast(
                 Brando.pubsub(),
                 topic,
                 {:block_restored,
@@ -1156,7 +1157,7 @@ defmodule BrandoAdmin.Components.Form.BlockField do
 
     # Broadcast the store's order to other users
     if topic = socket.assigns[:blocks_topic] do
-      Phoenix.PubSub.broadcast(
+      PubSub.broadcast(
         Brando.pubsub(),
         topic,
         {:blocks_reordered, %{block_list: socket.assigns.block_ops.order, user_id: socket.assigns.current_user.id}}

--- a/lib/brando_admin/components/form/block_field/ops.ex
+++ b/lib/brando_admin/components/form/block_field/ops.ex
@@ -900,8 +900,7 @@ defmodule BrandoAdmin.Components.Form.BlockField.Ops do
 
   defp put_data_pk(params, %Changeset{data: %schema{} = data}) do
     if function_exported?(schema, :__schema__, 1) do
-      schema
-      |> apply(:__schema__, [:primary_key])
+      schema.__schema__(:primary_key)
       |> Enum.reduce(params, fn pk_field, acc ->
         case Map.get(data, pk_field) do
           nil -> acc

--- a/lib/brando_admin/components/form/input/blocks/render_var.ex
+++ b/lib/brando_admin/components/form/input/blocks/render_var.ex
@@ -6,10 +6,12 @@ defmodule BrandoAdmin.Components.Form.Input.RenderVar do
   import BrandoAdmin.Components.Content.List.Row, only: [status_circle: 1]
   import Ecto.Changeset
 
+  alias Brando.Repo
   alias Brando.Utils
   alias BrandoAdmin.Components.Content
   alias BrandoAdmin.Components.Form.Input
   alias BrandoAdmin.Components.Form.Primitives
+  alias Phoenix.HTML
 
   # prop var, :any
   # prop render, :atom, values: [:all, :content, :config], default: :all
@@ -977,10 +979,10 @@ defmodule BrandoAdmin.Components.Form.Input.RenderVar do
     url
     |> String.split("/")
     |> Enum.map_join("/", fn segment ->
-      escaped = segment |> Phoenix.HTML.html_escape() |> Phoenix.HTML.safe_to_string()
+      escaped = segment |> HTML.html_escape() |> HTML.safe_to_string()
       "#{escaped}<wbr />"
     end)
-    |> Phoenix.HTML.raw()
+    |> HTML.raw()
   end
 
   attr(:link_text, :string, default: nil)
@@ -1552,13 +1554,13 @@ defmodule BrandoAdmin.Components.Form.Input.RenderVar do
       (gallery || %Brando.Galleries.Gallery{})
       |> Brando.Galleries.Gallery.changeset(params, current_user_id)
       |> then(fn changeset ->
-        if gallery, do: Brando.Repo.update(changeset), else: Brando.Repo.insert(changeset)
+        if gallery, do: Repo.update(changeset), else: Repo.insert(changeset)
       end)
 
     case result do
       {:ok, saved_gallery} ->
         saved_gallery =
-          Brando.Repo.preload(
+          Repo.preload(
             saved_gallery,
             [gallery_objects: [:image, video: [:thumbnail, :file]]],
             force: true
@@ -1600,7 +1602,7 @@ defmodule BrandoAdmin.Components.Form.Input.RenderVar do
   defp normalize_id(id) when is_binary(id), do: String.to_integer(id)
 
   defp current_user(nil), do: nil
-  defp current_user(user_id), do: Brando.Repo.get(Brando.Users.User, user_id)
+  defp current_user(user_id), do: Repo.get(Brando.Users.User, user_id)
 
   # Entry-level vars have no owning block component (`on_change` unset) — their
   # FKs live in the parent entry form's changeset. Sync the picked/reset value

--- a/lib/brando_admin/components/form/input/link.ex
+++ b/lib/brando_admin/components/form/input/link.ex
@@ -3,6 +3,7 @@ defmodule BrandoAdmin.Components.Form.Input.Link do
   use BrandoAdmin, :live_component
 
   alias BrandoAdmin.Components.Form.Input.RenderVar
+  alias Ecto.Changeset
 
   # prop form, :form
   # prop subform, :form
@@ -46,14 +47,14 @@ defmodule BrandoAdmin.Components.Form.Input.Link do
     changeset = field.form.source
 
     field_name = field.field
-    current_link = Ecto.Changeset.get_field(changeset, field_name)
+    current_link = Changeset.get_field(changeset, field_name)
 
     if current_link do
       socket
     else
       default_link =
         %Brando.Content.Var{}
-        |> Ecto.Changeset.change(%{
+        |> Changeset.change(%{
           type: :link,
           label: "Link",
           key: "link",
@@ -66,7 +67,7 @@ defmodule BrandoAdmin.Components.Form.Input.Link do
       module = changeset.data.__struct__
       form_id = "#{module.__naming__().singular}_form"
 
-      updated_changeset = Ecto.Changeset.put_change(changeset, field_name, default_link)
+      updated_changeset = Changeset.put_change(changeset, field_name, default_link)
 
       send_update(BrandoAdmin.Components.Form,
         id: form_id,

--- a/lib/brando_admin/components/form/input/multi_select.ex
+++ b/lib/brando_admin/components/form/input/multi_select.ex
@@ -11,6 +11,7 @@ defmodule BrandoAdmin.Components.Form.Input.MultiSelect do
   alias BrandoAdmin.Components.Form.Input
   alias BrandoAdmin.Components.Form.Input.Options
   alias BrandoAdmin.Components.Form.Primitives
+  alias Ecto.Changeset
 
   # prop form, :form
   # prop field, :atom
@@ -296,7 +297,7 @@ defmodule BrandoAdmin.Components.Form.Input.MultiSelect do
         new_rel =
           rel_module
           |> struct!()
-          |> Ecto.Changeset.change([{relation_key, id}])
+          |> Changeset.change([{relation_key, id}])
           |> Map.put(:action, :insert)
           |> maybe_change_sequence?(idx, sequenced?)
 
@@ -304,7 +305,7 @@ defmodule BrandoAdmin.Components.Form.Input.MultiSelect do
 
         struct =
           new_rel
-          |> Ecto.Changeset.apply_changes()
+          |> Changeset.apply_changes()
           |> maybe_add_relation(relation, assoc_data)
 
         {cs_acc ++ [new_rel], struct_acc ++ [struct]}
@@ -498,7 +499,7 @@ defmodule BrandoAdmin.Components.Form.Input.MultiSelect do
       selected_options = socket.assigns.selected_options
 
       if socket.assigns.relation_type in [:has_many, {:subform, :has_many}] do
-        Enum.map(selected_options, &Ecto.Changeset.apply_changes/1)
+        Enum.map(selected_options, &Changeset.apply_changes/1)
       else
         selected_options
       end
@@ -545,23 +546,23 @@ defmodule BrandoAdmin.Components.Form.Input.MultiSelect do
   end
 
   defp get_selected_options(changeset, field, {:array, _}) do
-    Ecto.Changeset.get_field(changeset, field.field) || []
+    Changeset.get_field(changeset, field.field) || []
   end
 
   defp get_selected_options(changeset, field, :many_to_many) do
-    Ecto.Changeset.get_assoc(changeset, field.field, :struct)
+    Changeset.get_assoc(changeset, field.field, :struct)
   end
 
   defp get_selected_options(changeset, field, :has_many) do
-    Ecto.Changeset.get_assoc(changeset, field.field)
+    Changeset.get_assoc(changeset, field.field)
   end
 
   defp get_selected_options(changeset, field, {:subform, :has_many}) do
-    Ecto.Changeset.get_assoc(changeset, field.field)
+    Changeset.get_assoc(changeset, field.field)
   end
 
   defp get_selected_options(changeset, field, :embeds_many) do
-    Ecto.Changeset.get_embed(changeset, field.field, :struct)
+    Changeset.get_embed(changeset, field.field, :struct)
   end
 
   def assign_input_options(%{assigns: %{field: field, opts: opts}} = socket) do
@@ -649,8 +650,8 @@ defmodule BrandoAdmin.Components.Form.Input.MultiSelect do
   defp compute_selected_values(selected_options, relation_key, relation_type)
        when relation_type in [:has_many, {:subform, :has_many}] do
     selected_options
-    |> Enum.reject(&(Ecto.Changeset.get_change(&1, :marked_as_deleted) == true))
-    |> MapSet.new(&to_string(Ecto.Changeset.get_field(&1, relation_key)))
+    |> Enum.reject(&(Changeset.get_change(&1, :marked_as_deleted) == true))
+    |> MapSet.new(&to_string(Changeset.get_field(&1, relation_key)))
   end
 
   defp compute_selected_values(selected_options, _relation_key, _relation_type) do
@@ -675,7 +676,7 @@ defmodule BrandoAdmin.Components.Form.Input.MultiSelect do
   defp find_invalid_options(selected_options, input_options, relation_key, relation_type, relation)
        when relation_type in [:has_many, {:subform, :has_many}] do
     selected_options
-    |> Enum.reject(&(Ecto.Changeset.get_change(&1, :marked_as_deleted) == true))
+    |> Enum.reject(&(Changeset.get_change(&1, :marked_as_deleted) == true))
     |> Enum.filter(&is_nil(get_opt(&1, input_options, relation_key, relation_type)))
     |> Enum.map(fn changeset ->
       %{title: get_invalid_option_title(changeset, relation)}
@@ -761,7 +762,7 @@ defmodule BrandoAdmin.Components.Form.Input.MultiSelect do
         data-sortable-dispatch-event="true"
       >
         <.inputs_for :let={selected_option} field={@field} skip_hidden>
-          <%= if Ecto.Changeset.get_change(selected_option.source, :marked_as_deleted) in [false, nil] do %>
+          <%= if Changeset.get_change(selected_option.source, :marked_as_deleted) in [false, nil] do %>
             <.selected_label
               :let={opt}
               selected_option={selected_option}
@@ -835,7 +836,7 @@ defmodule BrandoAdmin.Components.Form.Input.MultiSelect do
   def selected_label(%{relation_type: relation_type} = assigns)
       when relation_type in [:has_many, {:subform, :has_many}] do
     ~H"""
-    <div :if={Ecto.Changeset.get_change(@selected_option.source, :marked_as_deleted) in [false, nil]} class="selected-label">
+    <div :if={Changeset.get_change(@selected_option.source, :marked_as_deleted) in [false, nil]} class="selected-label">
       <div class="selected-label-text">
         {render_slot(
           @inner_block,
@@ -854,7 +855,7 @@ defmodule BrandoAdmin.Components.Form.Input.MultiSelect do
     <% else %>
       <div
         :for={opt <- @selected_options}
-        :if={Ecto.Changeset.get_change(opt, :marked_as_deleted) in [false, nil]}
+        :if={Changeset.get_change(opt, :marked_as_deleted) in [false, nil]}
         class="selected-label"
       >
         <div class="selected-label-text">
@@ -883,7 +884,7 @@ defmodule BrandoAdmin.Components.Form.Input.MultiSelect do
 
   defp get_opt(changeset, opts, relation_key, relation_type)
        when relation_type in [:has_many, {:subform, :has_many}] do
-    wanted_id = to_string(Ecto.Changeset.get_field(changeset, relation_key))
+    wanted_id = to_string(Changeset.get_field(changeset, relation_key))
     Enum.find(opts, &(option_value(&1) == wanted_id))
   end
 
@@ -894,7 +895,7 @@ defmodule BrandoAdmin.Components.Form.Input.MultiSelect do
     end)
   end
 
-  defp extract_value(%Ecto.Changeset{data: %{id: id}}), do: id
+  defp extract_value(%Changeset{data: %{id: id}}), do: id
   defp extract_value(%{value: value}), do: value
   defp extract_value(%{id: value}), do: value
   defp extract_value(value), do: value
@@ -944,7 +945,7 @@ defmodule BrandoAdmin.Components.Form.Input.MultiSelect do
     """
   end
 
-  defp get_label(%{opt: %Ecto.Changeset{} = changeset} = assigns) do
+  defp get_label(%{opt: %Changeset{} = changeset} = assigns) do
     entry = changeset.data
     identifier = entry.__struct__.__identifier__(entry, skip_cover: true)
 
@@ -1037,7 +1038,7 @@ defmodule BrandoAdmin.Components.Form.Input.MultiSelect do
     """
   end
 
-  defp maybe_slug(%Ecto.Changeset{data: %{id: id}}), do: id
+  defp maybe_slug(%Changeset{data: %{id: id}}), do: id
   defp maybe_slug(%{id: id}), do: id
   defp maybe_slug(opt) when is_atom(opt), do: to_string(opt)
   defp maybe_slug(opt) when is_integer(opt), do: opt
@@ -1051,7 +1052,7 @@ defmodule BrandoAdmin.Components.Form.Input.MultiSelect do
        when relation_type in [:has_many, {:subform, :has_many}] do
     count =
       selected_options
-      |> Enum.reject(&(Ecto.Changeset.get_change(&1, :marked_as_deleted) || &1.action == :replace))
+      |> Enum.reject(&(Changeset.get_change(&1, :marked_as_deleted) || &1.action == :replace))
       |> Enum.count()
 
     gettext("%{count} selected", count: count)
@@ -1112,7 +1113,7 @@ defmodule BrandoAdmin.Components.Form.Input.MultiSelect do
          |> update_input_options()
          |> maybe_assign_select_changeset()}
 
-      {:error, %Ecto.Changeset{} = select_changeset} ->
+      {:error, %Changeset{} = select_changeset} ->
         {:noreply, assign(socket, select_changeset: select_changeset)}
     end
   end
@@ -1188,8 +1189,8 @@ defmodule BrandoAdmin.Components.Form.Input.MultiSelect do
     exists_at_idx =
       Enum.find_index(
         selected_options,
-        &(to_string(Ecto.Changeset.get_field(&1, relation_fk)) == value &&
-            Ecto.Changeset.get_change(&1, :marked_as_deleted) != true)
+        &(to_string(Changeset.get_field(&1, relation_fk)) == value &&
+            Changeset.get_change(&1, :marked_as_deleted) != true)
       )
 
     {selected_options_structs, selected_options} =
@@ -1202,7 +1203,7 @@ defmodule BrandoAdmin.Components.Form.Input.MultiSelect do
               selected_options,
               exists_at_idx,
               to_delete
-              |> Ecto.Changeset.change(marked_as_deleted: true)
+              |> Changeset.change(marked_as_deleted: true)
               |> Map.put(:action, :delete)
             )
           else
@@ -1222,7 +1223,7 @@ defmodule BrandoAdmin.Components.Form.Input.MultiSelect do
         new_rel =
           rel_module
           |> struct!()
-          |> Ecto.Changeset.change([{relation_fk, value}])
+          |> Changeset.change([{relation_fk, value}])
           |> Map.put(:action, :insert)
           |> maybe_change_sequence?(sequence_count, sequenced?)
 
@@ -1231,7 +1232,7 @@ defmodule BrandoAdmin.Components.Form.Input.MultiSelect do
 
         selected_option_struct =
           new_rel
-          |> Ecto.Changeset.apply_changes()
+          |> Changeset.apply_changes()
           |> maybe_add_relation(relation, assoc_data)
 
         {selected_options_structs ++ [selected_option_struct], selected_options ++ [new_rel]}
@@ -1249,7 +1250,7 @@ defmodule BrandoAdmin.Components.Form.Input.MultiSelect do
 
     {updated, updated_structs} =
       Enum.reduce(selected, {[], socket.assigns.selected_options_structs}, fn opt, {acc, structs} ->
-        already_deleted? = Ecto.Changeset.get_change(opt, :marked_as_deleted) == true
+        already_deleted? = Changeset.get_change(opt, :marked_as_deleted) == true
         valid? = already_deleted? or not is_nil(get_opt(opt, opts, rk, rt))
 
         cond do
@@ -1257,8 +1258,8 @@ defmodule BrandoAdmin.Components.Form.Input.MultiSelect do
             {acc ++ [opt], structs}
 
           opt.data.id ->
-            deleted = opt |> Ecto.Changeset.change(marked_as_deleted: true) |> Map.put(:action, :delete)
-            fk_val = to_string(Ecto.Changeset.get_field(opt, rk))
+            deleted = opt |> Changeset.change(marked_as_deleted: true) |> Map.put(:action, :delete)
+            fk_val = to_string(Changeset.get_field(opt, rk))
             {acc ++ [deleted], Enum.reject(structs, &(to_string(Map.get(&1, rk)) == fk_val))}
 
           true ->
@@ -1286,11 +1287,11 @@ defmodule BrandoAdmin.Components.Form.Input.MultiSelect do
     updated_selected_options =
       Enum.reduce(selected_options, [], fn opt, acc ->
         cond do
-          Ecto.Changeset.get_change(opt, :marked_as_deleted) == true ->
+          Changeset.get_change(opt, :marked_as_deleted) == true ->
             acc ++ [opt]
 
           opt.data.id ->
-            acc ++ [opt |> Ecto.Changeset.change(marked_as_deleted: true) |> Map.put(:action, :delete)]
+            acc ++ [opt |> Changeset.change(marked_as_deleted: true) |> Map.put(:action, :delete)]
 
           true ->
             acc
@@ -1324,7 +1325,7 @@ defmodule BrandoAdmin.Components.Form.Input.MultiSelect do
 
   defp request_field_ship(socket) do
     field = socket.assigns.field
-    entry_id = Ecto.Changeset.get_field(field.form.source, :id)
+    entry_id = Changeset.get_field(field.form.source, :id)
     current_user = socket.assigns[:current_user]
 
     if entry_id do
@@ -1367,7 +1368,7 @@ defmodule BrandoAdmin.Components.Form.Input.MultiSelect do
 
   defp broadcast_field_focus(socket) do
     field = socket.assigns.field
-    entry_id = Ecto.Changeset.get_field(field.form.source, :id)
+    entry_id = Changeset.get_field(field.form.source, :id)
     current_user = socket.assigns[:current_user]
     field_name = "#{field.form.name}[#{field.field}]"
 
@@ -1440,11 +1441,11 @@ defmodule BrandoAdmin.Components.Form.Input.MultiSelect do
     # we should fetch and put the full "through" structs on the changeset, similar to how
     # select.ex uses the fetcher_fn to update the belongs_to relation after selection.
 
-    Ecto.Changeset.put_assoc(changeset, field, updated_relation)
+    Changeset.put_assoc(changeset, field, updated_relation)
   end
 
   defp update_relation(changeset, field, updated_relation, :embeds_many) do
-    Ecto.Changeset.put_embed(changeset, field, updated_relation)
+    Changeset.put_embed(changeset, field, updated_relation)
   end
 
   defp maybe_change_sequence?(changeset, _, false) do
@@ -1452,6 +1453,6 @@ defmodule BrandoAdmin.Components.Form.Input.MultiSelect do
   end
 
   defp maybe_change_sequence?(changeset, sequence_count, _) do
-    Ecto.Changeset.change(changeset, [{:sequence, sequence_count}])
+    Changeset.change(changeset, [{:sequence, sequence_count}])
   end
 end

--- a/lib/brando_admin/components/form/subform.ex
+++ b/lib/brando_admin/components/form/subform.ex
@@ -2,10 +2,12 @@ defmodule BrandoAdmin.Components.Form.Subform do
   use BrandoAdmin, :live_component
   # use Phoenix.HTML
 
+  alias Brando.Blueprint.Relations
   alias BrandoAdmin.Components.Form.Input
   alias BrandoAdmin.Components.Form.Input.SubformHelpers
   alias BrandoAdmin.Components.Form.Primitives
   alias BrandoAdmin.Components.Form.Subform
+  alias Ecto.Changeset
 
   use Gettext, backend: Brando.Gettext
 
@@ -52,11 +54,11 @@ defmodule BrandoAdmin.Components.Form.Subform do
         #   - has a :sequenced trait
         parent_schema = assigns.field.form.data.__struct__
 
-        case Brando.Blueprint.Relations.__relation__(parent_schema, assigns.subform.name) do
-          %Brando.Blueprint.Relations.Relation{type: :has_many, opts: %{module: rel_module}} ->
+        case Relations.__relation__(parent_schema, assigns.subform.name) do
+          %Relations.Relation{type: :has_many, opts: %{module: rel_module}} ->
             rel_module.has_trait(Brando.Trait.Sequenced)
 
-          %Brando.Blueprint.Relations.Relation{type: :embeds_many} ->
+          %Relations.Relation{type: :embeds_many} ->
             true
 
           _ ->
@@ -66,16 +68,16 @@ defmodule BrandoAdmin.Components.Form.Subform do
       |> assign_new(:embeds?, fn ->
         parent_schema = assigns.field.form.data.__struct__
 
-        case Brando.Blueprint.Relations.__relation__(parent_schema, assigns.subform.name) do
-          %Brando.Blueprint.Relations.Relation{type: :embeds_many} -> true
+        case Relations.__relation__(parent_schema, assigns.subform.name) do
+          %Relations.Relation{type: :embeds_many} -> true
           _ -> false
         end
       end)
       |> assign_new(:sort_param, fn ->
         parent_schema = assigns.field.form.data.__struct__
 
-        case Brando.Blueprint.Relations.__relation__(parent_schema, assigns.subform.name) do
-          %Brando.Blueprint.Relations.Relation{opts: opts} ->
+        case Relations.__relation__(parent_schema, assigns.subform.name) do
+          %Relations.Relation{opts: opts} ->
             Map.get(opts, :sort_param, :"sort_#{assigns.subform.name}_ids")
 
           _ ->
@@ -85,8 +87,8 @@ defmodule BrandoAdmin.Components.Form.Subform do
       |> assign_new(:drop_param, fn ->
         parent_schema = assigns.field.form.data.__struct__
 
-        case Brando.Blueprint.Relations.__relation__(parent_schema, assigns.subform.name) do
-          %Brando.Blueprint.Relations.Relation{opts: opts} ->
+        case Relations.__relation__(parent_schema, assigns.subform.name) do
+          %Relations.Relation{opts: opts} ->
             Map.get(opts, :drop_param, :"drop_#{assigns.subform.name}_ids")
 
           _ ->
@@ -312,7 +314,7 @@ defmodule BrandoAdmin.Components.Form.Subform do
 
   def handle_event("add_subentry", _, socket) do
     changeset = socket.assigns.field.form.source
-    entry = Ecto.Changeset.apply_changes(changeset)
+    entry = Changeset.apply_changes(changeset)
 
     default =
       case socket.assigns.subform.default do
@@ -386,15 +388,15 @@ defmodule BrandoAdmin.Components.Form.Subform do
         if embed? do
           entry
         else
-          Ecto.Changeset.change(entry, %{sequence: idx})
+          Changeset.change(entry, %{sequence: idx})
         end
       end)
 
     updated_changeset =
       if embed? do
-        Ecto.Changeset.put_embed(changeset, field_name, sorted_related_entries)
+        Changeset.put_embed(changeset, field_name, sorted_related_entries)
       else
-        Ecto.Changeset.put_assoc(changeset, field_name, sorted_related_entries)
+        Changeset.put_assoc(changeset, field_name, sorted_related_entries)
       end
 
     send_update(BrandoAdmin.Components.Form,
@@ -407,8 +409,8 @@ defmodule BrandoAdmin.Components.Form.Subform do
   end
 
   defp get_change_or_field(changeset, field) do
-    with nil <- Ecto.Changeset.get_change(changeset, field) do
-      Ecto.Changeset.get_field(changeset, field, [])
+    with nil <- Changeset.get_change(changeset, field) do
+      Changeset.get_field(changeset, field, [])
     end
   end
 end

--- a/lib/brando_admin/controllers/seo_controller.ex
+++ b/lib/brando_admin/controllers/seo_controller.ex
@@ -5,6 +5,7 @@ defmodule Brando.SEOController do
   use BrandoAdmin, :controller
 
   alias Brando.Cache
+  alias Plug.Conn
 
   @default_robots """
   User-agent: *
@@ -18,13 +19,13 @@ defmodule Brando.SEOController do
     case Map.get(seo, :robots) do
       nil ->
         conn
-        |> Plug.Conn.resp(200, @default_robots)
-        |> Plug.Conn.send_resp()
+        |> Conn.resp(200, @default_robots)
+        |> Conn.send_resp()
 
       robots ->
         conn
-        |> Plug.Conn.resp(200, robots)
-        |> Plug.Conn.send_resp()
+        |> Conn.resp(200, robots)
+        |> Conn.send_resp()
     end
   end
 end

--- a/lib/brando_admin/live/users/user_list_live.ex
+++ b/lib/brando_admin/live/users/user_list_live.ex
@@ -3,6 +3,7 @@ defmodule BrandoAdmin.Users.UserListLive do
   use BrandoAdmin.LiveView.Listing, schema: Brando.Users.User
   use Gettext, backend: Brando.Gettext
 
+  alias Brando.Users
   alias BrandoAdmin.Components.Content
 
   import BrandoAdmin.Utils, only: [hide_modal: 1]
@@ -141,11 +142,11 @@ defmodule BrandoAdmin.Users.UserListLive do
   end
 
   def handle_event("delete_user", %{"id" => id}, socket) do
-    user = Brando.Users.get_user!(id)
-    content_summary = Brando.Users.get_user_content_summary(user.id)
+    user = Users.get_user!(id)
+    content_summary = Users.get_user_content_summary(user.id)
 
     {:ok, all_users} =
-      Brando.Users.list_users(%{
+      Users.list_users(%{
         filter: %{active: true},
         preload: [{:avatar, :join}]
       })
@@ -176,10 +177,10 @@ defmodule BrandoAdmin.Users.UserListLive do
     %{deleting_user: user, transfer_to_user_id: to_id, current_user: current_user} =
       socket.assigns
 
-    case Brando.Users.delete_user_with_transfer(user.id, to_id, current_user) do
+    case Users.delete_user_with_transfer(user.id, to_id, current_user) do
       {:ok, _} ->
         send(self(), {:toast, gettext("User deleted and content transferred.")})
-        BrandoAdmin.LiveView.Listing.update_list_entries(Brando.Users.User)
+        BrandoAdmin.LiveView.Listing.update_list_entries(Users.User)
 
         {:noreply,
          socket
@@ -202,15 +203,15 @@ defmodule BrandoAdmin.Users.UserListLive do
   end
 
   def handle_event("disable_user", %{"id" => id}, socket) do
-    user = Brando.Users.get_user!(id)
-    Brando.Users.set_active(id, false, user)
+    user = Users.get_user!(id)
+    Users.set_active(id, false, user)
     send(self(), {:toast, gettext("User disabled.")})
     {:noreply, socket}
   end
 
   def handle_event("enable_user", %{"id" => id}, socket) do
-    user = Brando.Users.get_user!(id)
-    Brando.Users.set_active(id, true, user)
+    user = Users.get_user!(id)
+    Users.set_active(id, true, user)
     send(self(), {:toast, gettext("User enabled.")})
     {:noreply, socket}
   end

--- a/lib/mix/brando.ex
+++ b/lib/mix/brando.ex
@@ -3,6 +3,8 @@ defmodule Mix.Brando do
 
   @moduledoc false
 
+  alias Phoenix.Naming
+
   @doc """
   Asks a question, and refuses to guess when nobody is there to answer.
 
@@ -131,12 +133,12 @@ defmodule Mix.Brando do
   """
   def inflect(singular) do
     base = Mix.Phoenix.base()
-    scoped = Phoenix.Naming.camelize(singular)
-    path = Phoenix.Naming.underscore(scoped)
+    scoped = Naming.camelize(singular)
+    path = Naming.underscore(scoped)
     singular = path |> String.split("/") |> List.last()
     module = base |> Module.concat(scoped) |> inspect
     alias = module |> String.split(".") |> List.last()
-    human = Phoenix.Naming.humanize(singular)
+    human = Naming.humanize(singular)
 
     [
       alias: alias,
@@ -260,7 +262,7 @@ defmodule Mix.Brando do
     app = Mix.Project.config() |> Keyword.fetch!(:app)
 
     case Application.get_env(app, :app_namespace, app) do
-      ^app -> app |> to_string |> Phoenix.Naming.camelize()
+      ^app -> app |> to_string |> Naming.camelize()
       mod -> mod |> inspect
     end
   end

--- a/lib/mix/tasks/brando.entries.resave.ex
+++ b/lib/mix/tasks/brando.entries.resave.ex
@@ -1,6 +1,8 @@
 defmodule Mix.Tasks.Brando.Entries.Resave do
   use Mix.Task
 
+  alias IO.ANSI
+
   @shortdoc "Re-save all entries"
 
   @moduledoc """
@@ -100,17 +102,17 @@ defmodule Mix.Tasks.Brando.Entries.Resave do
 
       IO.write([
         "* [",
-        IO.ANSI.blue(),
+        ANSI.blue(),
         "#{singular}",
-        IO.ANSI.reset(),
+        ANSI.reset(),
         ":",
-        IO.ANSI.blue(),
+        ANSI.blue(),
         "#{entry.id}",
-        IO.ANSI.reset(),
+        ANSI.reset(),
         "] → ",
-        IO.ANSI.blue(),
+        ANSI.blue(),
         title,
-        IO.ANSI.reset(),
+        ANSI.reset(),
         " ... "
       ])
 
@@ -122,10 +124,10 @@ defmodule Mix.Tasks.Brando.Entries.Resave do
 
       case Brando.Repo.update(changeset, force: true) do
         {:ok, _} ->
-          IO.write([IO.ANSI.green(), "done!\n", IO.ANSI.reset()])
+          IO.write([ANSI.green(), "done!\n", ANSI.reset()])
 
         {:error, _} ->
-          IO.write([IO.ANSI.red(), "failed!\n", IO.ANSI.reset()])
+          IO.write([ANSI.red(), "failed!\n", ANSI.reset()])
       end
     end
   end

--- a/lib/mix/tasks/brando.static.deploy.ex
+++ b/lib/mix/tasks/brando.static.deploy.ex
@@ -1,5 +1,6 @@
 defmodule Mix.Tasks.Brando.Static.Deploy do
   use Mix.Task
+  alias Brando.CDN
   alias ExAws.S3
 
   @shortdoc "Upload static files to CDN"
@@ -8,7 +9,7 @@ defmodule Mix.Tasks.Brando.Static.Deploy do
     {parsed_opts, _, _} = OptionParser.parse(args, switches: [purge: :boolean])
     Mix.Task.run("app.config")
 
-    unless Brando.CDN.enabled?(Brando.Static) do
+    unless CDN.enabled?(Brando.Static) do
       raise "CDN not enabled in config."
     end
 
@@ -21,12 +22,12 @@ defmodule Mix.Tasks.Brando.Static.Deploy do
 
     s3_config =
       Brando.Static
-      |> Brando.CDN.config(:s3)
+      |> CDN.config(:s3)
       |> Map.from_struct()
 
     s3_config_list = Map.to_list(s3_config)
 
-    bucket = Brando.CDN.config(Brando.Static, :bucket)
+    bucket = CDN.config(Brando.Static, :bucket)
 
     bucket
     |> S3.get_bucket_location()

--- a/test/brando/blueprints/villain/block/reapply_test.exs
+++ b/test/brando/blueprints/villain/block/reapply_test.exs
@@ -234,8 +234,10 @@ defmodule Brando.Villain.Block.PictureBlockTest do
     updated_block_cs = Brando.Content.Blocks.sync_module(original_block, updated_module)
     updated_block = Ecto.Changeset.apply_changes(updated_block_cs)
 
-    orig_header_ref = List.first(original_block.refs)
-    orig_picture_ref = List.last(original_block.refs)
+    [
+      %Ref{data: %Blocks.HeaderBlock{}} = orig_header_ref,
+      %Ref{data: %Brando.Villain.Blocks.PictureBlock{}} = orig_picture_ref
+    ] = original_block.refs
 
     assert orig_header_ref.data.data.level == 2
     assert orig_header_ref.data.data.class == nil

--- a/test/brando/content/block_media_attrs_test.exs
+++ b/test/brando/content/block_media_attrs_test.exs
@@ -12,6 +12,7 @@ defmodule Brando.Content.BlockMediaAttrsTest do
 
   alias Brando.Content.Block
   alias Brando.Factory
+  alias Brando.Repo
   alias Ecto.Changeset
 
   setup do
@@ -29,7 +30,7 @@ defmodule Brando.Content.BlockMediaAttrsTest do
 
   # no :file factory exists yet
   defp insert_file(user) do
-    Brando.Repo.insert!(%Brando.Files.File{
+    Repo.insert!(%Brando.Files.File{
       filename: "doc.pdf",
       filesize: 1234,
       mime_type: "application/pdf",
@@ -59,15 +60,15 @@ defmodule Brando.Content.BlockMediaAttrsTest do
 
     {:ok, _} =
       page
-      |> Brando.Repo.preload(:entry_blocks)
+      |> Repo.preload(:entry_blocks)
       |> Changeset.change()
       |> Changeset.put_assoc(:entry_blocks, [entry_block_cs])
-      |> Brando.Repo.update()
+      |> Repo.update()
 
     [entry_block] =
       Brando.Pages.Page.Blocks
-      |> Brando.Repo.all()
-      |> Brando.Repo.preload(block: [:vars, :refs])
+      |> Repo.all()
+      |> Repo.preload(block: [:vars, :refs])
 
     entry_block.block
   end
@@ -233,10 +234,10 @@ defmodule Brando.Content.BlockMediaAttrsTest do
         |> Brando.Utils.set_action()
 
       page
-      |> Brando.Repo.preload(:entry_blocks)
+      |> Repo.preload(:entry_blocks)
       |> Changeset.change()
       |> Changeset.put_assoc(:entry_blocks, [entry_block_cs])
-      |> Brando.Repo.update()
+      |> Repo.update()
     end
   end
 

--- a/test/brando/villain/parser/dispatch_test.exs
+++ b/test/brando/villain/parser/dispatch_test.exs
@@ -15,6 +15,7 @@ defmodule Brando.Villain.ParserDispatchTest do
 
   alias Brando.Content
   alias Brando.Factory
+  alias Brando.Utils
 
   defmodule Parser do
     @moduledoc false
@@ -61,7 +62,7 @@ defmodule Brando.Villain.ParserDispatchTest do
         refs: [
           %{
             name: ref_name,
-            uid: Brando.Utils.generate_uid(),
+            uid: Utils.generate_uid(),
             data: %{type: ref_block.type, data: %{}}
           }
         ]
@@ -73,11 +74,11 @@ defmodule Brando.Villain.ParserDispatchTest do
       block: %{
         type: :module,
         module_id: module.id,
-        uid: Brando.Utils.generate_uid(),
+        uid: Utils.generate_uid(),
         vars: [],
         refs: [
           Map.merge(
-            %{name: ref_name, description: nil, uid: Brando.Utils.generate_uid()},
+            %{name: ref_name, description: nil, uid: Utils.generate_uid()},
             ref_block.ref
           )
         ]
@@ -234,7 +235,7 @@ defmodule Brando.Villain.ParserDispatchTest do
           refs: [
             %{
               name: "body",
-              uid: Brando.Utils.generate_uid(),
+              uid: Utils.generate_uid(),
               data: %{type: "text", data: %{}}
             }
           ]
@@ -245,13 +246,13 @@ defmodule Brando.Villain.ParserDispatchTest do
       child = %{
         type: :module,
         module_id: module.id,
-        uid: Brando.Utils.generate_uid(),
+        uid: Utils.generate_uid(),
         vars: [],
         refs: [
           %{
             name: "body",
             description: nil,
-            uid: Brando.Utils.generate_uid(),
+            uid: Utils.generate_uid(),
             data: %Brando.Villain.Blocks.TextBlock{
               type: "text",
               data: %Brando.Villain.Blocks.TextBlock.Data{text: "nested", type: :paragraph}
@@ -263,7 +264,7 @@ defmodule Brando.Villain.ParserDispatchTest do
       block = %{
         block: %{
           type: :container,
-          uid: Brando.Utils.generate_uid(),
+          uid: Utils.generate_uid(),
           palette_id: nil,
           container_id: nil,
           anchor: nil,

--- a/test/brando/villain/ref_rendering_test.exs
+++ b/test/brando/villain/ref_rendering_test.exs
@@ -3,6 +3,7 @@ defmodule Brando.Villain.RefRenderingTest do
   use Brando.ConnCase
   alias Brando.Content
   alias Brando.Factory
+  alias Brando.Utils
 
   setup do
     user = Factory.insert(:random_user)
@@ -66,7 +67,7 @@ defmodule Brando.Villain.RefRenderingTest do
           refs: [
             %{
               name: "title",
-              uid: Brando.Utils.generate_uid(),
+              uid: Utils.generate_uid(),
               data: %{type: "text", data: %{text: "Default Title", type: :paragraph}}
             }
           ]
@@ -82,7 +83,7 @@ defmodule Brando.Villain.RefRenderingTest do
             %{
               name: "title",
               description: nil,
-              uid: Brando.Utils.generate_uid(),
+              uid: Utils.generate_uid(),
               data: %Brando.Villain.Blocks.TextBlock{
                 type: "text",
                 data: %Brando.Villain.Blocks.TextBlock.Data{
@@ -92,7 +93,7 @@ defmodule Brando.Villain.RefRenderingTest do
               }
             }
           ],
-          uid: Brando.Utils.generate_uid(),
+          uid: Utils.generate_uid(),
           vars: []
         }
       }
@@ -112,7 +113,7 @@ defmodule Brando.Villain.RefRenderingTest do
             %{
               name: "cover",
               image_id: image.id,
-              uid: Brando.Utils.generate_uid(),
+              uid: Utils.generate_uid(),
               data: %{type: "picture", data: %{alt: "Default alt"}}
             }
           ]
@@ -130,7 +131,7 @@ defmodule Brando.Villain.RefRenderingTest do
               description: nil,
               image_id: image.id,
               image: image,
-              uid: Brando.Utils.generate_uid(),
+              uid: Utils.generate_uid(),
               data: %Brando.Villain.Blocks.PictureBlock{
                 type: "picture",
                 data: %Brando.Villain.Blocks.PictureBlock.Data{
@@ -139,7 +140,7 @@ defmodule Brando.Villain.RefRenderingTest do
               }
             }
           ],
-          uid: Brando.Utils.generate_uid(),
+          uid: Utils.generate_uid(),
           vars: []
         }
       }
@@ -160,7 +161,7 @@ defmodule Brando.Villain.RefRenderingTest do
             %{
               name: "hero_video",
               video_id: video.id,
-              uid: Brando.Utils.generate_uid(),
+              uid: Utils.generate_uid(),
               data: %{type: "video", data: %{autoplay: false}}
             }
           ]
@@ -178,7 +179,7 @@ defmodule Brando.Villain.RefRenderingTest do
               description: nil,
               video_id: video.id,
               video: video,
-              uid: Brando.Utils.generate_uid(),
+              uid: Utils.generate_uid(),
               data: %Brando.Villain.Blocks.VideoBlock{
                 type: "video",
                 data: %Brando.Villain.Blocks.VideoBlock.Data{
@@ -187,7 +188,7 @@ defmodule Brando.Villain.RefRenderingTest do
               }
             }
           ],
-          uid: Brando.Utils.generate_uid(),
+          uid: Utils.generate_uid(),
           vars: []
         }
       }
@@ -209,7 +210,7 @@ defmodule Brando.Villain.RefRenderingTest do
             %{
               name: "hero_video",
               video_id: video.id,
-              uid: Brando.Utils.generate_uid(),
+              uid: Utils.generate_uid(),
               data: %{type: "video", data: %{autoplay: false}}
             }
           ]
@@ -227,7 +228,7 @@ defmodule Brando.Villain.RefRenderingTest do
               description: nil,
               video_id: video.id,
               video: video,
-              uid: Brando.Utils.generate_uid(),
+              uid: Utils.generate_uid(),
               data: %Brando.Villain.Blocks.VideoBlock{
                 type: "video",
                 data: %Brando.Villain.Blocks.VideoBlock.Data{
@@ -236,7 +237,7 @@ defmodule Brando.Villain.RefRenderingTest do
               }
             }
           ],
-          uid: Brando.Utils.generate_uid(),
+          uid: Utils.generate_uid(),
           vars: []
         }
       }
@@ -269,7 +270,7 @@ defmodule Brando.Villain.RefRenderingTest do
             %{
               name: "report",
               file_id: file.id,
-              uid: Brando.Utils.generate_uid(),
+              uid: Utils.generate_uid(),
               data: %{type: "file", data: %{label: "Default report"}}
             }
           ]
@@ -287,7 +288,7 @@ defmodule Brando.Villain.RefRenderingTest do
               description: nil,
               file_id: file.id,
               file: file,
-              uid: Brando.Utils.generate_uid(),
+              uid: Utils.generate_uid(),
               data: %Brando.Villain.Blocks.FileBlock{
                 type: "file",
                 data: %Brando.Villain.Blocks.FileBlock.Data{
@@ -299,7 +300,7 @@ defmodule Brando.Villain.RefRenderingTest do
               }
             }
           ],
-          uid: Brando.Utils.generate_uid(),
+          uid: Utils.generate_uid(),
           vars: []
         }
       }
@@ -320,7 +321,7 @@ defmodule Brando.Villain.RefRenderingTest do
           refs: [
             %{
               name: "existing",
-              uid: Brando.Utils.generate_uid(),
+              uid: Utils.generate_uid(),
               data: %{type: "text", data: %{text: "Existing Content", type: :paragraph}}
             }
           ]
@@ -336,7 +337,7 @@ defmodule Brando.Villain.RefRenderingTest do
             %{
               name: "existing",
               description: nil,
-              uid: Brando.Utils.generate_uid(),
+              uid: Utils.generate_uid(),
               data: %Brando.Villain.Blocks.TextBlock{
                 type: "text",
                 data: %Brando.Villain.Blocks.TextBlock.Data{
@@ -346,7 +347,7 @@ defmodule Brando.Villain.RefRenderingTest do
               }
             }
           ],
-          uid: Brando.Utils.generate_uid(),
+          uid: Utils.generate_uid(),
           vars: []
         }
       }
@@ -376,13 +377,13 @@ defmodule Brando.Villain.RefRenderingTest do
           refs: [
             %{
               name: "child_title",
-              uid: Brando.Utils.generate_uid(),
+              uid: Utils.generate_uid(),
               data: %{type: "text", data: %{text: "Default Child Title", type: :paragraph}}
             },
             %{
               name: "child_image",
               image_id: image.id,
-              uid: Brando.Utils.generate_uid(),
+              uid: Utils.generate_uid(),
               data: %{type: "picture", data: %{alt: "Default child alt"}}
             }
           ]
@@ -395,12 +396,12 @@ defmodule Brando.Villain.RefRenderingTest do
         type: :module,
         module_id: child_module.id,
         active: true,
-        uid: Brando.Utils.generate_uid(),
+        uid: Utils.generate_uid(),
         refs: [
           %{
             name: "child_title",
             description: nil,
-            uid: Brando.Utils.generate_uid(),
+            uid: Utils.generate_uid(),
             data: %Brando.Villain.Blocks.TextBlock{
               type: "text",
               data: %Brando.Villain.Blocks.TextBlock.Data{
@@ -414,7 +415,7 @@ defmodule Brando.Villain.RefRenderingTest do
             description: nil,
             image_id: image.id,
             image: image,
-            uid: Brando.Utils.generate_uid(),
+            uid: Utils.generate_uid(),
             data: %Brando.Villain.Blocks.PictureBlock{
               type: "picture",
               data: %Brando.Villain.Blocks.PictureBlock.Data{
@@ -431,7 +432,7 @@ defmodule Brando.Villain.RefRenderingTest do
           type: :module,
           module_id: parent_module.id,
           multi: true,
-          uid: Brando.Utils.generate_uid(),
+          uid: Utils.generate_uid(),
           refs: [],
           vars: [],
           children: [child_block]
@@ -482,7 +483,7 @@ defmodule Brando.Villain.RefRenderingTest do
           refs: [
             %{
               name: "content",
-              uid: Brando.Utils.generate_uid(),
+              uid: Utils.generate_uid(),
               data: %{type: "text", data: %{text: "Default container content", type: :paragraph}}
             }
           ]
@@ -504,7 +505,7 @@ defmodule Brando.Villain.RefRenderingTest do
                 %{
                   name: "content",
                   description: nil,
-                  uid: Brando.Utils.generate_uid(),
+                  uid: Utils.generate_uid(),
                   data: %Brando.Villain.Blocks.TextBlock{
                     type: "text",
                     data: %Brando.Villain.Blocks.TextBlock.Data{
@@ -514,11 +515,11 @@ defmodule Brando.Villain.RefRenderingTest do
                   }
                 }
               ],
-              uid: Brando.Utils.generate_uid(),
+              uid: Utils.generate_uid(),
               vars: []
             }
           ],
-          uid: Brando.Utils.generate_uid()
+          uid: Utils.generate_uid()
         }
       }
 
@@ -542,13 +543,13 @@ defmodule Brando.Villain.RefRenderingTest do
           refs: [
             %{
               name: "title",
-              uid: Brando.Utils.generate_uid(),
+              uid: Utils.generate_uid(),
               data: %{type: "text", data: %{text: "Default Title", type: :paragraph}}
             },
             %{
               name: "cover",
               image_id: image.id,
-              uid: Brando.Utils.generate_uid(),
+              uid: Utils.generate_uid(),
               data: %{type: "picture", data: %{alt: "Default alt"}}
             }
           ]
@@ -564,7 +565,7 @@ defmodule Brando.Villain.RefRenderingTest do
             %{
               name: "title",
               description: nil,
-              uid: Brando.Utils.generate_uid(),
+              uid: Utils.generate_uid(),
               data: %Brando.Villain.Blocks.TextBlock{
                 type: "text",
                 data: %Brando.Villain.Blocks.TextBlock.Data{
@@ -578,7 +579,7 @@ defmodule Brando.Villain.RefRenderingTest do
               description: nil,
               image_id: image.id,
               image: image,
-              uid: Brando.Utils.generate_uid(),
+              uid: Utils.generate_uid(),
               data: %Brando.Villain.Blocks.PictureBlock{
                 type: "picture",
                 data: %Brando.Villain.Blocks.PictureBlock.Data{
@@ -587,7 +588,7 @@ defmodule Brando.Villain.RefRenderingTest do
               }
             }
           ],
-          uid: Brando.Utils.generate_uid(),
+          uid: Utils.generate_uid(),
           vars: []
         }
       }
@@ -613,7 +614,7 @@ defmodule Brando.Villain.RefRenderingTest do
           refs: [
             %{
               name: "title",
-              uid: Brando.Utils.generate_uid(),
+              uid: Utils.generate_uid(),
               data: %{type: "text", data: %{text: "Module Title", type: :paragraph}}
             }
           ]
@@ -629,7 +630,7 @@ defmodule Brando.Villain.RefRenderingTest do
             %{
               name: "title",
               description: nil,
-              uid: Brando.Utils.generate_uid(),
+              uid: Utils.generate_uid(),
               data: %Brando.Villain.Blocks.TextBlock{
                 type: "text",
                 data: %Brando.Villain.Blocks.TextBlock.Data{
@@ -639,7 +640,7 @@ defmodule Brando.Villain.RefRenderingTest do
               }
             }
           ],
-          uid: Brando.Utils.generate_uid(),
+          uid: Utils.generate_uid(),
           vars: []
         }
       }
@@ -661,7 +662,7 @@ defmodule Brando.Villain.RefRenderingTest do
           refs: [
             %{
               name: "content",
-              uid: Brando.Utils.generate_uid(),
+              uid: Utils.generate_uid(),
               data: %{type: "text", data: %{text: "Text content", type: :paragraph}}
             }
           ]
@@ -678,7 +679,7 @@ defmodule Brando.Villain.RefRenderingTest do
             %{
               name: "content",
               description: nil,
-              uid: Brando.Utils.generate_uid(),
+              uid: Utils.generate_uid(),
               data: %Brando.Villain.Blocks.HtmlBlock{
                 type: "html",
                 data: %Brando.Villain.Blocks.HtmlBlock.Data{
@@ -687,7 +688,7 @@ defmodule Brando.Villain.RefRenderingTest do
               }
             }
           ],
-          uid: Brando.Utils.generate_uid(),
+          uid: Utils.generate_uid(),
           vars: []
         }
       }
@@ -708,7 +709,7 @@ defmodule Brando.Villain.RefRenderingTest do
           refs: [
             %{
               name: "item_template",
-              uid: Brando.Utils.generate_uid(),
+              uid: Utils.generate_uid(),
               data: %{type: "text", data: %{text: "Template: " <> "{{ forloop.index }}", type: :paragraph}}
             }
           ]
@@ -724,7 +725,7 @@ defmodule Brando.Villain.RefRenderingTest do
             %{
               name: "item_template",
               description: nil,
-              uid: Brando.Utils.generate_uid(),
+              uid: Utils.generate_uid(),
               data: %Brando.Villain.Blocks.TextBlock{
                 type: "text",
                 data: %Brando.Villain.Blocks.TextBlock.Data{
@@ -734,7 +735,7 @@ defmodule Brando.Villain.RefRenderingTest do
               }
             }
           ],
-          uid: Brando.Utils.generate_uid(),
+          uid: Utils.generate_uid(),
           vars: [
             %{
               key: "items",
@@ -772,7 +773,7 @@ defmodule Brando.Villain.RefRenderingTest do
           refs: [
             %{
               name: "cover",
-              uid: Brando.Utils.generate_uid(),
+              uid: Utils.generate_uid(),
               data: %{type: "picture", data: %{}}
             }
           ]
@@ -784,13 +785,13 @@ defmodule Brando.Villain.RefRenderingTest do
         block: %{
           type: :module,
           module_id: module.id,
-          uid: Brando.Utils.generate_uid(),
+          uid: Utils.generate_uid(),
           vars: [],
           refs: [
             %{
               name: "cover",
               description: nil,
-              uid: Brando.Utils.generate_uid(),
+              uid: Utils.generate_uid(),
               image_id: image.id,
               image: image,
               data: %Brando.Villain.Blocks.PictureBlock{type: "picture", data: block_data}
@@ -811,7 +812,7 @@ defmodule Brando.Villain.RefRenderingTest do
           refs: [
             %{
               name: "hero",
-              uid: Brando.Utils.generate_uid(),
+              uid: Utils.generate_uid(),
               data: %{type: "video", data: %{}}
             }
           ]
@@ -823,13 +824,13 @@ defmodule Brando.Villain.RefRenderingTest do
         block: %{
           type: :module,
           module_id: module.id,
-          uid: Brando.Utils.generate_uid(),
+          uid: Utils.generate_uid(),
           vars: [],
           refs: [
             %{
               name: "hero",
               description: nil,
-              uid: Brando.Utils.generate_uid(),
+              uid: Utils.generate_uid(),
               video_id: video.id,
               video: video,
               data: %Brando.Villain.Blocks.VideoBlock{type: "video", data: block_data}
@@ -932,7 +933,7 @@ defmodule Brando.Villain.RefRenderingTest do
         Factory.params_for(:module, %{
           code: "{% ref refs.g %}",
           refs: [
-            %{name: "g", uid: Brando.Utils.generate_uid(), data: %{type: "gallery", data: %{}}}
+            %{name: "g", uid: Utils.generate_uid(), data: %{type: "gallery", data: %{}}}
           ]
         })
 
@@ -942,13 +943,13 @@ defmodule Brando.Villain.RefRenderingTest do
         block: %{
           type: :module,
           module_id: module.id,
-          uid: Brando.Utils.generate_uid(),
+          uid: Utils.generate_uid(),
           vars: [],
           refs: [
             %{
               name: "g",
               description: nil,
-              uid: Brando.Utils.generate_uid(),
+              uid: Utils.generate_uid(),
               gallery_id: gallery.id,
               gallery: gallery,
               data: %Brando.Villain.Blocks.GalleryBlock{type: "gallery", data: block_data}

--- a/test/brando_admin/components/form/block/child_diff_test.exs
+++ b/test/brando_admin/components/form/block/child_diff_test.exs
@@ -19,6 +19,7 @@ defmodule BrandoAdmin.Components.Form.Block.ChildDiffTest do
   alias BrandoAdmin.Components.Form.Block.Events
   alias BrandoAdmin.Components.Form.BlockField.Ops
   alias Ecto.Changeset
+  alias Phoenix.Component
 
   setup do
     user = Factory.insert(:random_user)
@@ -61,17 +62,17 @@ defmodule BrandoAdmin.Components.Form.Block.ChildDiffTest do
 
   defp socket_for(changeset, entry, user) do
     %Phoenix.LiveView.Socket{}
-    |> Phoenix.Component.assign(:form, to_form(changeset, as: "child_block", id: "child_block_form-childY"))
-    |> Phoenix.Component.assign(:uid, "childY")
-    |> Phoenix.Component.assign(:current_user_id, user.id)
-    |> Phoenix.Component.assign(:entry, entry)
-    |> Phoenix.Component.assign(:has_vars?, false)
-    |> Phoenix.Component.assign(:has_table_rows?, false)
-    |> Phoenix.Component.assign(:live_preview_active?, false)
-    |> Phoenix.Component.assign(:original_block_identifiers, [])
-    |> Phoenix.Component.assign(:form_id, "page_form")
-    |> Phoenix.Component.assign(:block_field, "blocks")
-    |> Phoenix.Component.assign(:belongs_to, {:child, "containerX"})
+    |> Component.assign(:form, to_form(changeset, as: "child_block", id: "child_block_form-childY"))
+    |> Component.assign(:uid, "childY")
+    |> Component.assign(:current_user_id, user.id)
+    |> Component.assign(:entry, entry)
+    |> Component.assign(:has_vars?, false)
+    |> Component.assign(:has_table_rows?, false)
+    |> Component.assign(:live_preview_active?, false)
+    |> Component.assign(:original_block_identifiers, [])
+    |> Component.assign(:form_id, "page_form")
+    |> Component.assign(:block_field, "blocks")
+    |> Component.assign(:belongs_to, {:child, "containerX"})
   end
 
   defp validate(socket, target, params) do

--- a/test/brando_admin/components/form/block/config_event_uid_test.exs
+++ b/test/brando_admin/components/form/block/config_event_uid_test.exs
@@ -23,6 +23,7 @@ defmodule BrandoAdmin.Components.Form.Block.ConfigEventUidTest do
   alias BrandoAdmin.Components.Form.Block.Events
   alias BrandoAdmin.Components.Form.BlockField
   alias Ecto.Changeset
+  alias Phoenix.Component
 
   defp create_module(user) do
     {:ok, module} =
@@ -94,12 +95,12 @@ defmodule BrandoAdmin.Components.Form.Block.ConfigEventUidTest do
     uid = uid_of(changeset, belongs_to)
 
     %Phoenix.LiveView.Socket{}
-    |> Phoenix.Component.assign(:form, Block.build_form_from_changeset(changeset, uid, belongs_to))
-    |> Phoenix.Component.assign(:belongs_to, belongs_to)
-    |> Phoenix.Component.assign(:module_id, module.id)
-    |> Phoenix.Component.assign(:uid, uid)
-    |> Phoenix.Component.assign(:form_id, "page_form")
-    |> Phoenix.Component.assign(:block_field, "blocks")
+    |> Component.assign(:form, Block.build_form_from_changeset(changeset, uid, belongs_to))
+    |> Component.assign(:belongs_to, belongs_to)
+    |> Component.assign(:module_id, module.id)
+    |> Component.assign(:uid, uid)
+    |> Component.assign(:form_id, "page_form")
+    |> Component.assign(:block_field, "blocks")
   end
 
   defp expected_form_id(uid, :root), do: "entry_block_form-#{uid}"

--- a/test/brando_admin/components/form/block/recover_blocks_security_test.exs
+++ b/test/brando_admin/components/form/block/recover_blocks_security_test.exs
@@ -19,6 +19,7 @@ defmodule BrandoAdmin.Components.Form.Block.RecoverBlocksSecurityTest do
   alias BrandoAdmin.Components.Form.BlockField
   alias BrandoAdmin.Components.Form.BlockField.Ops
   alias Ecto.Changeset
+  alias Phoenix.Component
 
   @block_module Brando.Pages.Page.Blocks
 
@@ -69,15 +70,15 @@ defmodule BrandoAdmin.Components.Form.Block.RecoverBlocksSecurityTest do
 
   defp socket(user, page, opts \\ []) do
     %Phoenix.LiveView.Socket{}
-    |> Phoenix.Component.assign(:block_module, @block_module)
-    |> Phoenix.Component.assign(:current_user, user)
-    |> Phoenix.Component.assign(:entry, page)
-    |> Phoenix.Component.assign(:entry_blocks, [])
-    |> Phoenix.Component.assign(:seed_forms, Keyword.get(opts, :seed_forms, %{}))
-    |> Phoenix.Component.assign(:block_ops, Ops.new(Keyword.get(opts, :order, [])))
-    |> Phoenix.Component.assign(:block_field, "blocks")
-    |> Phoenix.Component.assign(:form_id, "page_form")
-    |> Phoenix.Component.assign(:blocks_changed?, false)
+    |> Component.assign(:block_module, @block_module)
+    |> Component.assign(:current_user, user)
+    |> Component.assign(:entry, page)
+    |> Component.assign(:entry_blocks, [])
+    |> Component.assign(:seed_forms, Keyword.get(opts, :seed_forms, %{}))
+    |> Component.assign(:block_ops, Ops.new(Keyword.get(opts, :order, [])))
+    |> Component.assign(:block_field, "blocks")
+    |> Component.assign(:form_id, "page_form")
+    |> Component.assign(:blocks_changed?, false)
   end
 
   defp payload(block_params, opts \\ []) do

--- a/test/brando_admin/components/form/block/recover_children_test.exs
+++ b/test/brando_admin/components/form/block/recover_children_test.exs
@@ -24,6 +24,7 @@ defmodule BrandoAdmin.Components.Form.Block.RecoverChildrenTest do
   alias BrandoAdmin.Components.Form.BlockField
   alias BrandoAdmin.Components.Form.BlockField.Ops
   alias Ecto.Changeset
+  alias Phoenix.Component
 
   @block_module Brando.Pages.Page.Blocks
 
@@ -59,15 +60,15 @@ defmodule BrandoAdmin.Components.Form.Block.RecoverChildrenTest do
 
   defp socket(user, page) do
     %Phoenix.LiveView.Socket{}
-    |> Phoenix.Component.assign(:block_module, @block_module)
-    |> Phoenix.Component.assign(:current_user, user)
-    |> Phoenix.Component.assign(:entry, page)
-    |> Phoenix.Component.assign(:entry_blocks, [])
-    |> Phoenix.Component.assign(:seed_forms, %{})
-    |> Phoenix.Component.assign(:block_ops, Ops.new([]))
-    |> Phoenix.Component.assign(:block_field, "blocks")
-    |> Phoenix.Component.assign(:form_id, "page_form")
-    |> Phoenix.Component.assign(:blocks_changed?, false)
+    |> Component.assign(:block_module, @block_module)
+    |> Component.assign(:current_user, user)
+    |> Component.assign(:entry, page)
+    |> Component.assign(:entry_blocks, [])
+    |> Component.assign(:seed_forms, %{})
+    |> Component.assign(:block_ops, Ops.new([]))
+    |> Component.assign(:block_field, "blocks")
+    |> Component.assign(:form_id, "page_form")
+    |> Component.assign(:blocks_changed?, false)
   end
 
   # The params the hook's `formDataToParams` produces for one root block form.

--- a/test/brando_admin/components/form/block/ref_events_test.exs
+++ b/test/brando_admin/components/form/block/ref_events_test.exs
@@ -15,6 +15,7 @@ defmodule BrandoAdmin.Components.Form.Block.RefEventsTest do
   alias BrandoAdmin.Components.Form.Block.Events
   alias BrandoAdmin.Components.Form.BlockField
   alias Ecto.Changeset
+  alias Phoenix.Component
 
   defp create_module(user) do
     {:ok, module} =
@@ -70,12 +71,12 @@ defmodule BrandoAdmin.Components.Form.Block.RefEventsTest do
       end
 
     %Phoenix.LiveView.Socket{}
-    |> Phoenix.Component.assign(:form, Block.build_form_from_changeset(changeset, uid, belongs_to))
-    |> Phoenix.Component.assign(:belongs_to, belongs_to)
-    |> Phoenix.Component.assign(:module_id, module.id)
-    |> Phoenix.Component.assign(:uid, uid)
-    |> Phoenix.Component.assign(:form_id, "page_form")
-    |> Phoenix.Component.assign(:block_field, "blocks")
+    |> Component.assign(:form, Block.build_form_from_changeset(changeset, uid, belongs_to))
+    |> Component.assign(:belongs_to, belongs_to)
+    |> Component.assign(:module_id, module.id)
+    |> Component.assign(:uid, uid)
+    |> Component.assign(:form_id, "page_form")
+    |> Component.assign(:block_field, "blocks")
   end
 
   # Read the resulting refs back out of whichever level they live on.

--- a/test/brando_admin/components/form/block/ref_media_test.exs
+++ b/test/brando_admin/components/form/block/ref_media_test.exs
@@ -22,6 +22,7 @@ defmodule BrandoAdmin.Components.Form.Block.RefMediaTest do
   alias Brando.Factory
   alias BrandoAdmin.Components.Form.Block.Events
   alias Ecto.Changeset
+  alias Phoenix.Component
 
   setup do
     user = Factory.insert(:random_user)
@@ -85,19 +86,19 @@ defmodule BrandoAdmin.Components.Form.Block.RefMediaTest do
 
   defp socket_for(changeset, entry_block, user) do
     %Phoenix.LiveView.Socket{}
-    |> Phoenix.Component.assign(:form, to_form(changeset, as: "entry_block", id: "entry_block_form-blockrefs1"))
-    |> Phoenix.Component.assign(:uid, "blockrefs1")
-    |> Phoenix.Component.assign(:block_module, Brando.Pages.Page.Blocks)
-    |> Phoenix.Component.assign(:current_user_id, user.id)
-    |> Phoenix.Component.assign(:entry, entry_block.entry)
-    |> Phoenix.Component.assign(:has_vars?, false)
-    |> Phoenix.Component.assign(:has_children?, false)
-    |> Phoenix.Component.assign(:has_table_rows?, false)
-    |> Phoenix.Component.assign(:live_preview_active?, false)
-    |> Phoenix.Component.assign(:original_block_identifiers, [])
-    |> Phoenix.Component.assign(:form_id, "page_form")
-    |> Phoenix.Component.assign(:block_field, "blocks")
-    |> Phoenix.Component.assign(:belongs_to, :root)
+    |> Component.assign(:form, to_form(changeset, as: "entry_block", id: "entry_block_form-blockrefs1"))
+    |> Component.assign(:uid, "blockrefs1")
+    |> Component.assign(:block_module, Brando.Pages.Page.Blocks)
+    |> Component.assign(:current_user_id, user.id)
+    |> Component.assign(:entry, entry_block.entry)
+    |> Component.assign(:has_vars?, false)
+    |> Component.assign(:has_children?, false)
+    |> Component.assign(:has_table_rows?, false)
+    |> Component.assign(:live_preview_active?, false)
+    |> Component.assign(:original_block_identifiers, [])
+    |> Component.assign(:form_id, "page_form")
+    |> Component.assign(:block_field, "blocks")
+    |> Component.assign(:belongs_to, :root)
   end
 
   # The params a keystroke in the block's description sends. `ref_params` lets a

--- a/test/brando_admin/components/form/drawer_recovery_test.exs
+++ b/test/brando_admin/components/form/drawer_recovery_test.exs
@@ -19,6 +19,7 @@ defmodule BrandoAdmin.Components.Form.DrawerRecoveryTest do
   alias Brando.Factory
   alias BrandoAdmin.Components.Form
   alias Ecto.Changeset
+  alias Phoenix.Component
 
   setup do
     user = Factory.insert(:random_user)
@@ -28,16 +29,16 @@ defmodule BrandoAdmin.Components.Form.DrawerRecoveryTest do
 
   defp socket do
     %Phoenix.LiveView.Socket{}
-    |> Phoenix.Component.assign(:id, "page_form")
-    |> Phoenix.Component.assign(:editing_image?, false)
-    |> Phoenix.Component.assign(:editing_video?, false)
-    |> Phoenix.Component.assign(:editing_file?, false)
-    |> Phoenix.Component.assign(:edit_image, nil)
-    |> Phoenix.Component.assign(:edit_video, nil)
-    |> Phoenix.Component.assign(:edit_file, nil)
-    |> Phoenix.Component.assign(:image_changeset, nil)
-    |> Phoenix.Component.assign(:video_changeset, nil)
-    |> Phoenix.Component.assign(:file_changeset, nil)
+    |> Component.assign(:id, "page_form")
+    |> Component.assign(:editing_image?, false)
+    |> Component.assign(:editing_video?, false)
+    |> Component.assign(:editing_file?, false)
+    |> Component.assign(:edit_image, nil)
+    |> Component.assign(:edit_video, nil)
+    |> Component.assign(:edit_file, nil)
+    |> Component.assign(:image_changeset, nil)
+    |> Component.assign(:video_changeset, nil)
+    |> Component.assign(:file_changeset, nil)
   end
 
   defp drawer_params(image, changes) do

--- a/test/brando_admin/components/form/picker_select_test.exs
+++ b/test/brando_admin/components/form/picker_select_test.exs
@@ -19,6 +19,7 @@ defmodule BrandoAdmin.Components.Form.PickerSelectTest do
   alias Brando.Factory
   alias BrandoAdmin.Components.Form
   alias Ecto.Changeset
+  alias Phoenix.Component
 
   setup do
     user = Factory.insert(:random_user)
@@ -28,20 +29,20 @@ defmodule BrandoAdmin.Components.Form.PickerSelectTest do
 
   defp form_socket(page, user, edit_assigns) do
     %Phoenix.LiveView.Socket{}
-    |> Phoenix.Component.assign(:form, to_form(Changeset.change(page)))
-    |> Phoenix.Component.assign(:entry, page)
-    |> Phoenix.Component.assign(:schema, Brando.Pages.Page)
-    |> Phoenix.Component.assign(:singular, "page")
-    |> Phoenix.Component.assign(:current_user, user)
-    |> Phoenix.Component.assign(:processing_images, [])
+    |> Component.assign(:form, to_form(Changeset.change(page)))
+    |> Component.assign(:entry, page)
+    |> Component.assign(:schema, Brando.Pages.Page)
+    |> Component.assign(:singular, "page")
+    |> Component.assign(:current_user, user)
+    |> Component.assign(:processing_images, [])
     # drawer state `assign_drawer_recovery_state/1` destructures
-    |> Phoenix.Component.assign(:editing_image?, true)
-    |> Phoenix.Component.assign(:editing_video?, false)
-    |> Phoenix.Component.assign(:editing_file?, false)
-    |> Phoenix.Component.assign(:edit_image, nil)
-    |> Phoenix.Component.assign(:edit_video, nil)
-    |> Phoenix.Component.assign(:edit_file, nil)
-    |> Phoenix.Component.assign(edit_assigns)
+    |> Component.assign(:editing_image?, true)
+    |> Component.assign(:editing_video?, false)
+    |> Component.assign(:editing_file?, false)
+    |> Component.assign(:edit_image, nil)
+    |> Component.assign(:edit_video, nil)
+    |> Component.assign(:edit_file, nil)
+    |> Component.assign(edit_assigns)
   end
 
   defp committed_fk(socket, key) do

--- a/test/support/channel_case.ex
+++ b/test/support/channel_case.ex
@@ -1,7 +1,7 @@
 defmodule Brando.ChannelCase do
   @moduledoc """
-  This module defines the test case to be used by
-  channel tests.
+  Use this case template for channel tests that need the integration endpoint
+  and transactional database access.
 
   Such tests rely on `Phoenix.ChannelTest` and also
   import other functionality to make it easier

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -8,8 +8,8 @@ end
 
 defmodule Brando.ConnCase do
   @moduledoc """
-  This module defines the test case to be used by
-  tests that require setting up a connection.
+  Use this case template for tests that need a Plug connection and
+  transactional database access.
 
   Such tests rely on `Phoenix.ConnTest` and also
   imports other functionality to make it easier


### PR DESCRIPTION
## The line this draws

`Credo.Check.Design.AliasUsage` is **right wherever the natural last-segment alias is free**, and **wrong wherever that name is already taken** and the check can only be satisfied by inventing a rename.

Every `as:` alias in the original sweep fell in the second category, and each one for the same reason — the obvious alias was occupied:

| File | Credo's suggestion | Why the plain alias was unavailable |
|---|---|---|
| `modules_list_live.ex` | `alias Brando.Content, as: BrandoContent` | `Content` is `BrandoAdmin.Components.Content` in that file |
| `brando.gen.ex` | `alias Mix.Brando, as: MixBrando` | `Brando` is taken |
| `brando.gen.otel.ex` | `IgniterConfig` / `IgniterDeps` / `IgniterModule` | `Module` and `Config` are Elixir's |

An invented prefix costs the reader a trip to the top of the file to decode a name that was self-explanatory when fully qualified. Those three files keep their fully-qualified calls.

The fourth exclusion is `soft_delete/repo.ex`: `alias Ecto.Changeset` sits outside `__using__`, but `%Changeset{}` is matched *inside* the `quote`. Alias hygiene makes it compile, but the code generated into a consuming app's `Repo` then matches a struct whose alias appears nowhere in that file.

**47 files → 43.** Everything else from the sweep is kept.

## Aliases kept

All 19 are plain last-segment aliases of standard modules — the ordinary idiom, and shorter at every call site:

`Ecto.Changeset` (7) · `Phoenix.Component` (8) · `Brando.Utils` (4) · `Brando.Repo` (2) · `Plug.Conn` · `Phoenix.PubSub` · `Phoenix.Naming` · `Phoenix.HTML` · `IO.ANSI` · `Brando.Images` · `Brando.Users` · `Brando.Query` · `Brando.Cache` · `Brando.CDN` · `Brando.Content` · `Brando.Type.Role` · `Brando.Blueprint.Relations` · `Brando.Villain.Parser` · `Brando.Villain.RenderSourceQuery`

## Code improvements

**Dynamic dispatch instead of `apply/3`** where the module is a variable and the function is known at the call site — `Images.Operations.Info`, `Images.Operations.Sizing`, `Pages.list_templates/0`, `System.check_image_processing_executable/0`, `BlockField.Ops.put_data_pk/2`.

**`Utils.do_active_path?/2`** no longer splits the pattern just to ask whether it ends in a wildcard. `wildcard_path?/1` answers from the string; the split happens only on the branch that consumes it. Behaviour unchanged for `"*"`, `"/admin/*"`, `"/admin/foo*"` and `"//*"`, and the existing seven `active_path?/2` assertions cover it.

**`Form.cast_form_path_segments/1`** returns `{:ok, path, key}` directly. It built the list with `acc ++ [casted]` per segment, and the caller then used `List.last/1` and `Enum.drop(-1)` to pull it back apart — a quadratic append to construct something immediately decomposed. It now prepends and reverses once. This also drops a latent bug: `List.last([])` is `nil`, which passes the caller's `is_atom(key)` guard, so an empty path could produce a `nil` key.

**`Villain.Parser.parse_youtube_time/1`** was a two-branch `cond` whose second branch was `true`. That is an `if`.

**`reapply_test`** destructures `refs` and matches each ref's block type instead of indexing with `List.first/1` and `List.last/1`, so a reordering fails at the match rather than silently comparing the wrong ref.

**Two test case moduledocs** now say what the case template is for.

## Validation

Rebased onto `next` @ `56731bf66`. One conflict in `lib/mix/brando.ex` — `next` added `prompt/1` in c44d6f6ca, this branch added `alias Phoenix.Naming`; both kept.

- `mix format --check-formatted`
- `mix compile --warnings-as-errors`
- `mix test --warnings-as-errors` — 1789 passed (135 doctests, 1654 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016f8YajqmhZdUnjQpcxPHHw