### PR TITLE
feat(modules): track module migrations, stop destroying block content (#2642)

### DIFF
--- a/.claude/skills/brando-blocks/SKILL.md
+++ b/.claude/skills/brando-blocks/SKILL.md
@@ -116,9 +116,12 @@ Entry → EntryBlock (join table) → Block → vars/refs/children/table_rows/bl
 ```
 uid, type (:module/:container/:fragment/:module_entry), active, collapsed,
 description, anchor, multi, datasource, rendered_html, rendered_at,
-source (Brando.Type.Module), identifier_metas (JSON),
+source (Brando.Type.Module), identifier_metas (JSON), module_version,
 sequence, creator_id, module_id, container_id, fragment_id, parent_id, palette_id
 ```
+
+`module_version` is server-controlled and deliberately absent from `@block_attrs`
+— see section 14.
 
 ### Block Relations
 ```
@@ -461,6 +464,50 @@ When building maps for `put_assoc`, drop association keys (`:block`, `:module`, 
 - **`onEnd`**: Pushes `reposition` event with `{old: oldIndex, new: newIndex, ...item.dataset}`
 - Prevents `phx-blur` from firing during drag (`focusout` stopImmediatePropagation)
 - Optional grouping via `data-blocks-wrapper-type` for cross-container drag
+
+---
+
+## 14. Module Saves Are Site-Wide Migrations
+
+Saving a module re-syncs **every block that uses it, in every entry**:
+
+`Content.update_module/3` → `mutation :update, Module` → `Blocks.render_entries_with_module_id/2`
+→ `list_block_ids_using_module/2` → `sync_and_render_blocks/3` → `Blocks.sync_module/2`
+(one `Repo.update/1` per block, outside a transaction).
+
+### Rules
+
+- **Nothing is deleted.** Refs and vars the module no longer defines are
+  retained. A removal cannot be told apart from a rename here, and the data
+  belongs to the editor. Orphans lie dormant — the template does not reference
+  them — until an explicit upgrade resolves them.
+- **`Module.version` counts definition revisions**, bumped by
+  `Brando.Trait.ModuleVersioned` when `Brando.Content.ModuleDiff` says the change
+  was effective. It is also an optimistic lock: a save over a revision the editor
+  never saw raises `Ecto.StaleEntryError`.
+- **`Block.module_version` is how far that block got.** `sync_module/2` stamps it
+  only when every ref and var the block holds still has a definition of a
+  compatible type behind it. Anything else — an orphan, a retyped ref, or a
+  failed write — leaves the block behind, findable via
+  `Blocks.list_stale_block_ids/2` and `count_stale_blocks/2`.
+- **A `media` module ref is a slot, not a type.** It legitimately drives
+  picture / video / gallery / svg block refs, each of which has a `MediaBlock`
+  clause in `apply_ref/3`. Use `Brando.Villain.Blocks.ref_types_compatible?/2`
+  rather than comparing structs — treating that as a retype puts a warning in
+  front of every media module edit.
+- **Never trust `module_version` from params.** It is not in `@block_attrs`. An
+  entry editor opened before a migration must not be able to save its way to
+  claiming it is current.
+
+### Classifying a pending module change
+
+`ModuleDiff.diff(old_module, new_module_or_changeset)` → `:none` | `:metadata` |
+`:render` | `:compatible` | `:destructive` (most severe wins). `destructive?/1`
+gates the module editor's confirmation dialog; `summary/1` gives the lines it
+shows.
+
+`Module.uid` is lineage identity for import replacement (not yet built). Export
+and import mint a fresh one at v1, so import produces copies.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -242,6 +242,42 @@
 
 #### Features
 
+- **Module migration tracking, and a warning before a module save destroys
+  content** (#2642). Saving a module has always been a site-wide migration: every
+  block using it is re-synced, and any reference the module no longer declares was
+  deleted from every block, in every entry, with no warning and no way back.
+
+  - **References are now retained instead of deleted.** A removal is
+    indistinguishable from a rename at this level, and the data is the editor's,
+    not the module's. Orphaned references lie dormant — the template no longer
+    renders them — until an explicit upgrade resolves them. Variables were
+    already retained; references now match.
+  - **`content_modules.version` counts definition revisions.** It bumps on an
+    effective change (see `Brando.Content.ModuleDiff` for what counts) and not on
+    a save that changed nothing. The bump doubles as an optimistic lock, so two
+    editors on the same module can no longer silently publish two different next
+    revisions — the second is told to reload.
+  - **`content_blocks.module_version` records how far each block got.** A block
+    holding data the current definition cannot read — an orphaned reference or
+    variable, or a reference whose block type the module swapped — is left behind
+    its module rather than stamped as current, and is findable through
+    `Brando.Content.Blocks.list_stale_block_ids/2` and `count_stale_blocks/2`. A
+    block whose write fails mid-migration stays behind too, so a partial migration
+    is a visible queue instead of silent mixed state.
+  - **The module editor asks before a destructive save**, naming each reference
+    and variable that will be orphaned and how many blocks on the site use the
+    module.
+  - **`content_modules.uid`** is the new lineage identity, for the import
+    replacement still to come. Name and namespace cannot serve: both are i18n
+    JSON maps, neither is unique, and both are editable. Export and import mint a
+    fresh `uid` at v1 for now — importing has always produced copies, and
+    recognising a re-import as the same lineage needs the versioned envelope and
+    conflict handling still to be built.
+
+  Requires `brando_167`. Run `mix brando.upgrade && mix ecto.migrate`. Existing
+  modules are given a `uid`, and existing blocks are backfilled as current, so
+  upgrading does not flag a site as stale on day one.
+
 - **Igniter-assisted tenancy setup for existing applications.** The opt-in
   `mix brando.setup.tenancy` task configures `:single` or `:multi` mode, inserts
   `Brando.Plug.Tenant` idempotently into recognized browser pipelines before

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -398,6 +398,14 @@
 
 #### Fixes
 
+- **Modal dialogs sized their prose like page content, and stacked their footer
+  buttons edge to edge.** `.modal-body` inherited `body`'s `@fontsize base` —
+  20px on desktop, 23px at xl — so loose text in a dialog came out oversized
+  beside the 13–16px controls next to it; it is `@fontsize sm` now. Fields and
+  labels set their own sizes, so nothing else moves. `.modal-footer` was a flex
+  row with `justify-content: flex-end` and no `gap`, which left two buttons
+  touching.
+
 - **The identifier picker's filter input did nothing.** `Brando.SelectFilter`
   toggles `.filter-hidden` on each option it filters out, but the only rule for
   that class lived nested under `.multiselect .options .options-option` in

--- a/assets/css/components/Form/BlockEditor.css
+++ b/assets/css/components/Form/BlockEditor.css
@@ -650,6 +650,27 @@
   }
 }
 
+/* Saving a module migrates every block that uses it. The confirmation dialog
+   lists what that migration orphans — keep the list scannable, and let a module
+   with many changed references scroll rather than push the buttons off-screen. */
+.destructive-change-list {
+  max-height: 280px;
+  margin: 14px 0;
+  padding: 12px 12px 12px 28px;
+  overflow-y: auto;
+  border-left: 2px solid theme(colors.status.pending);
+  background-color: theme(colors.peach);
+
+  li {
+    margin-bottom: 4px;
+    font-size: 14px;
+
+    &:last-child {
+      margin-bottom: 0;
+    }
+  }
+}
+
 @media (max-width: 1180px) {
   .module-editor-panels {
     .code .cm-editor {

--- a/assets/css/components/Modal.css
+++ b/assets/css/components/Modal.css
@@ -345,6 +345,11 @@
 }
 
 .modal-body {
+  /* `body` is `@fontsize base` — 20px on desktop, 23px at xl — which is a
+     reading size for page content, not for a dialog. Prose in a modal inherited
+     it and came out oversized next to the 13-16px controls it sits beside.
+     Fields and labels set their own sizes, so this only reaches loose text. */
+  @fontsize sm;
   @space padding-y 18px;
   @space padding-x 20px;
   max-height: 80vh;
@@ -361,6 +366,7 @@
 .modal-footer {
   display: flex;
   align-items: center;
+  gap: 10px;
   @space padding-x 20px;
   padding-top: 12px;
   justify-content: flex-end;

--- a/e2e/e2e/playwright/tests/configuration/modules.spec.js
+++ b/e2e/e2e/playwright/tests/configuration/modules.spec.js
@@ -157,7 +157,17 @@ test('create, edit, duplicate, persist and delete refs and vars', async ({ page 
   await openModuleTab(page, 'References')
   await page.getByRole('button', { name: 'Delete reference intro_text_copy', exact: true }).click()
 
+  // Removing a reference or a variable migrates every block using this module,
+  // so the save is held until it is confirmed — and the dialog names exactly
+  // what is about to be orphaned. See issue #2642.
   await page.getByTestId('submit').click()
+  const destructiveModal = page.locator('#module-destructive-modal')
+  await expect(destructiveModal).toBeVisible()
+  await expect(destructiveModal).toContainText('intro_text_copy')
+  await expect(destructiveModal).toContainText('theme_copy')
+  await expect(page).toHaveURL(/\/admin\/config\/content\/modules\/update\/\d+$/)
+
+  await destructiveModal.getByRole('button', { name: 'Save anyway' }).click()
   await expect(page).toHaveURL('/admin/config/content/modules')
   await page.getByRole('link', { name: 'New module →' }).click()
   await syncLV(page)

--- a/lib/brando/content.ex
+++ b/lib/brando/content.ex
@@ -881,7 +881,21 @@ defmodule Brando.Content do
   defp prepare_single_module_for_export(module, current_user_id) do
     module =
       module
-      |> Map.put(:id, nil)
+      |> Map.merge(%{
+        id: nil,
+        # An exported module installs as a new lineage at v1, the same way
+        # duplicating one does. Carrying the source installation's `uid` would
+        # collide with it on re-import, and its `version`/`source_module_id`
+        # describe a history and a shared-library link the destination has no
+        # part in. Recognising a re-import as the *same* lineage needs the
+        # versioned envelope and conflict handling in issue #2642's phase 3.
+        uid: Brando.Utils.generate_uid(),
+        version: 1,
+        version_note: nil,
+        source_module_id: nil,
+        source_version: nil,
+        acknowledged_version: nil
+      })
       |> put_in([Access.key(:__meta__), Access.key(:state)], :built)
 
     refs_with_new_uids =

--- a/lib/brando/content/block.ex
+++ b/lib/brando/content/block.ex
@@ -98,6 +98,12 @@ defmodule Brando.Content.Block do
     attribute :rendered_at, :datetime
     attribute :source, Brando.Type.Module
     attribute :identifier_metas, Brando.Type.Json
+    # The newest module revision whose instance-data migration was applied to this
+    # block. Deliberately absent from `@block_attrs`: it is server-controlled, so
+    # an entry editor opened before a module migration cannot save its way to
+    # claiming it is current. See `Brando.Content.Blocks.sync_module/2`.
+    attribute :module_version, :integer
+
     attribute :module_origin, :enum, values: [:local, :shared], default: :local
     attribute :container_origin, :enum, values: [:local, :shared], default: :local
     attribute :palette_origin, :enum, values: [:local, :shared], default: :local

--- a/lib/brando/content/blocks.ex
+++ b/lib/brando/content/blocks.ex
@@ -652,6 +652,44 @@ defmodule Brando.Content.Blocks do
   # --- Module Sync ---
 
   @doc """
+  Ids of blocks that have not been migrated to a module's current revision.
+
+  A block is stale when its `module_version` is behind the module's `version`, or
+  is missing entirely (a block created before migration tracking landed and never
+  re-synced since). Stale means the block still holds data — refs or vars the
+  module no longer defines, or whose type it changed — that no definition backs
+  any more. It renders through the module's current code regardless; the version
+  gap is what makes the mismatch findable.
+  """
+  @spec list_stale_block_ids(Brando.Content.Module.t() | integer(), atom()) :: [integer()]
+  def list_stale_block_ids(module_or_id, origin \\ :local)
+
+  def list_stale_block_ids(%{id: module_id, version: version}, origin),
+    do: query_stale_block_ids(module_id, version || 1, origin)
+
+  def list_stale_block_ids(module_id, origin) when is_integer(module_id) do
+    case Brando.Repo.get(Brando.Content.Module, module_id) do
+      nil -> []
+      module -> query_stale_block_ids(module_id, module.version || 1, origin)
+    end
+  end
+
+  @doc "How many blocks are behind `module`'s current revision. See `list_stale_block_ids/2`."
+  @spec count_stale_blocks(Brando.Content.Module.t() | integer(), atom()) :: non_neg_integer()
+  def count_stale_blocks(module_or_id, origin \\ :local),
+    do: module_or_id |> list_stale_block_ids(origin) |> length()
+
+  defp query_stale_block_ids(module_id, version, origin) do
+    from(b in Block,
+      where: b.module_id == ^module_id,
+      where: is_nil(b.module_version) or b.module_version < ^version,
+      select: b.id
+    )
+    |> maybe_filter_library_origin(:module_origin, origin)
+    |> Brando.Repo.all()
+  end
+
+  @doc """
   Gets all blocks with `module_id` and reapply refs and vars, then saves them.
   Returns a list of all updated block ids.
   """
@@ -668,27 +706,40 @@ defmodule Brando.Content.Blocks do
         preload: [:vars, refs: Ref.preloads()]
       })
 
-    Enum.reduce(blocks, [], fn block, acc ->
-      updated_changeset = sync_module(block, module)
-      Brando.Repo.update(updated_changeset)
-      [block.id | acc]
+    blocks
+    |> Enum.reduce([], fn block, acc ->
+      case block |> sync_module(module) |> Brando.Repo.update() do
+        {:ok, _} -> [block.id | acc]
+        {:error, changeset} -> log_failed_sync(block, module, changeset, acc)
+      end
     end)
     |> render_blocks()
   end
 
   @doc """
-  Syncs a block's vars and refs with a module
+  Syncs a block's vars and refs with a module.
+
+  Called for every block using a module each time that module is saved, so this
+  is the site-wide migration path — see `Brando.Content.ModuleDiff`.
+
+  Refs and vars the module no longer defines are **retained**, not deleted. Their
+  data is the editor's, not the module's, and a removal is indistinguishable from
+  a rename here; deleting it destroyed content across every entry on the site
+  with no way back. The module's template no longer references them, so they lie
+  dormant until an explicit upgrade resolves them.
+
+  A block left holding such orphans — or a ref whose type the module changed
+  underneath it — is not stamped with the module's current version. It stays
+  discoverable through `list_stale_block_ids/2` instead of quietly claiming to be
+  up to date.
   """
   def sync_module(block, module) do
     module_refs = module.refs
+    module_refs_by_name = Map.new(module_refs, &{&1.name, &1})
     module_ref_names = Enum.map(module_refs, & &1.name)
     changeset = Changeset.change(block)
 
-    # strip away refs that are no longer in the module
-    current_refs =
-      changeset
-      |> Changeset.get_assoc(:refs)
-      |> Enum.filter(&(Changeset.get_field(&1, :name) in module_ref_names))
+    current_refs = Changeset.get_assoc(changeset, :refs)
 
     current_ref_names = Enum.map(current_refs, &Changeset.get_field(&1, :name))
     missing_ref_names = module_ref_names -- current_ref_names
@@ -726,7 +777,58 @@ defmodule Brando.Content.Blocks do
     changeset
     |> Changeset.put_assoc(:vars, reapplied_vars)
     |> Changeset.put_assoc(:refs, reapplied_refs)
+    |> stamp_module_version(module, reapplied_refs, new_vars, module_refs_by_name, module_var_keys)
   end
+
+  # `module_version` means "the newest module revision whose instance-data
+  # migration was successfully applied to this block". Only stamp it when every
+  # ref and var the block holds still has a definition of the same type behind
+  # it; anything else is data awaiting review, and claiming it current would make
+  # the stale count useless.
+  defp stamp_module_version(changeset, module, refs, vars, module_refs_by_name, module_var_keys) do
+    if fully_migrated?(refs, vars, module_refs_by_name, module_var_keys) do
+      Changeset.put_change(changeset, :module_version, module.version || 1)
+    else
+      changeset
+    end
+  end
+
+  defp fully_migrated?(refs, vars, module_refs_by_name, module_var_keys) do
+    Enum.all?(refs, &migratable_ref?(&1, module_refs_by_name)) and
+      Enum.all?(vars, &(Changeset.get_field(&1, :key) in module_var_keys))
+  end
+
+  @doc """
+  True when the module still defines this ref, with the same block type.
+
+  A ref whose name is gone, or whose block type the module swapped out from under
+  it, cannot be migrated: the stored data does not fit the new definition.
+  """
+  def migratable_ref?(ref_changeset, module_refs_by_name) do
+    case Map.get(module_refs_by_name, Changeset.get_field(ref_changeset, :name)) do
+      nil ->
+        false
+
+      ref_src ->
+        VillainBlocks.ref_types_compatible?(ref_data_type(ref_src), ref_data_type(ref_changeset))
+    end
+  end
+
+  defp ref_data_type(%Changeset{} = ref_changeset) do
+    ref_changeset
+    |> Changeset.get_field(:data)
+    |> block_data_type()
+  end
+
+  defp ref_data_type(%Ref{data: data}), do: block_data_type(data)
+  defp ref_data_type(_), do: nil
+
+  # A ref's `data` is a polymorphic embed, and reaches us either as the block
+  # struct itself or as a changeset on one, depending on whether anything has
+  # already touched it this pass.
+  defp block_data_type(%Changeset{data: %{__struct__: struct}}), do: struct
+  defp block_data_type(%{__struct__: struct}), do: struct
+  defp block_data_type(_), do: nil
 
   def sync_and_render_blocks(block_ids, module_id, origin \\ :local)
   def sync_and_render_blocks([], _module_id, _origin), do: %{}
@@ -755,13 +857,29 @@ defmodule Brando.Content.Blocks do
 
     blocks
     |> Enum.reduce([], fn block, acc ->
-      block
-      |> sync_module(module)
-      |> Brando.Repo.update()
-
-      [block.id | acc]
+      case block |> sync_module(module) |> Brando.Repo.update() do
+        {:ok, _} -> [block.id | acc]
+        {:error, changeset} -> log_failed_sync(block, module, changeset, acc)
+      end
     end)
     |> render_blocks()
+  end
+
+  # A module save migrates every block that uses it, one write at a time and
+  # outside a transaction. A block that fails keeps its old data and its old
+  # `module_version`, so it stays behind the module and shows up in
+  # `list_stale_block_ids/2` — a visible queue rather than silent mixed state.
+  defp log_failed_sync(block, module, changeset, acc) do
+    require Logger
+
+    Logger.error("""
+    Failed to sync block ##{block.id} with module ##{module.id}.
+    The block keeps its previous data and stays behind module version #{module.version || 1}.
+
+    #{inspect(changeset.errors, pretty: true)}
+    """)
+
+    acc
   end
 
   defp maybe_filter_library_origin(query, _field, nil), do: query
@@ -817,36 +935,28 @@ defmodule Brando.Content.Blocks do
     |> Brando.Repo.update()
   end
 
-  def reapply_refs(module, module_refs, refs) do
+  @doc """
+  Reapplies the module's template-controlled ref settings onto a block's refs.
+
+  Refs the module no longer defines, and refs whose block type it swapped out,
+  are passed through untouched. Both used to be impossible — the first was
+  filtered away before this ran, and the second raised — but a module save is a
+  migration over content the editor owns, and neither case is a reason to
+  overwrite it. `sync_module/2` leaves such a block behind its module's version
+  so it stays visible as needing review.
+  """
+  def reapply_refs(_module, module_refs, refs) do
     refs_by_name = Map.new(module_refs, &{&1.name, &1})
 
     Enum.map(refs, fn
       %Changeset{data: %{name: ref_name}} = ref ->
-        block_module =
-          case Changeset.get_field(ref, :data) do
-            %Changeset{} = data_cs ->
-              data_cs.data.__struct__
-
-            block_data ->
-              block_data.__struct__
-          end
-
-        ref_src = Map.get(refs_by_name, ref_name)
-
-        if ref_src == nil do
-          raise """
-
-          Ref #{ref_name} not found in module refs!
-
-          Module: ##{module.id} [#{module.namespace}] #{module.name}
-
-          #{inspect(module, pretty: true)}
-
-          """
+        if migratable_ref?(ref, refs_by_name) do
+          ref_src = Map.fetch!(refs_by_name, ref_name)
+          block_module = block_data_type(Changeset.get_field(ref, :data))
+          block_module.apply_ref(ref_src.data.__struct__, ref_src, apply_ref_principals(ref_src, ref))
+        else
+          ref
         end
-
-        ref_target = apply_ref_principals(ref_src, ref)
-        block_module.apply_ref(ref_src.data.__struct__, ref_src, ref_target)
     end)
   end
 

--- a/lib/brando/content/module.ex
+++ b/lib/brando/content/module.ex
@@ -51,7 +51,7 @@ defmodule Brando.Content.Module do
   persist_identifier false
 
   @derived_fields ~w(
-    id type name sequence namespace help_text multi color class code refs vars svg deleted_at
+    id uid type name sequence namespace help_text multi color class code refs vars svg deleted_at
     version version_note source_module_id source_version acknowledged_version library_origin
     override_id
   )a
@@ -61,9 +61,15 @@ defmodule Brando.Content.Module do
   trait :soft_delete
   trait :timestamped
   trait Brando.Trait.CastPolymorphicEmbeds
+  trait :ensure_uid
   trait :validate_var_keys
+  trait Brando.Trait.ModuleVersioned
 
   attributes do
+    # Lineage identity. Survives export/import, where name and namespace cannot:
+    # both are i18n JSON maps, neither is unique, and both are editable.
+    attribute :uid, :string, required: true
+
     attribute :type, :enum, values: [:liquid, :heex], default: :liquid
     attribute :name, :i18n_string, required: true
     attribute :namespace, :i18n_string, required: true
@@ -259,8 +265,7 @@ defmodule Brando.Content.Module do
       }
     ],
     vars: [],
-    multi: false,
-    uid: "abcdef"
+    multi: false
   }
 
   @doc """

--- a/lib/brando/content/module_diff.ex
+++ b/lib/brando/content/module_diff.ex
@@ -1,0 +1,242 @@
+defmodule Brando.Content.ModuleDiff do
+  @moduledoc """
+  Classifies the difference between two revisions of a module definition.
+
+  Saving a module runs a migration across every block that uses it
+  (`Brando.Content.Blocks.sync_module/2`). Some of those changes are harmless —
+  a reworded help text, a tweak to the template code — and some silently rewrite
+  or orphan editor content in every entry on the site.
+
+  This module answers *what kind* of change a pending module save is, without
+  touching the database and without deciding policy. Callers use it to decide
+  whether to warn the editor (`destructive?/1`), whether the definition moved at
+  all (`effective?/1`), and how to describe the change (`summary/1`).
+
+  ## Classes
+
+    * `:none` — nothing meaningful changed.
+    * `:metadata` — name, namespace, help text, svg, colour, sequence. Blocks
+      keep their data untouched.
+    * `:render` — the template code or class changed but the ref/var contract did
+      not. Blocks re-render; their data is untouched.
+    * `:compatible` — refs or vars were added. Existing block data survives and
+      the new ones are instantiated from the module.
+    * `:destructive` — refs or vars were removed or retyped, or a contract field
+      (multi, datasource, table template, module type) changed. Existing block
+      data no longer has a definition behind it.
+
+  The classes are ordered: `classify/1` returns the most severe one that applies.
+  """
+
+  alias Brando.Content.Module
+  alias Brando.Villain.Blocks
+  alias Ecto.Changeset
+
+  defstruct added_refs: [],
+            removed_refs: [],
+            retyped_refs: [],
+            added_vars: [],
+            removed_vars: [],
+            retyped_vars: [],
+            contract_changes: [],
+            metadata_changed?: false,
+            code_changed?: false
+
+  @type t :: %__MODULE__{
+          added_refs: [String.t()],
+          removed_refs: [String.t()],
+          retyped_refs: [{String.t(), module(), module()}],
+          added_vars: [String.t()],
+          removed_vars: [String.t()],
+          retyped_vars: [{String.t(), atom(), atom()}],
+          contract_changes: [{atom(), term(), term()}],
+          metadata_changed?: boolean(),
+          code_changed?: boolean()
+        }
+
+  @type class :: :none | :metadata | :render | :compatible | :destructive
+
+  @metadata_fields ~w(name namespace help_text svg color sequence)a
+
+  # `class` sits with `code` rather than with the metadata: both feed the rendered
+  # markup and neither touches a block's stored instance data.
+  @render_fields ~w(code class)a
+
+  # Fields that change what a block's stored instance data *means*, rather than
+  # how it looks. `multi` decides whether a block owns child entries,
+  # `table_template_id` reshapes table rows, and the datasource fields swap out
+  # where a block's content comes from entirely.
+  @contract_fields ~w(type multi datasource datasource_module datasource_type datasource_query table_template_id)a
+
+  @doc """
+  Diffs a persisted module against its pending revision.
+
+  The second argument may be a `%Module{}` or a changeset on one — a changeset is
+  applied first, so this works straight off an unsaved admin form.
+  """
+  @spec diff(Module.t(), Module.t() | Changeset.t()) :: t()
+  def diff(%Module{} = old, %Changeset{} = changeset),
+    do: diff(old, Changeset.apply_changes(changeset))
+
+  def diff(%Module{} = old, %Module{} = new) do
+    old_refs = ref_map(old)
+    new_refs = ref_map(new)
+    old_vars = var_map(old)
+    new_vars = var_map(new)
+
+    %__MODULE__{
+      added_refs: sorted_keys(new_refs, old_refs),
+      removed_refs: sorted_keys(old_refs, new_refs),
+      retyped_refs: retyped(old_refs, new_refs, &ref_retyped?/2),
+      added_vars: sorted_keys(new_vars, old_vars),
+      removed_vars: sorted_keys(old_vars, new_vars),
+      retyped_vars: retyped(old_vars, new_vars, &!=/2),
+      contract_changes: contract_changes(old, new),
+      metadata_changed?: any_field_changed?(old, new, @metadata_fields),
+      code_changed?: any_field_changed?(old, new, @render_fields)
+    }
+  end
+
+  @doc """
+  True when the change orphans or reinterprets instance data that blocks already hold.
+  """
+  @spec destructive?(t()) :: boolean()
+  def destructive?(%__MODULE__{} = diff) do
+    diff.removed_refs != [] or diff.retyped_refs != [] or
+      diff.removed_vars != [] or diff.retyped_vars != [] or
+      diff.contract_changes != []
+  end
+
+  @doc """
+  True when the module definition moved at all.
+
+  A save that only rewords a `version_note`, or that persists no change beyond
+  timestamps, is not an effective change and should not bump the module version.
+  """
+  @spec effective?(t()) :: boolean()
+  def effective?(%__MODULE__{} = diff), do: classify(diff) != :none
+
+  @doc "Returns the most severe class that applies to this diff."
+  @spec classify(t()) :: class()
+  def classify(%__MODULE__{} = diff) do
+    cond do
+      destructive?(diff) -> :destructive
+      diff.added_refs != [] or diff.added_vars != [] -> :compatible
+      diff.code_changed? -> :render
+      diff.metadata_changed? -> :metadata
+      true -> :none
+    end
+  end
+
+  @doc """
+  Human-readable lines describing every destructive part of the diff.
+
+  Returns `[]` for a non-destructive diff. Used by the module editor's
+  confirmation dialog, so the strings are deliberately concrete: an editor
+  should be able to tell which of their references is about to be orphaned.
+  """
+  @spec summary(t()) :: [String.t()]
+  def summary(%__MODULE__{} = diff) do
+    Enum.concat([
+      Enum.map(diff.removed_refs, &~s(Reference "#{&1}" was removed)),
+      Enum.map(diff.retyped_refs, fn {name, from, to} ->
+        ~s(Reference "#{name}" changed from #{ref_type_label(from)} to #{ref_type_label(to)})
+      end),
+      Enum.map(diff.removed_vars, &~s(Variable "#{&1}" was removed)),
+      Enum.map(diff.retyped_vars, fn {key, from, to} ->
+        ~s(Variable "#{key}" changed from #{from} to #{to})
+      end),
+      Enum.map(diff.contract_changes, fn {field, from, to} ->
+        ~s("#{field}" changed from #{value_label(from)} to #{value_label(to)})
+      end)
+    ])
+  end
+
+  # Every block module answers `__block_type__/0` with the short name the editor
+  # already knows the reference by ("picture", "text"), which beats printing the
+  # fully qualified struct at someone deciding whether to save.
+  defp ref_type_label(nil), do: "none"
+
+  defp ref_type_label(struct) do
+    if function_exported?(struct, :__block_type__, 0) do
+      struct.__block_type__()
+    else
+      struct |> Elixir.Module.split() |> List.last()
+    end
+  end
+
+  defp value_label(nil), do: "none"
+  defp value_label(value) when is_binary(value), do: value
+  defp value_label(value), do: inspect(value)
+
+  defp ref_map(module) do
+    module
+    |> loaded_list(:refs)
+    |> Map.new(&{&1.name, ref_type(&1)})
+  end
+
+  defp var_map(module) do
+    module
+    |> loaded_list(:vars)
+    |> Map.new(&{&1.key, &1.type})
+  end
+
+  # A ref's type is the polymorphic embed it carries — swapping a picture ref for
+  # a text ref keeps the name but makes the stored data meaningless.
+  defp ref_type(%{data: %{__struct__: struct}}), do: struct
+  defp ref_type(_ref), do: nil
+
+  defp loaded_list(module, field) do
+    case Map.get(module, field) do
+      list when is_list(list) -> list
+      _not_loaded_or_nil -> []
+    end
+  end
+
+  defp sorted_keys(from, against) do
+    from
+    |> Map.keys()
+    |> Enum.reject(&Map.has_key?(against, &1))
+    |> Enum.sort()
+  end
+
+  defp retyped(old, new, changed?) do
+    old
+    |> Enum.sort()
+    |> Enum.filter(fn {key, old_type} ->
+      Map.has_key?(new, key) and changed?.(old_type, Map.fetch!(new, key))
+    end)
+    |> Enum.map(fn {key, old_type} -> {key, old_type, Map.fetch!(new, key)} end)
+  end
+
+  # A `media` ref is a slot that legitimately backs a picture, video, gallery or
+  # svg block ref, so swapping between those is not a retype — see
+  # `Brando.Villain.Blocks.ref_types_compatible?/2`. Anything else leaves the
+  # block holding data the new definition cannot read.
+  defp ref_retyped?(old_type, new_type) do
+    not (Blocks.ref_types_compatible?(old_type, new_type) or
+           Blocks.ref_types_compatible?(new_type, old_type))
+  end
+
+  defp contract_changes(old, new) do
+    @contract_fields
+    |> Enum.filter(&field_changed?(old, new, &1))
+    |> Enum.map(&{&1, Map.get(old, &1), Map.get(new, &1)})
+  end
+
+  defp any_field_changed?(old, new, fields),
+    do: Enum.any?(fields, &field_changed?(old, new, &1))
+
+  defp field_changed?(old, new, field),
+    do: unset(Map.get(old, field)) != unset(Map.get(new, field))
+
+  # A module that has never had its `multi` checkbox touched stores `nil`, and
+  # the form posts `false` the first time it is saved. Reading that as a change
+  # of the multi contract put the destructive-change dialog in front of the
+  # *first* save of every new module. `nil`, `false` and `""` all mean the same
+  # thing here: the field was never set.
+  defp unset(nil), do: nil
+  defp unset(false), do: nil
+  defp unset(""), do: nil
+  defp unset(value), do: value
+end

--- a/lib/brando/traits/ensure_uid.ex
+++ b/lib/brando/traits/ensure_uid.ex
@@ -6,6 +6,11 @@ defmodule Brando.Trait.EnsureUID do
 
   import Ecto.Changeset
 
+  # Generate the uid before `validate_required` looks for it — a schema that
+  # declares `uid` required and leans on this trait to supply it would otherwise
+  # fail its own validation on insert.
+  @changeset_phase :before_validate_required
+
   def changeset_mutator(_module, _config, changeset, _user, _opts) do
     case get_field(changeset, :uid) do
       nil -> put_change(changeset, :uid, Brando.Utils.generate_uid())

--- a/lib/brando/traits/module_versioned.ex
+++ b/lib/brando/traits/module_versioned.ex
@@ -1,0 +1,41 @@
+defmodule Brando.Trait.ModuleVersioned do
+  @moduledoc """
+  Bumps `Module.version` whenever a save effectively changes the module definition.
+
+  Saving a module migrates every block that uses it, so the version is the marker
+  that says *which* revision a block was last migrated to — see
+  `Brando.Content.ModuleDiff` for what counts as an effective change, and
+  `Brando.Content.Blocks.sync_module/2` for where blocks are stamped.
+
+  A save that changes nothing (or only the changelog note) does not bump, so the
+  version stays a meaningful count of definition revisions rather than of clicks
+  on Save.
+
+  When it does bump, the bump doubles as an optimistic lock: two editors who open
+  the same module and both save cannot silently publish two different "next"
+  revisions — the second one gets an `Ecto.StaleEntryError` instead.
+  """
+  use Brando.Trait
+
+  alias Brando.Content.ModuleDiff
+  alias Ecto.Changeset
+
+  def changeset_mutator(_module, _config, changeset, _user, _opts) do
+    cond do
+      # A new module is born at v1; there is nothing to migrate from.
+      is_nil(changeset.data.id) ->
+        changeset
+
+      # The shared library sets the next version itself when publishing a
+      # library revision. Don't second-guess an explicit decision.
+      Changeset.changed?(changeset, :version) ->
+        changeset
+
+      ModuleDiff.effective?(ModuleDiff.diff(changeset.data, changeset)) ->
+        Changeset.optimistic_lock(changeset, :version, &((&1 || 1) + 1))
+
+      true ->
+        changeset
+    end
+  end
+end

--- a/lib/brando/villain/blocks.ex
+++ b/lib/brando/villain/blocks.ex
@@ -19,6 +19,31 @@ defmodule Brando.Villain.Blocks do
     video: Module.concat(["Brando", "Villain", "Blocks", "VideoBlock"])
   ]
 
+  # A `media` ref in a module is a slot, not a fixed type: `MediaBlock.Data`
+  # carries a template for each of these, and each of them defines a
+  # `MediaBlock`-specific `apply_ref/3` clause that reads its own template out of
+  # the source. So a block ref of any of these types is still driven by a `media`
+  # module ref — it has not been retyped out from under the editor.
+  @media_slot_blocks [:picture, :video, :gallery, :svg]
+
   @spec list_blocks() :: keyword(module())
   def list_blocks, do: @blocks
+
+  @doc """
+  True when a module ref of type `module_type` can still drive a block ref of
+  type `block_type`.
+
+  Identical types always can. Beyond that, only the `media` slot: it exists
+  precisely so one module ref can back a picture, video, gallery or svg,
+  depending on what the editor put there.
+  """
+  @spec ref_types_compatible?(module() | nil, module() | nil) :: boolean()
+  def ref_types_compatible?(nil, _block_type), do: false
+  def ref_types_compatible?(_module_type, nil), do: false
+  def ref_types_compatible?(same, same), do: true
+
+  def ref_types_compatible?(module_type, block_type) do
+    media = Keyword.fetch!(@blocks, :media)
+    module_type == media and block_type in Enum.map(@media_slot_blocks, &Keyword.fetch!(@blocks, &1))
+  end
 end

--- a/lib/brando_admin/components/form/block_field.ex
+++ b/lib/brando_admin/components/form/block_field.ex
@@ -1730,6 +1730,9 @@ defmodule BrandoAdmin.Components.Form.BlockField do
         creator_id: user_id,
         module_id: module_id,
         module_origin: module_origin,
+        # Born at the module's current revision — a block built from the
+        # definition as it stands now has nothing to migrate.
+        module_version: module.version || 1,
         parent_id: parent_id,
         multi: module.multi,
         source: source,

--- a/lib/brando_admin/live/content/module_form_live.ex
+++ b/lib/brando_admin/live/content/module_form_live.ex
@@ -5,6 +5,7 @@ defmodule BrandoAdmin.Content.ModuleFormLive do
   use Gettext, backend: Brando.Gettext
 
   alias Brando.Content.Blocks, as: ContentBlocks
+  alias Brando.Content.ModuleDiff
   alias Brando.Content.Ref
   alias Brando.Content.Var
   alias Brando.Villain.Blocks.TextBlock
@@ -29,6 +30,7 @@ defmodule BrandoAdmin.Content.ModuleFormLive do
          |> assign(:shared_library?, shared_library?)
          |> assign(:save_redirect_target, :listing)
          |> assign(:open_item_modal, nil)
+         |> assign(:pending_destructive_save, nil)
          |> assign(:active_tab, :template)
          |> assign_entry(entry_id)
          |> assign_current_user(token)
@@ -109,7 +111,66 @@ defmodule BrandoAdmin.Content.ModuleFormLive do
         </div>
       </.form>
     </div>
+
+    <.destructive_save_modal pending={@pending_destructive_save} />
     """
+  end
+
+  attr :pending, :any, required: true
+
+  # Saving a module migrates every block that uses it, across every entry on the
+  # site. When that migration would orphan content the editor typed — a removed
+  # reference, a variable whose type changed — say so before it happens, and say
+  # how far it reaches. The data is retained either way (see
+  # `Brando.Content.Blocks.sync_module/2`), but the affected blocks stop
+  # matching their module until someone resolves them.
+  defp destructive_save_modal(assigns) do
+    ~H"""
+    <Content.modal
+      :if={@pending}
+      id="module-destructive-modal"
+      title={gettext("This change affects existing content")}
+      show={true}
+      medium
+      close={JS.push("cancel_destructive_save")}
+    >
+      <p>{affected_line(@pending.affected)}</p>
+      <ul class="destructive-change-list">
+        <li :for={line <- @pending.summary}>{line}</li>
+      </ul>
+      <p>
+        {gettext(
+          "Existing content is kept, not deleted — but those blocks will no longer match this module until they are reviewed."
+        )}
+      </p>
+      <:footer>
+        <button type="button" class="secondary" phx-click={JS.push("cancel_destructive_save")}>
+          {gettext("Cancel")}
+        </button>
+        <button type="button" class="primary" phx-click={JS.push("confirm_destructive_save")}>
+          {gettext("Save anyway")}
+        </button>
+      </:footer>
+    </Content.modal>
+    """
+  end
+
+  defp affected_line({:blocks, count}) do
+    ngettext(
+      "%{count} block on this site uses this module.",
+      "%{count} blocks on this site use this module.",
+      count,
+      count: count
+    )
+  end
+
+  defp affected_line({:sites, count}) do
+    ngettext(
+      "%{count} site uses this shared module.",
+      "%{count} sites use this shared module.",
+      count,
+      count: count
+    )
   end
 
   @tabs ~w(template overview variables references datasource)a
@@ -355,6 +416,51 @@ defmodule BrandoAdmin.Content.ModuleFormLive do
   end
 
   def handle_event("save", %{"module" => module_params}, socket) do
+    case pending_destructive_change(socket, module_params) do
+      nil -> do_save(socket, module_params)
+      pending -> {:noreply, assign(socket, :pending_destructive_save, pending)}
+    end
+  end
+
+  def handle_event("cancel_destructive_save", _, socket) do
+    {:noreply, assign(socket, :pending_destructive_save, nil)}
+  end
+
+  def handle_event("confirm_destructive_save", _, socket) do
+    %{params: module_params} = socket.assigns.pending_destructive_save
+    do_save(assign(socket, :pending_destructive_save, nil), module_params)
+  end
+
+  # Returns what the confirmation dialog needs, or nil when the save may go
+  # straight through. The diff is taken against the persisted entry, so it
+  # describes exactly the migration this save is about to run.
+  defp pending_destructive_change(%{assigns: %{pending_destructive_save: nil}} = socket, module_params) do
+    %{current_user: current_user, entry: entry} = socket.assigns
+    changeset = Brando.Content.Module.changeset(entry, module_params, current_user)
+    diff = ModuleDiff.diff(entry, changeset)
+
+    if ModuleDiff.destructive?(diff) do
+      %{
+        params: module_params,
+        summary: ModuleDiff.summary(diff),
+        affected: count_affected(socket)
+      }
+    end
+  end
+
+  defp pending_destructive_change(_socket, _module_params), do: nil
+
+  # A shared module is edited in the public schema, where no tenant's blocks are
+  # visible — count the sites it reaches instead, and let the dialog say so.
+  defp count_affected(%{assigns: %{shared_library?: true, entry: entry}}) do
+    {:sites, length(Brando.Content.SharedLibrary.usage(:module, entry.id))}
+  end
+
+  defp count_affected(%{assigns: %{entry: entry}}) do
+    {:blocks, length(ContentBlocks.list_block_ids_using_module(entry.id))}
+  end
+
+  defp do_save(socket, module_params) do
     user = socket.assigns.current_user
     entry = socket.assigns.entry
 
@@ -380,6 +486,17 @@ defmodule BrandoAdmin.Content.ModuleFormLive do
       end
 
     case persist_module(changeset, user, socket.assigns.shared_library?) do
+      {:error, :stale} ->
+        send(
+          self(),
+          {:toast,
+           gettext(
+             "This module was changed by someone else while you were editing. Reload to see their version before saving yours."
+           )}
+        )
+
+        {:noreply, socket}
+
       {:ok, entry} ->
         send(self(), {:toast, gettext("Module updated")})
 
@@ -508,11 +625,20 @@ defmodule BrandoAdmin.Content.ModuleFormLive do
 
   defp maybe_use_public_library_context(socket), do: socket
 
-  defp persist_module(changeset, user, true) do
+  # `Brando.Trait.ModuleVersioned` bumps the version under an optimistic lock, so
+  # a second editor saving over a revision they never saw raises instead of
+  # silently winning. Turn that into an answer this function's caller can render.
+  defp persist_module(changeset, user, shared_library?) do
+    do_persist_module(changeset, user, shared_library?)
+  rescue
+    Ecto.StaleEntryError -> {:error, :stale}
+  end
+
+  defp do_persist_module(changeset, user, true) do
     Brando.Content.SharedLibrary.update_shared(:module, changeset.data.id, changeset, user)
   end
 
-  defp persist_module(changeset, user, false), do: Brando.Content.update_module(changeset, user)
+  defp do_persist_module(changeset, user, false), do: Brando.Content.update_module(changeset, user)
 
   defp build_ref_data(TextBlock) do
     struct(TextBlock.Data, %{styles: TextBlock.Data.default_styles()})

--- a/priv/repo/migrations/20260905000000_add_module_migration_tracking.exs
+++ b/priv/repo/migrations/20260905000000_add_module_migration_tracking.exs
@@ -1,0 +1,42 @@
+defmodule Brando.Repo.Migrations.AddModuleMigrationTracking do
+  use Ecto.Migration
+
+  @moduledoc """
+  Mirrors `brando_167_add_module_migration_tracking.exs` for the test/e2e schema.
+  """
+
+  def up do
+    alter table(:content_modules) do
+      add :uid, :text
+    end
+
+    alter table(:content_blocks) do
+      add :module_version, :integer
+    end
+
+    execute "UPDATE content_modules SET uid = replace(gen_random_uuid()::text, '-', '') WHERE uid IS NULL"
+
+    execute """
+    UPDATE content_blocks b
+    SET module_version = m.version
+    FROM content_modules m
+    WHERE b.module_id = m.id AND b.module_version IS NULL
+    """
+
+    create unique_index(:content_modules, [:uid])
+    create index(:content_blocks, [:module_id, :module_version])
+  end
+
+  def down do
+    drop_if_exists index(:content_blocks, [:module_id, :module_version])
+    drop_if_exists unique_index(:content_modules, [:uid])
+
+    alter table(:content_blocks) do
+      remove :module_version
+    end
+
+    alter table(:content_modules) do
+      remove :uid
+    end
+  end
+end

--- a/priv/templates/brando.upgrade/migrations/brando_167_add_module_migration_tracking.exs
+++ b/priv/templates/brando.upgrade/migrations/brando_167_add_module_migration_tracking.exs
@@ -1,0 +1,96 @@
+defmodule Brando.Repo.Migrations.Brando167AddModuleMigrationTracking do
+  use Ecto.Migration
+
+  @moduledoc """
+  Migration tracking for module definitions (issue #2642).
+
+  `content_modules.uid` is the module's lineage identity: it survives export and
+  import, where the name and namespace cannot — both are i18n JSON maps, neither
+  is unique, and both are editable.
+
+  `content_blocks.module_version` records the newest module revision whose
+  instance-data migration was successfully applied to that block. A block behind
+  its module is stale: it keeps its own data and renders through the module's
+  current code, and the editor is told so.
+
+  Existing rows are backfilled as current, so upgrading does not flag the whole
+  site as stale on day one.
+  """
+
+  def up do
+    alter table(:content_modules) do
+      add :uid, :text
+    end
+
+    alter table(:content_blocks) do
+      add :module_version, :integer
+    end
+
+    execute "UPDATE content_modules SET uid = replace(gen_random_uuid()::text, '-', '') WHERE uid IS NULL"
+
+    execute """
+    UPDATE content_blocks b
+    SET module_version = m.version
+    FROM content_modules m
+    WHERE b.module_id = m.id AND b.module_version IS NULL
+    """
+
+    create unique_index(:content_modules, [:uid])
+    create index(:content_blocks, [:module_id, :module_version])
+
+    execute """
+    DO $$
+    DECLARE tenant_schema text;
+    BEGIN
+      FOR tenant_schema IN
+        SELECT nspname FROM pg_namespace
+        WHERE nspname ~ '^tenant_[a-z0-9-]+_[a-z0-9-]+$'
+      LOOP
+        IF to_regclass(format('%I.content_modules', tenant_schema)) IS NOT NULL THEN
+          EXECUTE format('ALTER TABLE %I.content_modules ADD COLUMN IF NOT EXISTS uid text', tenant_schema);
+          EXECUTE format('UPDATE %I.content_modules SET uid = replace(gen_random_uuid()::text, ''-'', '''') WHERE uid IS NULL', tenant_schema);
+          EXECUTE format('CREATE UNIQUE INDEX IF NOT EXISTS %I ON %I.content_modules (uid)', tenant_schema || '_content_modules_uid_index', tenant_schema);
+        END IF;
+        IF to_regclass(format('%I.content_blocks', tenant_schema)) IS NOT NULL THEN
+          EXECUTE format('ALTER TABLE %I.content_blocks ADD COLUMN IF NOT EXISTS module_version integer', tenant_schema);
+          EXECUTE format('UPDATE %I.content_blocks b SET module_version = m.version FROM %I.content_modules m WHERE b.module_id = m.id AND b.module_version IS NULL', tenant_schema, tenant_schema);
+          EXECUTE format('CREATE INDEX IF NOT EXISTS %I ON %I.content_blocks (module_id, module_version)', tenant_schema || '_content_blocks_module_id_module_version_index', tenant_schema);
+        END IF;
+      END LOOP;
+    END $$;
+    """
+  end
+
+  def down do
+    execute """
+    DO $$
+    DECLARE tenant_schema text;
+    BEGIN
+      FOR tenant_schema IN
+        SELECT nspname FROM pg_namespace
+        WHERE nspname ~ '^tenant_[a-z0-9-]+_[a-z0-9-]+$'
+      LOOP
+        IF to_regclass(format('%I.content_blocks', tenant_schema)) IS NOT NULL THEN
+          EXECUTE format('DROP INDEX IF EXISTS %I.%I', tenant_schema, tenant_schema || '_content_blocks_module_id_module_version_index');
+          EXECUTE format('ALTER TABLE %I.content_blocks DROP COLUMN IF EXISTS module_version', tenant_schema);
+        END IF;
+        IF to_regclass(format('%I.content_modules', tenant_schema)) IS NOT NULL THEN
+          EXECUTE format('DROP INDEX IF EXISTS %I.%I', tenant_schema, tenant_schema || '_content_modules_uid_index');
+          EXECUTE format('ALTER TABLE %I.content_modules DROP COLUMN IF EXISTS uid', tenant_schema);
+        END IF;
+      END LOOP;
+    END $$;
+    """
+
+    drop_if_exists index(:content_blocks, [:module_id, :module_version])
+    drop_if_exists unique_index(:content_modules, [:uid])
+
+    alter table(:content_blocks) do
+      remove :module_version
+    end
+
+    alter table(:content_modules) do
+      remove :uid
+    end
+  end
+end

--- a/test/brando/content/module_diff_test.exs
+++ b/test/brando/content/module_diff_test.exs
@@ -1,0 +1,263 @@
+defmodule Brando.Content.ModuleDiffTest do
+  use ExUnit.Case, async: true
+
+  alias Brando.Content.Module
+  alias Brando.Content.ModuleDiff
+  alias Brando.Content.Ref
+  alias Brando.Content.Var
+  alias Brando.Villain.Blocks
+
+  defp module(attrs \\ %{}) do
+    struct(
+      %Module{
+        id: 1,
+        uid: "modmodmodmod",
+        name: %{"en" => "Test"},
+        namespace: %{"en" => "general"},
+        help_text: %{"en" => "help"},
+        class: "test",
+        code: "<div>{% ref refs.h2 %}</div>",
+        version: 1,
+        refs: [],
+        vars: []
+      },
+      attrs
+    )
+  end
+
+  defp ref(name, data) do
+    %Ref{name: name, uid: "uid-#{name}", data: data}
+  end
+
+  defp header_ref(name \\ "h2") do
+    ref(name, %Blocks.HeaderBlock{
+      type: "header",
+      data: %Blocks.HeaderBlock.Data{level: 2, text: "Heading"}
+    })
+  end
+
+  defp picture_ref(name \\ "h2") do
+    ref(name, %Blocks.PictureBlock{type: "picture", data: %Blocks.PictureBlock.Data{}})
+  end
+
+  defp var(key, type \\ :string), do: %Var{key: key, type: type, label: key}
+
+  describe "classify/1 — every diff class" do
+    test "no change at all" do
+      old = module()
+      diff = ModuleDiff.diff(old, module())
+
+      assert ModuleDiff.classify(diff) == :none
+      refute ModuleDiff.effective?(diff)
+      refute ModuleDiff.destructive?(diff)
+    end
+
+    test "metadata only" do
+      diff = ModuleDiff.diff(module(), module(%{name: %{"en" => "Renamed"}}))
+
+      assert ModuleDiff.classify(diff) == :metadata
+      assert ModuleDiff.effective?(diff)
+      refute ModuleDiff.destructive?(diff)
+      assert diff.metadata_changed?
+    end
+
+    test "code change is render-only" do
+      diff = ModuleDiff.diff(module(), module(%{code: "<p>new</p>"}))
+
+      assert ModuleDiff.classify(diff) == :render
+      assert diff.code_changed?
+    end
+
+    test "class change is render-only, not metadata" do
+      diff = ModuleDiff.diff(module(), module(%{class: "other"}))
+
+      assert ModuleDiff.classify(diff) == :render
+      refute diff.metadata_changed?
+    end
+
+    test "adding a ref is compatible" do
+      old = module()
+      new = module(%{refs: [header_ref()]})
+      diff = ModuleDiff.diff(old, new)
+
+      assert ModuleDiff.classify(diff) == :compatible
+      assert diff.added_refs == ["h2"]
+      refute ModuleDiff.destructive?(diff)
+    end
+
+    test "adding a var is compatible" do
+      diff = ModuleDiff.diff(module(), module(%{vars: [var("title")]}))
+
+      assert ModuleDiff.classify(diff) == :compatible
+      assert diff.added_vars == ["title"]
+    end
+
+    test "removing a ref is destructive" do
+      old = module(%{refs: [header_ref()]})
+      diff = ModuleDiff.diff(old, module())
+
+      assert ModuleDiff.classify(diff) == :destructive
+      assert diff.removed_refs == ["h2"]
+      assert ModuleDiff.destructive?(diff)
+    end
+
+    test "removing a var is destructive" do
+      old = module(%{vars: [var("title")]})
+      diff = ModuleDiff.diff(old, module())
+
+      assert ModuleDiff.classify(diff) == :destructive
+      assert diff.removed_vars == ["title"]
+    end
+
+    test "retyping a ref is destructive" do
+      old = module(%{refs: [header_ref()]})
+      new = module(%{refs: [picture_ref()]})
+      diff = ModuleDiff.diff(old, new)
+
+      assert ModuleDiff.classify(diff) == :destructive
+
+      assert diff.retyped_refs == [
+               {"h2", Blocks.HeaderBlock, Blocks.PictureBlock}
+             ]
+
+      assert diff.removed_refs == []
+      assert diff.added_refs == []
+    end
+
+    test "a media ref backing a picture is not a retype" do
+      # `media` is a slot: one module ref legitimately drives a picture, video,
+      # gallery or svg block ref, and each of those reads its own template out of
+      # the media source. Flagging that as destructive would put a confirmation
+      # dialog in front of every media module edit.
+      media = ref("hero", %Blocks.MediaBlock{type: "media", data: %Blocks.MediaBlock.Data{}})
+
+      old = module(%{refs: [media]})
+      new = module(%{refs: [picture_ref("hero")]})
+
+      diff = ModuleDiff.diff(old, new)
+
+      assert diff.retyped_refs == []
+      refute ModuleDiff.destructive?(diff)
+    end
+
+    test "retyping a var is destructive" do
+      old = module(%{vars: [var("title", :string)]})
+      new = module(%{vars: [var("title", :boolean)]})
+      diff = ModuleDiff.diff(old, new)
+
+      assert ModuleDiff.classify(diff) == :destructive
+      assert diff.retyped_vars == [{"title", :string, :boolean}]
+    end
+
+    test "a rename reads as remove plus add, and is destructive" do
+      old = module(%{refs: [header_ref("h2")]})
+      new = module(%{refs: [header_ref("heading")]})
+      diff = ModuleDiff.diff(old, new)
+
+      assert diff.removed_refs == ["h2"]
+      assert diff.added_refs == ["heading"]
+      assert ModuleDiff.classify(diff) == :destructive
+    end
+
+    test "contract fields are destructive even when flipping from a falsey value" do
+      for {field, from, to} <- [
+            {:multi, false, true},
+            {:multi, nil, true},
+            {:datasource, false, true},
+            {:table_template_id, nil, 3},
+            {:type, :liquid, :heex},
+            {:datasource_type, nil, :list}
+          ] do
+        diff = ModuleDiff.diff(module(%{field => from}), module(%{field => to}))
+
+        assert ModuleDiff.destructive?(diff),
+               "expected #{field} #{inspect(from)} -> #{inspect(to)} to be destructive"
+
+        assert {field, from, to} in diff.contract_changes
+      end
+    end
+
+    test "an unset contract field settling to its off value is not a change" do
+      # A module created through the admin stores `multi: nil` until the checkbox
+      # is touched, and the form posts `false` on the first save. Reading that as
+      # a contract change put the confirmation dialog in front of the first save
+      # of every new module.
+      for {from, to} <- [{nil, false}, {false, nil}, {nil, nil}] do
+        diff = ModuleDiff.diff(module(%{multi: from}), module(%{multi: to}))
+
+        assert diff.contract_changes == [],
+               "expected multi #{inspect(from)} -> #{inspect(to)} to be no change"
+
+        assert ModuleDiff.classify(diff) == :none
+      end
+    end
+
+    test "an unset string field settling to an empty string is not a change" do
+      diff = ModuleDiff.diff(module(%{datasource_module: nil}), module(%{datasource_module: ""}))
+
+      assert ModuleDiff.classify(diff) == :none
+    end
+
+    test "destructive wins over compatible when both are present" do
+      old = module(%{refs: [header_ref("h2")], vars: [var("title")]})
+      new = module(%{refs: [header_ref("h3")], vars: [var("title"), var("subtitle")]})
+      diff = ModuleDiff.diff(old, new)
+
+      assert ModuleDiff.classify(diff) == :destructive
+      assert diff.added_vars == ["subtitle"]
+      assert diff.removed_refs == ["h2"]
+    end
+  end
+
+  describe "diff/2 with a changeset" do
+    test "applies pending changes before comparing" do
+      old = module(%{refs: [header_ref()]})
+
+      changeset =
+        old
+        |> Ecto.Changeset.change(%{code: "<p>gone</p>"})
+        |> Ecto.Changeset.put_assoc(:refs, [])
+
+      diff = ModuleDiff.diff(old, changeset)
+
+      assert diff.removed_refs == ["h2"]
+      assert diff.code_changed?
+      assert ModuleDiff.destructive?(diff)
+    end
+  end
+
+  describe "unloaded associations" do
+    test "are treated as empty rather than crashing" do
+      old = %{module() | refs: %Ecto.Association.NotLoaded{}, vars: %Ecto.Association.NotLoaded{}}
+      diff = ModuleDiff.diff(old, old)
+
+      assert ModuleDiff.classify(diff) == :none
+    end
+  end
+
+  describe "summary/1" do
+    test "is empty for a non-destructive diff" do
+      assert ModuleDiff.summary(ModuleDiff.diff(module(), module(%{code: "x"}))) == []
+    end
+
+    test "names each orphaned reference and variable" do
+      old = module(%{refs: [header_ref("h2"), picture_ref("img")], vars: [var("title")]})
+      new = module(%{refs: [picture_ref("img")], vars: [var("title", :boolean)], multi: true})
+
+      summary = ModuleDiff.summary(ModuleDiff.diff(old, new))
+
+      assert ~s(Reference "h2" was removed) in summary
+      assert ~s(Variable "title" changed from string to boolean) in summary
+      assert ~s("multi" changed from none to true) in summary
+    end
+
+    test "uses the editor-facing block type name when a reference is retyped" do
+      old = module(%{refs: [header_ref("hero")]})
+      new = module(%{refs: [picture_ref("hero")]})
+
+      assert ModuleDiff.summary(ModuleDiff.diff(old, new)) == [
+               ~s(Reference "hero" changed from header to picture)
+             ]
+    end
+  end
+end

--- a/test/brando/content/module_sync_test.exs
+++ b/test/brando/content/module_sync_test.exs
@@ -1,0 +1,277 @@
+defmodule Brando.Content.ModuleSyncTest do
+  @moduledoc """
+  Covers what a module save does to the blocks that already use it.
+
+  Every one of these runs through `sync_module/2` on plain structs — the same
+  function the update mutation calls for every block on the site — so the
+  assertions are about the migration itself, not about the admin UI on top of it.
+  """
+  use ExUnit.Case, async: true
+
+  alias Brando.Content.Block
+  alias Brando.Content.Blocks
+  alias Brando.Content.Module
+  alias Brando.Content.Ref
+  alias Brando.Content.Var
+  alias Brando.Villain.Blocks, as: VillainBlocks
+  alias Ecto.Changeset
+
+  defp header_data(text \\ "Heading") do
+    %VillainBlocks.HeaderBlock{
+      type: "header",
+      data: %VillainBlocks.HeaderBlock.Data{level: 2, text: text}
+    }
+  end
+
+  defp picture_data do
+    %VillainBlocks.PictureBlock{
+      type: "picture",
+      data: %VillainBlocks.PictureBlock.Data{title: "A picture"}
+    }
+  end
+
+  defp ref(name, data, opts \\ []) do
+    %Ref{
+      id: Keyword.get(opts, :id),
+      name: name,
+      description: Keyword.get(opts, :description),
+      uid: "uid-#{name}",
+      data: data,
+      sequence: 0
+    }
+  end
+
+  defp module(attrs) do
+    struct(
+      %Module{
+        id: 22,
+        uid: "modmodmodmod",
+        name: %{"en" => "Test"},
+        namespace: %{"en" => "general"},
+        class: "test",
+        code: "<div>{% ref refs.h2 %}</div>",
+        version: 2,
+        refs: [],
+        vars: []
+      },
+      attrs
+    )
+  end
+
+  defp block(attrs) do
+    struct(
+      %Block{
+        id: 100,
+        uid: "blockblockblo",
+        type: :module,
+        module_id: 22,
+        module_version: 1,
+        refs: [],
+        vars: []
+      },
+      attrs
+    )
+  end
+
+  defp synced_refs(changeset) do
+    changeset
+    |> Changeset.get_assoc(:refs)
+    |> Enum.map(&{Changeset.get_field(&1, :name), Changeset.get_field(&1, :data)})
+    |> Map.new()
+  end
+
+  describe "refs the module no longer defines" do
+    test "are retained instead of deleted" do
+      module = module(refs: [ref("h2", header_data("From module"))])
+
+      block =
+        block(
+          refs: [
+            ref("h2", header_data("Editor wrote this"), id: 1),
+            ref("gone", header_data("Content nobody wants to lose"), id: 2)
+          ]
+        )
+
+      refs = block |> Blocks.sync_module(module) |> synced_refs()
+
+      assert Map.has_key?(refs, "gone")
+      assert refs["gone"].data.text == "Content nobody wants to lose"
+    end
+
+    test "leave the block behind the module's version" do
+      module = module(refs: [ref("h2", header_data())])
+      block = block(refs: [ref("h2", header_data(), id: 1), ref("gone", header_data(), id: 2)])
+
+      changeset = Blocks.sync_module(block, module)
+
+      refute Map.has_key?(changeset.changes, :module_version)
+      assert Changeset.get_field(changeset, :module_version) == 1
+    end
+
+    test "are untouched by the module's template settings" do
+      module = module(refs: [ref("h2", header_data())])
+
+      block =
+        block(refs: [ref("gone", header_data("Kept"), id: 2, description: "editor description")])
+
+      changeset = Blocks.sync_module(block, module)
+
+      gone =
+        changeset
+        |> Changeset.get_assoc(:refs)
+        |> Enum.find(&(Changeset.get_field(&1, :name) == "gone"))
+
+      assert Changeset.get_field(gone, :description) == "editor description"
+      assert Changeset.get_field(gone, :data).data.text == "Kept"
+    end
+  end
+
+  describe "refs the module retyped" do
+    test "keep the block's own data rather than being merged into garbage" do
+      module = module(refs: [ref("hero", picture_data())])
+      block = block(refs: [ref("hero", header_data("Still a heading"), id: 1)])
+
+      refs = block |> Blocks.sync_module(module) |> synced_refs()
+
+      assert refs["hero"].__struct__ == VillainBlocks.HeaderBlock
+      assert refs["hero"].data.text == "Still a heading"
+    end
+
+    test "leave the block behind the module's version" do
+      module = module(refs: [ref("hero", picture_data())])
+      block = block(refs: [ref("hero", header_data(), id: 1)])
+
+      assert Blocks.sync_module(block, module) |> Changeset.get_field(:module_version) == 1
+    end
+  end
+
+  describe "a media ref" do
+    # `media` module refs drive picture/video/gallery/svg block refs by design —
+    # `PictureBlock.apply_ref/3` has a MediaBlock clause that reads
+    # `template_picture` out of the source. That is a match, not a retype.
+    test "still drives a picture block ref, and the block is stamped" do
+      media =
+        ref("hero", %VillainBlocks.MediaBlock{
+          type: "media",
+          data: %VillainBlocks.MediaBlock.Data{
+            template_picture: %VillainBlocks.PictureBlock.Data{img_class: "from-module"}
+          }
+        })
+
+      module = module(refs: [media])
+      block = block(refs: [ref("hero", picture_data(), id: 1)])
+
+      changeset = Blocks.sync_module(block, module)
+      refs = synced_refs(changeset)
+
+      assert refs["hero"].__struct__ == VillainBlocks.PictureBlock
+      assert refs["hero"].data.img_class == "from-module"
+      assert Changeset.get_change(changeset, :module_version) == 2
+    end
+  end
+
+  describe "a clean migration" do
+    test "stamps the block with the module's current version" do
+      module = module(refs: [ref("h2", header_data("From module"))])
+      block = block(refs: [ref("h2", header_data("Editor text"), id: 1)])
+
+      changeset = Blocks.sync_module(block, module)
+
+      assert Changeset.get_change(changeset, :module_version) == 2
+    end
+
+    test "instantiates refs the block is missing" do
+      module = module(refs: [ref("h2", header_data()), ref("added", header_data("Default"))])
+      block = block(refs: [ref("h2", header_data("Editor text"), id: 1)])
+
+      refs = block |> Blocks.sync_module(module) |> synced_refs()
+
+      assert Map.has_key?(refs, "added")
+      assert refs["added"].data.text == "Default"
+    end
+
+    test "instantiating a new ref still stamps the version" do
+      module = module(refs: [ref("added", header_data("Default"))])
+      block = block(refs: [])
+
+      assert Blocks.sync_module(block, module) |> Changeset.get_change(:module_version) == 2
+    end
+
+    test "preserves the editor's ref content while reapplying template settings" do
+      module = module(refs: [ref("h2", header_data("Module placeholder"), description: "from module")])
+      block = block(refs: [ref("h2", header_data("Editor text"), id: 1, description: "stale")])
+
+      changeset = Blocks.sync_module(block, module)
+
+      h2 =
+        changeset
+        |> Changeset.get_assoc(:refs)
+        |> Enum.find(&(Changeset.get_field(&1, :name) == "h2"))
+
+      assert Changeset.get_field(h2, :description) == "from module"
+      # `text` is not a protected attr on HeaderBlock, so the module owns it —
+      # the point here is that the ref survives as the same row rather than
+      # being deleted and reinserted.
+      assert Changeset.get_field(h2, :uid) == "uid-h2"
+    end
+
+    test "treats a module with no version as version 1" do
+      module = module(version: nil, refs: [ref("h2", header_data())])
+      block = block(module_version: nil, refs: [ref("h2", header_data(), id: 1)])
+
+      assert Blocks.sync_module(block, module) |> Changeset.get_change(:module_version) == 1
+    end
+  end
+
+  describe "vars" do
+    test "the module no longer defines are retained and hold the block behind" do
+      module = module(vars: [%Var{key: "title", type: :string, label: "Title"}])
+
+      block =
+        block(
+          vars: [
+            %Var{id: 1, key: "title", type: :string, label: "Title", value: "Editor value"},
+            %Var{id: 2, key: "orphan", type: :string, label: "Orphan", value: "Kept"}
+          ]
+        )
+
+      changeset = Blocks.sync_module(block, module)
+      vars = Changeset.get_assoc(changeset, :vars)
+
+      assert Enum.map(vars, &Changeset.get_field(&1, :key)) == ["title", "orphan"]
+
+      assert changeset
+             |> Changeset.get_assoc(:vars)
+             |> Enum.find(&(Changeset.get_field(&1, :key) == "orphan"))
+             |> Changeset.get_field(:value) == "Kept"
+
+      assert Changeset.get_field(changeset, :module_version) == 1
+    end
+
+    test "added by the module are instantiated and the block is stamped" do
+      module =
+        module(vars: [%Var{key: "title", type: :string, label: "Title", value: "Default"}])
+
+      block = block(vars: [])
+
+      changeset = Blocks.sync_module(block, module)
+
+      assert changeset |> Changeset.get_assoc(:vars) |> length() == 1
+      assert Changeset.get_change(changeset, :module_version) == 2
+    end
+
+    test "keep the editor's value while template settings are reapplied" do
+      module = module(vars: [%Var{key: "title", type: :string, label: "New label"}])
+      block = block(vars: [%Var{id: 1, key: "title", type: :string, label: "Old", value: "Mine"}])
+
+      var =
+        block
+        |> Blocks.sync_module(module)
+        |> Changeset.get_assoc(:vars)
+        |> List.first()
+
+      assert Changeset.get_field(var, :value) == "Mine"
+      assert Changeset.get_field(var, :label) == "New label"
+    end
+  end
+end

--- a/test/brando/content/module_versioning_test.exs
+++ b/test/brando/content/module_versioning_test.exs
@@ -1,0 +1,197 @@
+defmodule Brando.Content.ModuleVersioningTest do
+  @moduledoc """
+  The version bump and the stale-block bookkeeping it drives, against the database.
+  """
+  use ExUnit.Case, async: false
+  use Brando.ConnCase
+
+  alias Brando.Content.Block
+  alias Brando.Content.Blocks, as: ContentBlocks
+  alias Brando.Content.Module
+  alias Brando.Factory
+  alias Ecto.Changeset
+
+  defp insert_module(user, attrs \\ %{}) do
+    Factory.insert(:module, Map.merge(%{code: "<div>{% ref refs.h2 %}</div>"}, attrs))
+    |> tap(fn _ -> user end)
+  end
+
+  defp save(module, params, user) do
+    module
+    |> Module.changeset(params, user)
+    |> Brando.Repo.update()
+  end
+
+  describe "uid" do
+    test "is generated for a new module" do
+      user = Factory.insert(:random_user)
+
+      {:ok, module} =
+        %Module{}
+        |> Module.changeset(
+          %{
+            name: %{"en" => "New"},
+            namespace: %{"en" => "general"},
+            help_text: %{"en" => "help"},
+            class: "c",
+            code: "code"
+          },
+          user
+        )
+        |> Brando.Repo.insert()
+
+      assert is_binary(module.uid)
+      assert module.uid != ""
+    end
+
+    test "survives an update untouched" do
+      user = Factory.insert(:random_user)
+      module = insert_module(user)
+      {:ok, updated} = save(module, %{code: "changed"}, user)
+
+      assert updated.uid == module.uid
+    end
+  end
+
+  describe "version bumping" do
+    test "a save that changes nothing does not bump" do
+      user = Factory.insert(:random_user)
+      module = insert_module(user)
+
+      {:ok, updated} = save(module, %{}, user)
+
+      assert updated.version == module.version
+    end
+
+    test "a metadata change bumps" do
+      user = Factory.insert(:random_user)
+      module = insert_module(user)
+
+      {:ok, updated} = save(module, %{name: %{"en" => "Renamed"}}, user)
+
+      assert updated.version == module.version + 1
+    end
+
+    test "a code change bumps" do
+      user = Factory.insert(:random_user)
+      module = insert_module(user)
+
+      {:ok, updated} = save(module, %{code: "<p>different</p>"}, user)
+
+      assert updated.version == module.version + 1
+    end
+
+    test "a version_note-only save does not bump" do
+      user = Factory.insert(:random_user)
+      module = insert_module(user)
+
+      {:ok, updated} = save(module, %{version_note: "just a note"}, user)
+
+      assert updated.version == module.version
+    end
+
+    test "successive effective saves keep counting" do
+      user = Factory.insert(:random_user)
+      module = insert_module(user)
+
+      {:ok, v2} = save(module, %{code: "one"}, user)
+      {:ok, v3} = save(v2, %{code: "two"}, user)
+
+      assert v3.version == module.version + 2
+    end
+
+    test "an explicit version change is left alone" do
+      user = Factory.insert(:random_user)
+      module = insert_module(user)
+
+      {:ok, updated} = save(module, %{code: "changed", version: 99}, user)
+
+      assert updated.version == 99
+    end
+  end
+
+  describe "the version bump as an optimistic lock" do
+    test "a second editor saving over a revision they never saw is rejected" do
+      user = Factory.insert(:random_user)
+      module = insert_module(user)
+
+      # Both editors opened the same revision.
+      stale_copy = module
+
+      {:ok, _} = save(module, %{code: "first editor wins"}, user)
+
+      assert_raise Ecto.StaleEntryError, fn ->
+        save(stale_copy, %{code: "second editor clobbers"}, user)
+      end
+    end
+
+    test "a no-op save over a moved revision does not raise" do
+      user = Factory.insert(:random_user)
+      module = insert_module(user)
+      stale_copy = module
+
+      {:ok, _} = save(module, %{code: "moved on"}, user)
+
+      # Nothing to publish, nothing to conflict over.
+      assert {:ok, _} = save(stale_copy, %{}, user)
+    end
+  end
+
+  describe "list_stale_block_ids/2" do
+    setup do
+      user = Factory.insert(:random_user)
+      module = insert_module(user)
+      %{user: user, module: module}
+    end
+
+    defp insert_block(module, user, module_version) do
+      %Block{}
+      |> Changeset.change(%{
+        uid: Brando.Utils.generate_uid(),
+        type: :module,
+        module_id: module.id,
+        module_version: module_version,
+        creator_id: user.id,
+        sequence: 0
+      })
+      |> Brando.Repo.insert!()
+    end
+
+    test "a block at the module's version is not stale", %{module: module, user: user} do
+      block = insert_block(module, user, module.version)
+
+      refute block.id in ContentBlocks.list_stale_block_ids(module)
+      assert ContentBlocks.count_stale_blocks(module) == 0
+    end
+
+    test "a block behind the module is stale", %{module: module, user: user} do
+      block = insert_block(module, user, module.version - 1)
+
+      assert block.id in ContentBlocks.list_stale_block_ids(module)
+      assert ContentBlocks.count_stale_blocks(module) == 1
+    end
+
+    test "a block that predates tracking is stale", %{module: module, user: user} do
+      block = insert_block(module, user, nil)
+
+      assert block.id in ContentBlocks.list_stale_block_ids(module)
+    end
+
+    test "accepts a module id and reads the version from the row", %{module: module, user: user} do
+      block = insert_block(module, user, nil)
+
+      assert block.id in ContentBlocks.list_stale_block_ids(module.id)
+    end
+
+    test "an unknown module id yields nothing rather than raising" do
+      assert ContentBlocks.list_stale_block_ids(-1) == []
+    end
+
+    test "blocks of other modules are not counted", %{module: module, user: user} do
+      other = insert_module(user)
+      insert_block(other, user, nil)
+
+      assert ContentBlocks.count_stale_blocks(module) == 0
+    end
+  end
+end

--- a/test/brando/content/ref_test.exs
+++ b/test/brando/content/ref_test.exs
@@ -362,10 +362,14 @@ defmodule Brando.Content.RefTest do
       assert new_ref.data.data.text == "New text"
     end
 
-    test "handles refs with missing module refs during reapply" do
-      # This tests the error condition where a ref exists in a block
-      # but the corresponding ref is removed from the module
+    test "retains refs the module no longer defines, rather than deleting them" do
+      # A ref removed from a module is indistinguishable from a renamed one, and
+      # the block's copy holds content an editor typed. Deleting it here wiped
+      # that content out of every entry on the site — see issue #2642. It is kept
+      # instead, and the block is left behind the module's version so it stays
+      # findable through `Blocks.list_stale_block_ids/2`.
       module_with_missing_ref = %Content.Module{
+        version: 3,
         id: 1,
         name: "Test Module",
         namespace: "test",
@@ -389,11 +393,15 @@ defmodule Brando.Content.RefTest do
         ]
       }
 
-      # Should remove the orphaned ref
       updated_block_cs = Brando.Content.Blocks.sync_module(original_block, module_with_missing_ref)
       updated_block = Ecto.Changeset.apply_changes(updated_block_cs)
 
-      assert updated_block.refs == []
+      assert [orphan] = updated_block.refs
+      assert orphan.name == "orphaned_ref"
+      assert orphan.data.data.text == "Orphaned text"
+
+      # ...and the block is not stamped as migrated to the module's revision
+      refute Ecto.Changeset.get_change(updated_block_cs, :module_version)
     end
   end
 

--- a/test/brando_admin/live/content/module_destructive_save_test.exs
+++ b/test/brando_admin/live/content/module_destructive_save_test.exs
@@ -1,0 +1,230 @@
+defmodule BrandoAdmin.Live.Content.ModuleDestructiveSaveTest do
+  @moduledoc """
+  A module save migrates every block that uses it. These cover the gate in front
+  of the saves that orphan editor content — that it opens, that it says how far
+  the change reaches, and that it does not stand between the editor and an
+  ordinary save.
+  """
+  use ExUnit.Case, async: false
+  use Brando.ConnCase
+
+  import Phoenix.Component, only: [to_form: 2]
+
+  alias Brando.Content.Block
+  alias Brando.Content.Module
+  alias Brando.Content.Ref
+  alias Brando.Content.Var
+  alias Brando.Factory
+  alias Brando.Villain.Blocks.TextBlock
+  alias BrandoAdmin.Content.ModuleFormLive
+  alias Ecto.Changeset
+
+  defp text_ref(name) do
+    %Ref{
+      name: name,
+      uid: "uid-#{name}",
+      data: %TextBlock{type: "text", data: %TextBlock.Data{text: "Hello"}},
+      sequence: 0
+    }
+  end
+
+  defp insert_module(refs, vars \\ []) do
+    :module
+    |> Factory.build(%{code: "<div>{% ref refs.intro %}</div>"})
+    |> Changeset.change()
+    |> Changeset.put_assoc(:refs, refs)
+    |> Changeset.put_assoc(:vars, vars)
+    |> Brando.Repo.insert!()
+    |> Brando.Repo.preload([:refs, :vars])
+  end
+
+  defp insert_block(module, user) do
+    %Block{}
+    |> Changeset.change(%{
+      uid: Brando.Utils.generate_uid(),
+      type: :module,
+      module_id: module.id,
+      module_version: module.version,
+      creator_id: user.id,
+      sequence: 0
+    })
+    |> Brando.Repo.insert!()
+  end
+
+  defp socket_for(module, user) do
+    form = module |> Module.changeset(%{}, user) |> to_form([])
+
+    %Phoenix.LiveView.Socket{}
+    |> Phoenix.Component.assign(:form, form)
+    |> Phoenix.Component.assign(:entry, module)
+    |> Phoenix.Component.assign(:current_user, user)
+    |> Phoenix.Component.assign(:shared_library?, false)
+    |> Phoenix.Component.assign(:save_redirect_target, :self)
+    |> Phoenix.Component.assign(:pending_destructive_save, nil)
+  end
+
+  # The params a save event carries. Refs and vars come back as index-keyed maps,
+  # so dropping one is expressed by simply not sending it.
+  defp params(module, overrides) do
+    Map.merge(
+      %{
+        "name" => module.name,
+        "namespace" => module.namespace,
+        "help_text" => module.help_text,
+        "class" => module.class,
+        "code" => module.code
+      },
+      overrides
+    )
+  end
+
+  defp ref_params(refs) do
+    refs
+    |> Enum.with_index()
+    |> Map.new(fn {ref, index} ->
+      {to_string(index),
+       %{
+         "id" => to_string(ref.id),
+         "name" => ref.name,
+         "uid" => ref.uid,
+         "data" => %{"type" => "text", "data" => %{"text" => "Hello"}}
+       }}
+    end)
+  end
+
+  setup do
+    %{user: Factory.insert(:random_user)}
+  end
+
+  describe "a destructive save" do
+    test "is held for confirmation instead of running", %{user: user} do
+      module = insert_module([text_ref("intro"), text_ref("outro")])
+      block = insert_block(module, user)
+
+      assert {:noreply, socket} =
+               ModuleFormLive.handle_event(
+                 "save",
+                 %{"module" => params(module, %{"refs" => ref_params([hd(module.refs)])})},
+                 socket_for(module, user)
+               )
+
+      pending = socket.assigns.pending_destructive_save
+      assert pending
+      assert pending.summary != []
+      assert Enum.any?(pending.summary, &(&1 =~ "outro"))
+
+      # Nothing was written: the module and its block are exactly as they were.
+      assert Brando.Repo.get(Module, module.id).version == module.version
+      assert Brando.Repo.get(Block, block.id).module_version == module.version
+    end
+
+    test "reports how many blocks the change reaches", %{user: user} do
+      module = insert_module([text_ref("intro"), text_ref("outro")])
+      for _ <- 1..3, do: insert_block(module, user)
+
+      {:noreply, socket} =
+        ModuleFormLive.handle_event(
+          "save",
+          %{"module" => params(module, %{"refs" => ref_params([hd(module.refs)])})},
+          socket_for(module, user)
+        )
+
+      assert socket.assigns.pending_destructive_save.affected == {:blocks, 3}
+    end
+
+    test "runs once confirmed", %{user: user} do
+      module = insert_module([text_ref("intro"), text_ref("outro")])
+
+      {:noreply, held} =
+        ModuleFormLive.handle_event(
+          "save",
+          %{"module" => params(module, %{"refs" => ref_params([hd(module.refs)])})},
+          socket_for(module, user)
+        )
+
+      assert {:noreply, saved} = ModuleFormLive.handle_event("confirm_destructive_save", %{}, held)
+
+      assert saved.assigns.pending_destructive_save == nil
+      reloaded = Brando.Repo.get(Module, module.id)
+      assert reloaded.version == module.version + 1
+      assert Brando.Repo.preload(reloaded, :refs).refs |> Enum.map(& &1.name) == ["intro"]
+    end
+
+    test "is abandoned on cancel, leaving the module untouched", %{user: user} do
+      module = insert_module([text_ref("intro"), text_ref("outro")])
+
+      {:noreply, held} =
+        ModuleFormLive.handle_event(
+          "save",
+          %{"module" => params(module, %{"refs" => ref_params([hd(module.refs)])})},
+          socket_for(module, user)
+        )
+
+      assert {:noreply, cancelled} =
+               ModuleFormLive.handle_event("cancel_destructive_save", %{}, held)
+
+      assert cancelled.assigns.pending_destructive_save == nil
+      assert Brando.Repo.get(Module, module.id).version == module.version
+    end
+
+    test "removing a variable also asks", %{user: user} do
+      module = insert_module([], [%Var{key: "title", type: :string, label: "Title"}])
+
+      {:noreply, socket} =
+        ModuleFormLive.handle_event(
+          "save",
+          %{"module" => params(module, %{"vars" => %{}})},
+          socket_for(module, user)
+        )
+
+      assert socket.assigns.pending_destructive_save
+      assert Enum.any?(socket.assigns.pending_destructive_save.summary, &(&1 =~ "title"))
+    end
+  end
+
+  describe "a non-destructive save" do
+    test "goes straight through", %{user: user} do
+      module = insert_module([text_ref("intro")])
+
+      assert {:noreply, socket} =
+               ModuleFormLive.handle_event(
+                 "save",
+                 %{
+                   "module" =>
+                     params(module, %{
+                       "code" => "<p>rewritten</p>",
+                       "refs" => ref_params(module.refs)
+                     })
+                 },
+                 socket_for(module, user)
+               )
+
+      assert socket.assigns.pending_destructive_save == nil
+      assert Brando.Repo.get(Module, module.id).code == "<p>rewritten</p>"
+    end
+
+    test "adding a reference goes straight through", %{user: user} do
+      module = insert_module([text_ref("intro")])
+
+      new_refs =
+        module.refs
+        |> ref_params()
+        |> Map.put("1", %{
+          "name" => "added",
+          "uid" => "uid-added",
+          "data" => %{"type" => "text", "data" => %{"text" => "Hi"}}
+        })
+
+      {:noreply, socket} =
+        ModuleFormLive.handle_event(
+          "save",
+          %{"module" => params(module, %{"refs" => new_refs})},
+          socket_for(module, user)
+        )
+
+      assert socket.assigns.pending_destructive_save == nil
+      reloaded = Brando.Repo.preload(Brando.Repo.get(Module, module.id), :refs)
+      assert Enum.sort(Enum.map(reloaded.refs, & &1.name)) == ["added", "intro"]
+    end
+  end
+end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -105,6 +105,7 @@ defmodule Brando.Factory do
 
   def module_factory do
     %Module{
+      uid: sequence(:module_uid, &"module_uid_#{&1}"),
       name: "test",
       namespace: "posts",
       help_text: "help",


### PR DESCRIPTION
Closes the data-loss half of #2642 — the "ship that half" slice from the deep-dive's phase 1.

## The bug

Saving a module has always been a site-wide migration: every block using it is re-synced. Any **reference the module no longer declares was deleted from every block, in every entry**, with no warning and no recovery. A rename is indistinguishable from a removal at that level, so renaming a ref destroyed its content everywhere.

## What changed

**References are retained, not deleted.** The module's template no longer renders them, so they lie dormant until an explicit upgrade resolves them. Variables were already retained; references now match. A reference whose *block type* the module swapped is left alone too, rather than merged into a struct that cannot hold it.

**`content_modules.version` counts definition revisions.** Bumped by the new `Brando.Trait.ModuleVersioned` when `Brando.Content.ModuleDiff` classifies the change as effective — not on a save that changed nothing. The bump doubles as an optimistic lock, so two editors on the same module can no longer silently publish two different next revisions.

**`content_blocks.module_version` records how far each block got.** `sync_module/2` stamps it only when every ref and var the block holds still has a compatible definition behind it. Orphans, retypes and failed writes all leave the block behind, findable through `Blocks.list_stale_block_ids/2` — a partial migration becomes a visible queue instead of silent mixed state.

**The module editor asks before a destructive save**, naming each reference and variable about to be orphaned and how many blocks on the site use the module.

**`content_modules.uid`** is lineage identity for the import replacement still to come (phase 3). Name and namespace cannot serve: both are editable i18n maps. Export and import mint a fresh uid at v1, which matches what import already does in practice — it produces copies.

## Two things found on the way

- A `media` module ref is a *slot*, not a type: it legitimately drives picture/video/gallery/svg block refs, each of which has a `MediaBlock` clause in `apply_ref/3`. Comparing structs naively put a confirmation dialog in front of every media module edit. `Brando.Villain.Blocks.ref_types_compatible?/2` is the rule now.
- A fresh module stores `multi: nil` and the form posts `false` on first save. Reading that as a contract change gated the *first* save of every new module behind the dialog. Caught by the e2e suite.

`Brando.Trait.EnsureUID` moves to the `:before_validate_required` phase, which is what that phase is for.

## Migration

Requires `brando_167`. Existing modules get a `uid`; existing blocks are backfilled as current, so upgrading does not flag a site as stale on day one.

## Testing

- 47 new unit tests: every diff class, the sync behaviour, the version bump and lock, the stale queries, and the editor's confirmation flow.
- `modules.spec.js` extended to cover the new gate; full suite green (1847 unit / 133 e2e).

## Deliberately not in scope

Phase 2 (bulk upgrade UI, stale badges) and phase 3 (versioned import envelope, conflict matrix). Both are written up on the issue.
