### PR TITLE
Polish frontend asset management

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -78,6 +78,7 @@
 @import "./views/assets/Images.css";
 @import "./views/config/Cache.css";
 @import "./views/config/Environments.css";
+@import "./views/config/FrontendAssets.css";
 @import "./views/config/Globals.css";
 @import "./views/config/ScheduledPublishing.css";
 @import "./views/config/Utils.css";

--- a/assets/css/views/config/FrontendAssets.css
+++ b/assets/css/views/config/FrontendAssets.css
@@ -1,0 +1,362 @@
+.frontend-assets-live {
+  display: grid;
+  gap: 24px;
+  padding-bottom: 80px;
+
+  .frontend-assets-current,
+  .frontend-assets-library {
+    border: 1px solid color-mix(in srgb, var(--brando-color-dark) 18%, transparent);
+    border-radius: 16px;
+    background: var(--brando-color-white);
+    box-shadow: 0 2px 10px color-mix(in srgb, var(--brando-color-dark) 5%, transparent);
+  }
+
+  .frontend-assets-current {
+    position: relative;
+    display: grid;
+    grid-template-columns: 58px minmax(0, 1fr) auto;
+    align-items: center;
+    gap: 22px;
+    overflow: hidden;
+    padding: 26px;
+
+    &::before {
+      position: absolute;
+      top: 0;
+      bottom: 0;
+      left: 0;
+      width: 4px;
+      background: color-mix(in srgb, var(--brando-color-dark) 38%, transparent);
+      content: "";
+    }
+
+    &.uploaded {
+      background: color-mix(in srgb, var(--brando-color-blue) 4%, var(--brando-color-white));
+
+      &::before {
+        background: var(--brando-color-blue);
+      }
+    }
+  }
+
+  .frontend-assets-current__icon,
+  .frontend-assets-build__icon,
+  .frontend-assets-empty__icon {
+    display: inline-grid;
+    place-items: center;
+    flex: 0 0 auto;
+    border-radius: 14px;
+    background: var(--brando-color-dark);
+    color: var(--brando-color-peach);
+
+    svg {
+      width: 24px;
+      height: 24px;
+    }
+  }
+
+  .frontend-assets-current__icon {
+    width: 58px;
+    height: 58px;
+  }
+
+  .frontend-assets-eyebrow,
+  dt {
+    @font mono;
+    font-size: 10px;
+    font-weight: 500;
+    letter-spacing: 0.08em;
+    line-height: 1.3;
+    text-transform: uppercase;
+  }
+
+  .frontend-assets-eyebrow {
+    display: block;
+    margin-bottom: 7px;
+    color: color-mix(in srgb, var(--brando-color-dark) 62%, transparent);
+  }
+
+  h2,
+  h3,
+  p,
+  dl,
+  dd {
+    margin: 0;
+  }
+
+  .frontend-assets-current__content h2 {
+    margin-bottom: 5px;
+    font-size: clamp(24px, 3vw, 34px);
+    line-height: 1.05;
+  }
+
+  .frontend-assets-current__content > p,
+  .frontend-assets-library > header p,
+  .frontend-assets-empty p {
+    max-width: 720px;
+    color: color-mix(in srgb, var(--brando-color-dark) 68%, transparent);
+    line-height: 1.5;
+  }
+
+  .frontend-assets-current__meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 18px 30px;
+    margin-top: 20px;
+
+    > div {
+      min-width: 120px;
+    }
+
+    dt {
+      margin-bottom: 4px;
+      color: color-mix(in srgb, var(--brando-color-dark) 52%, transparent);
+    }
+
+    dd {
+      font-size: 13px;
+      line-height: 1.4;
+    }
+
+    dd + dd {
+      color: color-mix(in srgb, var(--brando-color-dark) 58%, transparent);
+    }
+  }
+
+  .frontend-assets-current__actions,
+  .frontend-assets-build__actions {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: 12px;
+  }
+
+  .frontend-assets-current__actions {
+    flex-direction: column;
+    align-items: flex-end;
+  }
+
+  .frontend-assets-status,
+  .frontend-assets-count {
+    display: inline-flex;
+    align-items: center;
+    gap: 7px;
+    white-space: nowrap;
+    border: 1px solid color-mix(in srgb, var(--brando-color-dark) 16%, transparent);
+    border-radius: 999px;
+    background: color-mix(in srgb, var(--brando-color-dark) 5%, transparent);
+    padding: 7px 11px;
+    font-size: 11px;
+    font-weight: 500;
+    line-height: 1;
+  }
+
+  .frontend-assets-status > span {
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+    background: color-mix(in srgb, var(--brando-color-dark) 36%, transparent);
+  }
+
+  .frontend-assets-status.active {
+    border-color: color-mix(in srgb, #21875c 28%, transparent);
+    background: color-mix(in srgb, #2bb673 12%, var(--brando-color-white));
+
+    > span {
+      background: #21875c;
+      box-shadow: 0 0 0 3px color-mix(in srgb, #2bb673 16%, transparent);
+    }
+  }
+
+  .frontend-assets-library {
+    overflow: hidden;
+  }
+
+  .frontend-assets-library > header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 24px;
+    padding: 24px 26px;
+    border-bottom: 1px solid color-mix(in srgb, var(--brando-color-dark) 12%, transparent);
+
+    h2 {
+      margin-bottom: 6px;
+      font-size: 22px;
+    }
+  }
+
+  .frontend-assets-count {
+    margin-top: 2px;
+  }
+
+  .frontend-assets-empty {
+    display: grid;
+    justify-items: center;
+    padding: 62px 24px 68px;
+    text-align: center;
+
+    h3 {
+      margin: 18px 0 7px;
+      font-size: 18px;
+    }
+
+    p {
+      max-width: 520px;
+    }
+  }
+
+  .frontend-assets-empty__icon {
+    width: 52px;
+    height: 52px;
+    background: color-mix(in srgb, var(--brando-color-dark) 8%, transparent);
+    color: var(--brando-color-dark);
+  }
+
+  .frontend-assets-list {
+    display: grid;
+  }
+
+  .frontend-assets-build {
+    position: relative;
+    display: grid;
+    grid-template-columns: 44px minmax(180px, 1fr) minmax(260px, 0.9fr) auto;
+    align-items: center;
+    gap: 18px;
+    min-height: 96px;
+    padding: 18px 24px;
+    border-bottom: 1px solid color-mix(in srgb, var(--brando-color-dark) 10%, transparent);
+    transition: background-color 0.15s ease;
+
+    &:last-child {
+      border-bottom: 0;
+    }
+
+    &:hover {
+      background: color-mix(in srgb, var(--brando-color-dark) 2.5%, transparent);
+    }
+
+    &.active {
+      background: color-mix(in srgb, var(--brando-color-blue) 4%, var(--brando-color-white));
+      box-shadow: inset 3px 0 0 var(--brando-color-blue);
+    }
+  }
+
+  .frontend-assets-build__icon {
+    width: 44px;
+    height: 44px;
+    border-radius: 11px;
+    background: color-mix(in srgb, var(--brando-color-dark) 8%, transparent);
+    color: var(--brando-color-dark);
+
+    svg {
+      width: 20px;
+      height: 20px;
+    }
+  }
+
+  .frontend-assets-build__identity {
+    min-width: 0;
+
+    h3 {
+      margin-bottom: 5px;
+      font-size: 16px;
+    }
+
+    code {
+      display: block;
+      overflow: hidden;
+      padding: 0;
+      background: transparent;
+      color: color-mix(in srgb, var(--brando-color-dark) 58%, transparent);
+      font-size: 11px;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+  }
+
+  .frontend-assets-build__meta {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 14px;
+
+    dt {
+      margin-bottom: 4px;
+      color: color-mix(in srgb, var(--brando-color-dark) 48%, transparent);
+    }
+
+    dd {
+      font-size: 12px;
+      line-height: 1.4;
+    }
+  }
+
+  @media (max-width: 1080px) {
+    .frontend-assets-current {
+      grid-template-columns: 58px minmax(0, 1fr);
+    }
+
+    .frontend-assets-current__actions {
+      grid-column: 2;
+      flex-direction: row;
+      align-items: center;
+      justify-content: flex-start;
+    }
+
+    .frontend-assets-build {
+      grid-template-columns: 44px minmax(0, 1fr) auto;
+    }
+
+    .frontend-assets-build__meta {
+      grid-column: 2;
+      grid-row: 2;
+    }
+
+    .frontend-assets-build__actions {
+      grid-column: 3;
+      grid-row: 1 / span 2;
+    }
+  }
+
+  @media (max-width: 700px) {
+    .frontend-assets-current {
+      grid-template-columns: 1fr;
+      padding: 22px;
+    }
+
+    .frontend-assets-current__actions,
+    .frontend-assets-current__content,
+    .frontend-assets-current__icon {
+      grid-column: 1;
+    }
+
+    .frontend-assets-current__actions {
+      align-items: flex-start;
+    }
+
+    .frontend-assets-library > header {
+      display: grid;
+      padding: 22px;
+    }
+
+    .frontend-assets-count {
+      width: max-content;
+    }
+
+    .frontend-assets-build {
+      grid-template-columns: 44px minmax(0, 1fr);
+      padding: 18px 20px;
+    }
+
+    .frontend-assets-build__meta,
+    .frontend-assets-build__actions {
+      grid-column: 1 / -1;
+      grid-row: auto;
+    }
+
+    .frontend-assets-build__actions {
+      justify-content: flex-start;
+      flex-wrap: wrap;
+    }
+  }
+}

--- a/lib/brando_admin/live/config/asset_live.ex
+++ b/lib/brando_admin/live/config/asset_live.ex
@@ -20,6 +20,7 @@ defmodule BrandoAdmin.Sites.AssetLive do
          socket
          |> assign(:socket_connected, true)
          |> assign(:scope_site, scope_site(socket))
+         |> set_admin_locale()
          |> refresh()}
 
       true ->
@@ -37,74 +38,131 @@ defmodule BrandoAdmin.Sites.AssetLive do
     ~H"""
     <Content.header
       title={gettext("Frontend assets")}
-      subtitle={gettext("Activate or revert persistent frontend builds without deploying a release")}
+      subtitle={gettext("Manage the frontend build currently served by Phoenix")}
     >
       <button type="button" class="secondary" phx-click="refresh">{gettext("Refresh")}</button>
     </Content.header>
 
-    <div class="environment-management-live">
-      <section class="environment-panel">
-        <header>
-          <div>
-            <h2>{scope_name(@scope_site)}</h2>
-            <p>{gettext("Florist registers uploaded sets here; registration never activates a build.")}</p>
-          </div>
-          <button
-            type="button"
-            class="danger"
-            disabled={is_nil(@active_set)}
-            phx-click="deactivate"
-            phx-confirm={gettext("Revert to the frontend assets included in the current release?")}
-          >
-            {gettext("Revert to release assets")}
-          </button>
-        </header>
-
-        <div :if={@sets == []} class="environment-notice">
-          {gettext("No uploaded frontend asset sets have been registered.")}
+    <div class="frontend-assets-live">
+      <section class={["frontend-assets-current", @active_set && "uploaded"]}>
+        <div class="frontend-assets-current__icon">
+          <.icon name={if @active_set, do: "hero-cube-transparent", else: "hero-code-bracket"} />
         </div>
 
-        <div :if={@sets != []} class="environment-table-wrap">
-          <table>
-            <thead>
-              <tr>
-                <th>{gettext("Set")}</th>
-                <th>{gettext("Uploaded")}</th>
-                <th>{gettext("Files")}</th>
-                <th>{gettext("Size")}</th>
-                <th>{gettext("State")}</th>
-                <th>{gettext("Actions")}</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr :for={asset_set <- @sets} id={"asset-set-#{asset_set.id}"}>
-                <td>
-                  <strong>{asset_set.name}</strong>
-                  <code>{asset_set.metadata["revision"] || asset_set.path}</code>
-                </td>
-                <td>{format_datetime(asset_set.uploaded_at)}</td>
-                <td>{asset_set.file_count}</td>
-                <td>{format_size(asset_set.size)}</td>
-                <td>
-                  <span class={["environment-state", asset_set.active && "live"]}>
-                    {if asset_set.active, do: gettext("Active"), else: gettext("Available")}
-                  </span>
-                </td>
-                <td>
-                  <button
-                    :if={!asset_set.active}
-                    type="button"
-                    class="primary small"
-                    phx-click="activate"
-                    phx-value-id={asset_set.id}
-                    phx-confirm={gettext("Activate %{name} immediately?", name: asset_set.name)}
-                  >
-                    {gettext("Activate")}
-                  </button>
-                </td>
-              </tr>
-            </tbody>
-          </table>
+        <div class="frontend-assets-current__content">
+          <span class="frontend-assets-eyebrow">
+            {gettext("Currently served")} · {scope_name(@scope_site)}
+          </span>
+          <h2>{if @active_set, do: @active_set.name, else: gettext("Release assets")}</h2>
+          <p>
+            {if @active_set,
+              do: gettext("This uploaded build is serving frontend requests now."),
+              else: gettext("The CSS and JavaScript packaged with the current application release are being served.")}
+          </p>
+
+          <dl :if={@active_set} class="frontend-assets-current__meta">
+            <div>
+              <dt>{gettext("Revision")}</dt>
+              <dd>{@active_set.metadata["revision"] || gettext("Not provided")}</dd>
+            </div>
+            <div>
+              <dt>{gettext("Uploaded")}</dt>
+              <dd>{format_datetime(@active_set.uploaded_at)}</dd>
+            </div>
+            <div>
+              <dt>{gettext("Bundle")}</dt>
+              <dd>{ngettext("%{count} file", "%{count} files", @active_set.file_count)}</dd>
+              <dd>{format_size(@active_set.size)}</dd>
+            </div>
+          </dl>
+        </div>
+
+        <div class="frontend-assets-current__actions">
+          <span class="frontend-assets-status active">
+            <span aria-hidden="true"></span>
+            {gettext("Serving now")}
+          </span>
+          <button
+            :if={@active_set}
+            type="button"
+            class="secondary small"
+            phx-click="deactivate"
+            phx-confirm={gettext("Use the frontend assets included in the current release?")}
+          >
+            {gettext("Use release assets")}
+          </button>
+        </div>
+      </section>
+
+      <section class="frontend-assets-library">
+        <header>
+          <div>
+            <span class="frontend-assets-eyebrow">{gettext("Build library")}</span>
+            <h2>{gettext("Uploaded builds")}</h2>
+            <p>
+              {gettext(
+                "Florist registers each build here. Activating one takes effect immediately and does not deploy the application."
+              )}
+            </p>
+          </div>
+          <span class="frontend-assets-count">
+            {ngettext("%{count} build", "%{count} builds", length(@sets))}
+          </span>
+        </header>
+
+        <div :if={@sets == []} class="frontend-assets-empty">
+          <span class="frontend-assets-empty__icon"><.icon name="hero-arrow-path" /></span>
+          <h3>{gettext("No uploaded builds yet")}</h3>
+          <p>
+            {gettext("The frontend packaged with the current release remains active until Florist registers a build.")}
+          </p>
+        </div>
+
+        <div :if={@sets != []} class="frontend-assets-list">
+          <article
+            :for={asset_set <- @sets}
+            id={"asset-set-#{asset_set.id}"}
+            class={["frontend-assets-build", asset_set.active && "active"]}
+          >
+            <span class="frontend-assets-build__icon"><.icon name="hero-cube-transparent" /></span>
+
+            <div class="frontend-assets-build__identity">
+              <h3>{asset_set.name}</h3>
+              <code>{asset_set.metadata["revision"] || asset_set.path}</code>
+            </div>
+
+            <dl class="frontend-assets-build__meta">
+              <div>
+                <dt>{gettext("Uploaded")}</dt>
+                <dd>{format_datetime(asset_set.uploaded_at)}</dd>
+              </div>
+              <div>
+                <dt>{gettext("Bundle")}</dt>
+                <dd>
+                  {ngettext("%{count} file", "%{count} files", asset_set.file_count)} · {format_size(asset_set.size)}
+                </dd>
+              </div>
+            </dl>
+
+            <div class="frontend-assets-build__actions">
+              <span class={["frontend-assets-status", asset_set.active && "active"]}>
+                <span aria-hidden="true"></span>
+                {if asset_set.active, do: gettext("Active"), else: gettext("Available")}
+              </span>
+              <button
+                :if={!asset_set.active}
+                type="button"
+                class="primary small"
+                phx-click="activate"
+                phx-value-id={asset_set.id}
+                phx-confirm={
+                  gettext("Activate %{name} now? Frontend requests will switch immediately.", name: asset_set.name)
+                }
+              >
+                {gettext("Activate build")}
+              </button>
+            </div>
+          </article>
         </div>
       </section>
     </div>
@@ -151,7 +209,15 @@ defmodule BrandoAdmin.Sites.AssetLive do
     if Tenant.mode() == :multi, do: socket.assigns[:current_site], else: nil
   end
 
-  defp scope_name(nil), do: gettext("Standalone frontend")
+  defp set_admin_locale(%{assigns: %{current_user: current_user}} = socket) do
+    current_user.language
+    |> to_string()
+    |> Gettext.put_locale()
+
+    socket
+  end
+
+  defp scope_name(nil), do: gettext("This installation")
   defp scope_name(site), do: site.name
 
   defp format_datetime(%DateTime{} = datetime),

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -3129,6 +3129,9 @@ msgstr ""
 msgid "Save changes"
 msgstr ""
 
+#: lib/brando_admin/components/file_picker.ex:213
+#: lib/brando_admin/live/config/asset_live.ex:77
+#: lib/brando_admin/live/config/asset_live.ex:147
 #: lib/brando_admin/live/files/file_list_live.ex:236
 #, elixir-autogen, elixir-format
 msgid "%{count} file"
@@ -3877,4 +3880,156 @@ msgstr ""
 #: lib/brando_admin/components/form/block_field.ex:1277
 #, elixir-autogen, elixir-format
 msgid "Undo"
+msgstr ""
+
+#: lib/brando_admin/live/config/asset_live.ex:112
+#, elixir-autogen, elixir-format
+msgid "%{count} build"
+msgid_plural "%{count} builds"
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/brando_admin/live/config/asset_live.ex:164
+#, elixir-autogen, elixir-format
+msgid "Activate %{name} now? Frontend requests will switch immediately."
+msgstr ""
+
+#: lib/brando_admin/live/config/asset_live.ex:167
+#, elixir-autogen, elixir-format
+msgid "Activate build"
+msgstr ""
+
+#: lib/brando_admin/live/config/asset_live.ex:184
+#, elixir-autogen, elixir-format
+msgid "Activated %{name}"
+msgstr ""
+
+#: lib/brando_admin/live/config/asset_live.ex:155
+#, elixir-autogen, elixir-format
+msgid "Active"
+msgstr ""
+
+#: lib/brando_admin/live/config/asset_live.ex:155
+#, elixir-autogen, elixir-format
+msgid "Available"
+msgstr ""
+
+#: lib/brando_admin/live/config/asset_live.ex:103
+#, elixir-autogen, elixir-format
+msgid "Build library"
+msgstr ""
+
+#: lib/brando_admin/live/config/asset_live.ex:76
+#: lib/brando_admin/live/config/asset_live.ex:145
+#, elixir-autogen, elixir-format
+msgid "Bundle"
+msgstr ""
+
+#: lib/brando_admin/live/config/asset_live.ex:188
+#, elixir-autogen, elixir-format
+msgid "Could not activate the frontend asset set"
+msgstr ""
+
+#: lib/brando_admin/live/config/asset_live.ex:200
+#, elixir-autogen, elixir-format
+msgid "Could not revert the frontend assets"
+msgstr ""
+
+#: lib/brando_admin/live/config/asset_live.ex:54
+#, elixir-autogen, elixir-format
+msgid "Currently served"
+msgstr ""
+
+#: lib/brando_admin/live/config/asset_live.ex:106
+#, elixir-autogen, elixir-format
+msgid ""
+"Florist registers each build here. Activating one takes effect immediately "
+"and does not deploy the application."
+msgstr ""
+
+#: lib/brando_admin/live/config/asset_live.ex:40
+#: lib/brando_admin/menu.ex:388
+#, elixir-autogen, elixir-format
+msgid "Frontend assets"
+msgstr ""
+
+#: lib/brando_admin/live/config/asset_live.ex:41
+#, elixir-autogen, elixir-format
+msgid "Manage the frontend build currently served by Phoenix"
+msgstr ""
+
+#: lib/brando_admin/live/config/asset_live.ex:118
+#, elixir-autogen, elixir-format
+msgid "No uploaded builds yet"
+msgstr ""
+
+#: lib/brando_admin/live/config/asset_live.ex:69
+#, elixir-autogen, elixir-format
+msgid "Not provided"
+msgstr ""
+
+#: lib/brando_admin/live/config/asset_live.ex:56
+#, elixir-autogen, elixir-format
+msgid "Release assets"
+msgstr ""
+
+#: lib/brando_admin/live/config/asset_live.ex:196
+#, elixir-autogen, elixir-format
+msgid "Reverted to release assets"
+msgstr ""
+
+#: lib/brando_admin/components/form/revisions_drawer.ex:115
+#: lib/brando_admin/live/config/asset_live.ex:68
+#, elixir-autogen, elixir-format
+msgid "Revision"
+msgstr ""
+
+#: lib/brando_admin/live/config/asset_live.ex:86
+#, elixir-autogen, elixir-format
+msgid "Serving now"
+msgstr ""
+
+#: lib/brando_admin/live/config/asset_live.ex:61
+#, elixir-autogen, elixir-format
+msgid ""
+"The CSS and JavaScript packaged with the current application release are "
+"being served."
+msgstr ""
+
+#: lib/brando_admin/live/config/asset_live.ex:120
+#, elixir-autogen, elixir-format
+msgid ""
+"The frontend packaged with the current release remains active until Florist "
+"registers a build."
+msgstr ""
+
+#: lib/brando_admin/live/config/asset_live.ex:225
+#, elixir-autogen, elixir-format
+msgid "This installation"
+msgstr ""
+
+#: lib/brando_admin/live/config/asset_live.ex:59
+#, elixir-autogen, elixir-format
+msgid "This uploaded build is serving frontend requests now."
+msgstr ""
+
+#: lib/brando_admin/live/config/asset_live.ex:72
+#: lib/brando_admin/live/config/asset_live.ex:141
+#, elixir-autogen, elixir-format
+msgid "Uploaded"
+msgstr ""
+
+#: lib/brando_admin/live/config/asset_live.ex:104
+#, elixir-autogen, elixir-format
+msgid "Uploaded builds"
+msgstr ""
+
+#: lib/brando_admin/live/config/asset_live.ex:95
+#, elixir-autogen, elixir-format
+msgid "Use release assets"
+msgstr ""
+
+#: lib/brando_admin/live/config/asset_live.ex:93
+#, elixir-autogen, elixir-format
+msgid "Use the frontend assets included in the current release?"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -3129,8 +3129,11 @@ msgstr ""
 msgid "Save changes"
 msgstr ""
 
+#: lib/brando_admin/components/file_picker.ex:213
+#: lib/brando_admin/live/config/asset_live.ex:77
+#: lib/brando_admin/live/config/asset_live.ex:147
 #: lib/brando_admin/live/files/file_list_live.ex:236
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "%{count} file"
 msgid_plural "%{count} files"
 msgstr[0] ""
@@ -3877,4 +3880,156 @@ msgstr ""
 #: lib/brando_admin/components/form/block_field.ex:1277
 #, elixir-autogen, elixir-format
 msgid "Undo"
+msgstr ""
+
+#: lib/brando_admin/live/config/asset_live.ex:112
+#, elixir-autogen, elixir-format
+msgid "%{count} build"
+msgid_plural "%{count} builds"
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/brando_admin/live/config/asset_live.ex:164
+#, elixir-autogen, elixir-format
+msgid "Activate %{name} now? Frontend requests will switch immediately."
+msgstr ""
+
+#: lib/brando_admin/live/config/asset_live.ex:167
+#, elixir-autogen, elixir-format
+msgid "Activate build"
+msgstr ""
+
+#: lib/brando_admin/live/config/asset_live.ex:184
+#, elixir-autogen, elixir-format
+msgid "Activated %{name}"
+msgstr ""
+
+#: lib/brando_admin/live/config/asset_live.ex:155
+#, elixir-autogen, elixir-format
+msgid "Active"
+msgstr ""
+
+#: lib/brando_admin/live/config/asset_live.ex:155
+#, elixir-autogen, elixir-format
+msgid "Available"
+msgstr ""
+
+#: lib/brando_admin/live/config/asset_live.ex:103
+#, elixir-autogen, elixir-format
+msgid "Build library"
+msgstr ""
+
+#: lib/brando_admin/live/config/asset_live.ex:76
+#: lib/brando_admin/live/config/asset_live.ex:145
+#, elixir-autogen, elixir-format
+msgid "Bundle"
+msgstr ""
+
+#: lib/brando_admin/live/config/asset_live.ex:188
+#, elixir-autogen, elixir-format
+msgid "Could not activate the frontend asset set"
+msgstr ""
+
+#: lib/brando_admin/live/config/asset_live.ex:200
+#, elixir-autogen, elixir-format
+msgid "Could not revert the frontend assets"
+msgstr ""
+
+#: lib/brando_admin/live/config/asset_live.ex:54
+#, elixir-autogen, elixir-format
+msgid "Currently served"
+msgstr ""
+
+#: lib/brando_admin/live/config/asset_live.ex:106
+#, elixir-autogen, elixir-format
+msgid ""
+"Florist registers each build here. Activating one takes effect immediately "
+"and does not deploy the application."
+msgstr ""
+
+#: lib/brando_admin/live/config/asset_live.ex:40
+#: lib/brando_admin/menu.ex:388
+#, elixir-autogen, elixir-format
+msgid "Frontend assets"
+msgstr ""
+
+#: lib/brando_admin/live/config/asset_live.ex:41
+#, elixir-autogen, elixir-format
+msgid "Manage the frontend build currently served by Phoenix"
+msgstr ""
+
+#: lib/brando_admin/live/config/asset_live.ex:118
+#, elixir-autogen, elixir-format
+msgid "No uploaded builds yet"
+msgstr ""
+
+#: lib/brando_admin/live/config/asset_live.ex:69
+#, elixir-autogen, elixir-format
+msgid "Not provided"
+msgstr ""
+
+#: lib/brando_admin/live/config/asset_live.ex:56
+#, elixir-autogen, elixir-format
+msgid "Release assets"
+msgstr ""
+
+#: lib/brando_admin/live/config/asset_live.ex:196
+#, elixir-autogen, elixir-format
+msgid "Reverted to release assets"
+msgstr ""
+
+#: lib/brando_admin/components/form/revisions_drawer.ex:115
+#: lib/brando_admin/live/config/asset_live.ex:68
+#, elixir-autogen, elixir-format
+msgid "Revision"
+msgstr ""
+
+#: lib/brando_admin/live/config/asset_live.ex:86
+#, elixir-autogen, elixir-format
+msgid "Serving now"
+msgstr ""
+
+#: lib/brando_admin/live/config/asset_live.ex:61
+#, elixir-autogen, elixir-format
+msgid ""
+"The CSS and JavaScript packaged with the current application release are "
+"being served."
+msgstr ""
+
+#: lib/brando_admin/live/config/asset_live.ex:120
+#, elixir-autogen, elixir-format
+msgid ""
+"The frontend packaged with the current release remains active until Florist "
+"registers a build."
+msgstr ""
+
+#: lib/brando_admin/live/config/asset_live.ex:225
+#, elixir-autogen, elixir-format
+msgid "This installation"
+msgstr ""
+
+#: lib/brando_admin/live/config/asset_live.ex:59
+#, elixir-autogen, elixir-format
+msgid "This uploaded build is serving frontend requests now."
+msgstr ""
+
+#: lib/brando_admin/live/config/asset_live.ex:72
+#: lib/brando_admin/live/config/asset_live.ex:141
+#, elixir-autogen, elixir-format
+msgid "Uploaded"
+msgstr ""
+
+#: lib/brando_admin/live/config/asset_live.ex:104
+#, elixir-autogen, elixir-format
+msgid "Uploaded builds"
+msgstr ""
+
+#: lib/brando_admin/live/config/asset_live.ex:95
+#, elixir-autogen, elixir-format
+msgid "Use release assets"
+msgstr ""
+
+#: lib/brando_admin/live/config/asset_live.ex:93
+#, elixir-autogen, elixir-format
+msgid "Use the frontend assets included in the current release?"
 msgstr ""

--- a/priv/gettext/no/LC_MESSAGES/default.po
+++ b/priv/gettext/no/LC_MESSAGES/default.po
@@ -3130,12 +3130,15 @@ msgstr "Nytt bilde opprettet."
 msgid "Save changes"
 msgstr "Lagre endringer"
 
+#: lib/brando_admin/components/file_picker.ex:213
+#: lib/brando_admin/live/config/asset_live.ex:77
+#: lib/brando_admin/live/config/asset_live.ex:147
 #: lib/brando_admin/live/files/file_list_live.ex:236
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "%{count} file"
 msgid_plural "%{count} files"
-msgstr[0] "%{count} valgt"
-msgstr[1] "%{count} valgt"
+msgstr[0] "%{count} fil"
+msgstr[1] "%{count} filer"
 
 #: lib/brando_admin/components/image_picker.ex:302
 #: lib/brando_admin/live/images/image_list_live.ex:237
@@ -3879,3 +3882,159 @@ msgstr "Nullstill video"
 #, elixir-autogen, elixir-format
 msgid "Undo"
 msgstr "Angre"
+
+#: lib/brando_admin/live/config/asset_live.ex:112
+#, elixir-autogen, elixir-format
+msgid "%{count} build"
+msgid_plural "%{count} builds"
+msgstr[0] "%{count} bygg"
+msgstr[1] "%{count} bygg"
+
+#: lib/brando_admin/live/config/asset_live.ex:164
+#, elixir-autogen, elixir-format
+msgid "Activate %{name} now? Frontend requests will switch immediately."
+msgstr "Aktiver %{name} nå? Frontend-filene byttes umiddelbart."
+
+#: lib/brando_admin/live/config/asset_live.ex:167
+#, elixir-autogen, elixir-format
+msgid "Activate build"
+msgstr "Aktiver bygg"
+
+#: lib/brando_admin/live/config/asset_live.ex:184
+#, elixir-autogen, elixir-format
+msgid "Activated %{name}"
+msgstr "Aktiverte %{name}"
+
+#: lib/brando_admin/live/config/asset_live.ex:155
+#, elixir-autogen, elixir-format
+msgid "Active"
+msgstr "Aktiv"
+
+#: lib/brando_admin/live/config/asset_live.ex:155
+#, elixir-autogen, elixir-format
+msgid "Available"
+msgstr "Tilgjengelig"
+
+#: lib/brando_admin/live/config/asset_live.ex:103
+#, elixir-autogen, elixir-format
+msgid "Build library"
+msgstr "Byggbibliotek"
+
+#: lib/brando_admin/live/config/asset_live.ex:76
+#: lib/brando_admin/live/config/asset_live.ex:145
+#, elixir-autogen, elixir-format
+msgid "Bundle"
+msgstr "Pakke"
+
+#: lib/brando_admin/live/config/asset_live.ex:188
+#, elixir-autogen, elixir-format
+msgid "Could not activate the frontend asset set"
+msgstr "Kunne ikke aktivere frontend-pakken"
+
+#: lib/brando_admin/live/config/asset_live.ex:200
+#, elixir-autogen, elixir-format
+msgid "Could not revert the frontend assets"
+msgstr "Kunne ikke bytte til frontend-filene fra releasen"
+
+#: lib/brando_admin/live/config/asset_live.ex:54
+#, elixir-autogen, elixir-format
+msgid "Currently served"
+msgstr "I bruk nå"
+
+#: lib/brando_admin/live/config/asset_live.ex:106
+#, elixir-autogen, elixir-format
+msgid ""
+"Florist registers each build here. Activating one takes effect immediately "
+"and does not deploy the application."
+msgstr ""
+"Florist registrerer hvert bygg her. Aktivering trer i kraft umiddelbart og "
+"deployer ikke applikasjonen."
+
+#: lib/brando_admin/live/config/asset_live.ex:40
+#: lib/brando_admin/menu.ex:388
+#, elixir-autogen, elixir-format
+msgid "Frontend assets"
+msgstr "Frontend-ressurser"
+
+#: lib/brando_admin/live/config/asset_live.ex:41
+#, elixir-autogen, elixir-format
+msgid "Manage the frontend build currently served by Phoenix"
+msgstr "Administrer frontend-bygget som leveres av Phoenix"
+
+#: lib/brando_admin/live/config/asset_live.ex:118
+#, elixir-autogen, elixir-format
+msgid "No uploaded builds yet"
+msgstr "Ingen opplastede bygg ennå"
+
+#: lib/brando_admin/live/config/asset_live.ex:69
+#, elixir-autogen, elixir-format
+msgid "Not provided"
+msgstr "Ikke oppgitt"
+
+#: lib/brando_admin/live/config/asset_live.ex:56
+#, elixir-autogen, elixir-format
+msgid "Release assets"
+msgstr "Frontend-filer fra release"
+
+#: lib/brando_admin/live/config/asset_live.ex:196
+#, elixir-autogen, elixir-format
+msgid "Reverted to release assets"
+msgstr "Byttet til frontend-filer fra release"
+
+#: lib/brando_admin/components/form/revisions_drawer.ex:115
+#: lib/brando_admin/live/config/asset_live.ex:68
+#, elixir-autogen, elixir-format
+msgid "Revision"
+msgstr "Revisjon"
+
+#: lib/brando_admin/live/config/asset_live.ex:86
+#, elixir-autogen, elixir-format
+msgid "Serving now"
+msgstr "I bruk nå"
+
+#: lib/brando_admin/live/config/asset_live.ex:61
+#, elixir-autogen, elixir-format
+msgid ""
+"The CSS and JavaScript packaged with the current application release are "
+"being served."
+msgstr "CSS og JavaScript fra gjeldende applikasjonsrelease er i bruk."
+
+#: lib/brando_admin/live/config/asset_live.ex:120
+#, elixir-autogen, elixir-format
+msgid ""
+"The frontend packaged with the current release remains active until Florist "
+"registers a build."
+msgstr ""
+"Frontend-filene som følger med gjeldende release, forblir aktive til Florist "
+"registrerer et bygg."
+
+#: lib/brando_admin/live/config/asset_live.ex:225
+#, elixir-autogen, elixir-format
+msgid "This installation"
+msgstr "Denne installasjonen"
+
+#: lib/brando_admin/live/config/asset_live.ex:59
+#, elixir-autogen, elixir-format
+msgid "This uploaded build is serving frontend requests now."
+msgstr "Dette opplastede bygget leverer frontend-filene nå."
+
+#: lib/brando_admin/live/config/asset_live.ex:72
+#: lib/brando_admin/live/config/asset_live.ex:141
+#, elixir-autogen, elixir-format
+msgid "Uploaded"
+msgstr "Lastet opp"
+
+#: lib/brando_admin/live/config/asset_live.ex:104
+#, elixir-autogen, elixir-format
+msgid "Uploaded builds"
+msgstr "Opplastede bygg"
+
+#: lib/brando_admin/live/config/asset_live.ex:95
+#, elixir-autogen, elixir-format
+msgid "Use release assets"
+msgstr "Bruk filer fra release"
+
+#: lib/brando_admin/live/config/asset_live.ex:93
+#, elixir-autogen, elixir-format
+msgid "Use the frontend assets included in the current release?"
+msgstr "Bruk frontend-filene som følger med gjeldende release?"

--- a/test/brando_admin/live/asset_live_test.exs
+++ b/test/brando_admin/live/asset_live_test.exs
@@ -29,21 +29,38 @@ defmodule BrandoAdmin.Sites.AssetLiveTest do
 
     assert html =~ "Frontend assets"
     assert has_element?(view, "#asset-set-#{asset_set.id}", asset_set.name)
-    assert has_element?(view, "#asset-set-#{asset_set.id} button", "Activate")
+    assert has_element?(view, ".frontend-assets-current", "Release assets")
+    assert has_element?(view, "#asset-set-#{asset_set.id} button", "Activate build")
 
     view
-    |> element("#asset-set-#{asset_set.id} button", "Activate")
+    |> element("#asset-set-#{asset_set.id} button", "Activate build")
     |> render_click()
 
     assert SiteAssets.active_set().id == asset_set.id
     assert has_element?(view, "#asset-set-#{asset_set.id}", "Active")
+    assert has_element?(view, ".frontend-assets-current.uploaded", asset_set.name)
 
     view
-    |> element("button", "Revert to release assets")
+    |> element("button", "Use release assets")
     |> render_click()
 
     refute SiteAssets.active_set()
     assert has_element?(view, "#asset-set-#{asset_set.id}", "Available")
+  end
+
+  test "uses the superuser's Norwegian admin locale", %{current_user: current_user} do
+    {:ok, norwegian_user} =
+      current_user
+      |> Ecto.Changeset.change(language: :no)
+      |> Repo.update()
+
+    conn = log_in_user(Phoenix.ConnTest.build_conn(), norwegian_user)
+    {:ok, view, html} = live(conn, "/admin/config/assets")
+
+    assert html =~ "Frontend-ressurser"
+    assert has_element?(view, ".frontend-assets-current", "Frontend-filer fra release")
+    assert has_element?(view, ".frontend-assets-library", "Opplastede bygg")
+    assert has_element?(view, "button", "Aktiver bygg")
   end
 
   test "non-superusers are redirected", %{asset_set: _asset_set} do

--- a/test/brando_admin/menu_test.exs
+++ b/test/brando_admin/menu_test.exs
@@ -64,9 +64,24 @@ defmodule BrandoAdmin.MenuTest do
     refute menu_urls(dynamic_menu) =~ "/admin/config/publishing"
   end
 
+  test "frontend assets is translated in the Norwegian menu" do
+    menu_names =
+      Gettext.with_locale("no", fn ->
+        %{role: :superuser}
+        |> BrandoAdmin.Menu.get_menu()
+        |> menu_names()
+      end)
+
+    assert "Frontend-ressurser" in menu_names
+  end
+
   defp menu_urls(menus) do
     menus
     |> Enum.flat_map(fn menu -> List.wrap(menu[:url]) ++ List.wrap(menu[:items] && menu_urls(menu.items)) end)
     |> Enum.join(" ")
+  end
+
+  defp menu_names(menus) do
+    Enum.flat_map(menus, fn menu -> [menu.name | menu_names(List.wrap(menu[:items]))] end)
   end
 end


### PR DESCRIPTION
## Summary

- redesign the frontend-assets screen around a clear currently-served status and uploaded-build library
- add responsive narrow-screen behavior and dedicated styling
- localize the screen and menu entry in Norwegian
- use the admin user locale when rendering the LiveView
- cover the Norwegian menu and frontend-assets screen with tests

## Validation

- mix compile --warnings-as-errors
- mix test --warnings-as-errors (1702 passed)
- mix credo --strict on changed Elixir source and tests (no issues)
- E2E backend consumer asset build
- focused browser check in Norwegian at desktop and narrow widths, including uploaded and release asset states