### PR TITLE
refactor: eliminate the compile-connected dependency cycle (#2737)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,14 +119,15 @@ jobs:
       - name: Run strict Blueprint code analysis
         run: mix credo --strict lib/brando/blueprint.ex lib/brando/blueprint
 
-      # One known cycle is tolerated: a 195-module compile-connected loop held
-      # together by the Blueprint DSL (`use Brando.Blueprint` pulls in
-      # blueprint/dsl.ex, attributes/dsl.ex, assets/dsl.ex and their
-      # transformers at compile time). Removing it is an architectural change,
-      # not a cleanup — see brandocms/brando#2737. This gate still catches any
-      # *new* cycle, which is what it is worth having.
+      # Back to zero. The 251-module cycle this gate used to tolerate was not
+      # the Blueprint DSL after all — it was a handful of accidental
+      # compile-time calls, the last of which was a single struct literal in a
+      # form `default`. See brandocms/brando#2737 for the list; the pattern to
+      # watch for is a compile-time call (module attribute, `%Struct{}` literal,
+      # macro-expansion-time function call) that crosses from a leaf into a
+      # module the callee's own dependencies reach back to.
       - name: Reject compile-connected dependency cycles
-        run: mix xref graph --format cycles --label compile-connected --fail-above 1
+        run: mix xref graph --format cycles --label compile-connected --fail-above 0
 
   docs:
     name: Published documentation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -240,6 +240,36 @@
     shared renderer uses, and it defeated `preload` by making the browser fetch
     the manifest eagerly.
 
+#### Improvements
+
+- **The 251-module compile-connected dependency cycle is gone** (#2737), and the
+  CI gate is back to `--fail-above 0`.
+
+  It was never the Blueprint DSL. Every edge holding it together was an
+  accidental compile-time call from one module into another whose own
+  dependencies led back:
+
+  - `BrandoAdmin.live_view/0` and `UploadManager` called `Brando.config/1` during
+    macro expansion; they read the same value off the leaf
+    `Brando.RuntimeConfig` now.
+  - `SharedLibrary`'s `@definitions` and `Content`'s `@module_cache_opts`
+    resolved `Ref.preloads/0` into module attributes; both are functions now.
+  - `Block.Render` read `Content.Block.carried_var_attrs/0` into an attribute;
+    the lists moved to the new leaf `Brando.Content.VarAttrs`, which
+    `Content.Block` re-exports.
+  - `Content.Module`'s listing action called `BrandoAdmin.Utils.show_modal/2` at
+    compile time — a core schema recompiling with the admin. The JS command
+    builders moved to the new leaf `BrandoAdmin.JSCommands`; `BrandoAdmin.Utils`
+    delegates to it, so existing call sites are unchanged.
+  - The last one was a single struct literal: `default %Palette.Color{}` in
+    `Content.Palette`'s form. `default` also takes a 2-arity function, which
+    defers it.
+
+  The pattern to watch for is in `Brando.Blueprint.Forms`' docs now: a
+  compile-time call — module attribute, `%Struct{}` literal, or a function call
+  during macro expansion — that crosses into a module the callee's own
+  dependencies reach back to.
+
 #### Features
 
 - **Igniter-assisted tenancy setup for existing applications.** The opt-in

--- a/lib/brando/blueprint/forms.ex
+++ b/lib/brando/blueprint/forms.ex
@@ -76,6 +76,16 @@ defmodule Brando.Blueprint.Forms do
 
   Renders a sub form
 
+  `default` supplies the entry created by the subform's "Add entry" button. It
+  takes either a struct or a 2-arity function `fn entry, _ -> ... end`.
+
+  Prefer the function form when the default is a struct of another Blueprint
+  schema. A `%Struct{}` literal is resolved while *this* schema compiles, so it
+  is a compile-time dependency; when the target's own dependency graph leads back
+  here, that single literal closes a compile-connected cycle and every module in
+  the loop recompiles whenever any of them is touched. One such literal held a
+  251-module cycle together — see brandocms/brando#2737.
+
   ## Example
 
   Regular inline form set:

--- a/lib/brando/content.ex
+++ b/lib/brando/content.ex
@@ -224,10 +224,15 @@ defmodule Brando.Content do
     end
   end
 
-  @module_cache_opts %{
-    cache: {:ttl, :infinite},
-    preload: [{:vars, {Var, [asc: :sequence]}}, refs: Brando.Content.Ref.preloads()]
-  }
+  # A function, not a module attribute: `Ref.preloads/0` resolved into an
+  # attribute is a compile-time call into a Blueprint schema, which is one of the
+  # edges holding Blueprint's compile-connected cycle together. See issue #2737.
+  defp module_cache_opts do
+    %{
+      cache: {:ttl, :infinite},
+      preload: [{:vars, {Var, [asc: :sequence]}}, refs: Brando.Content.Ref.preloads()]
+    }
+  end
 
   @container_cache_opts %{
     cache: {:ttl, :infinite},
@@ -243,7 +248,7 @@ defmodule Brando.Content do
     if Brando.Tenant.enabled?() do
       Brando.Content.SharedLibrary.get_for_current_tenant(:module, id, origin)
     else
-      {:ok, modules} = list_modules(@module_cache_opts)
+      {:ok, modules} = list_modules(module_cache_opts())
       Enum.find(modules, &(&1.id == id))
     end
   end

--- a/lib/brando/content/block.ex
+++ b/lib/brando/content/block.ex
@@ -13,6 +13,8 @@ defmodule Brando.Content.Block do
 
   use Gettext, backend: Brando.Gettext
 
+  alias Brando.Content.VarAttrs
+
   @type t :: %__MODULE__{}
 
   @block_attrs [
@@ -37,46 +39,7 @@ defmodule Brando.Content.Block do
     :identifier_metas
   ]
 
-  @var_attrs [
-    :type,
-    :label,
-    :placeholder,
-    :key,
-    :value,
-    :value_boolean,
-    :placement,
-    :new_row,
-    :instructions,
-    :color_picker,
-    :color_opacity,
-    :link_text,
-    :link_type,
-    :link_identifier_schemas,
-    :link_target_blank,
-    :link_allow_custom_text,
-    :width,
-    :sequence,
-    :creator_id,
-    :module_id,
-    :page_id,
-    :block_id,
-    :palette_id,
-    :identifier_id,
-    :global_set_id,
-    :table_template_id,
-    # Media a var can carry. The editor renders and commits all four
-    # (`render_var.ex`, `block.ex`'s `commit_var_data`), so omitting any of them
-    # here means the cast silently drops it and the value never reaches the DB.
-    :image_id,
-    :file_id,
-    :video_id,
-    :gallery_id,
-    # Upload/picker configuration for media vars, set through the var's config UI
-    :config_target,
-    :gallery_image_config_target,
-    :gallery_video_config_target,
-    :gallery_allowed_types
-  ]
+  @var_attrs VarAttrs.all()
 
   # ++ Traits
   trait :creator
@@ -293,9 +256,7 @@ defmodule Brando.Content.Block do
   `palette_id` and `identifier_id` stay: for a palette or identifier var those
   *are* the value.
   """
-  @var_owner_attrs [:creator_id, :module_id, :page_id, :block_id, :global_set_id, :table_template_id]
-
-  def carried_var_attrs, do: @var_attrs -- @var_owner_attrs
+  def carried_var_attrs, do: VarAttrs.carried()
 
   def var_changeset(var, attrs, position, user) when is_integer(position) do
     var

--- a/lib/brando/content/module.ex
+++ b/lib/brando/content/module.ex
@@ -138,11 +138,14 @@ defmodule Brando.Content.Module do
       filter label: t("Class"), key: "class"
       filter label: t("Code"), key: "code"
 
+      # `JSCommands`, not `BrandoAdmin.Utils`: a `selection_action`'s event is built
+      # during compilation of this schema, and `Utils` pulls in the translator and
+      # `Phoenix.Component` — so this schema recompiled with the admin. See #2737.
       selection_action label: t("Export modules"),
                        event:
                          "export_modules"
                          |> JS.push()
-                         |> BrandoAdmin.Utils.show_modal("#module-export-modal")
+                         |> BrandoAdmin.JSCommands.show_modal("#module-export-modal")
 
       child_listing name: :module_entries, schema: Brando.Content.Module
       component &__MODULE__.listing_row/1

--- a/lib/brando/content/palette.ex
+++ b/lib/brando/content/palette.ex
@@ -63,7 +63,7 @@ defmodule Brando.Content.Palette do
           inputs_for :colors do
             style :inline
             cardinality :many
-            default %Brando.Content.Palette.Color{}
+            default fn _entry, _ -> struct(Brando.Content.Palette.Color) end
 
             input :hex_value, :color, monospace: true
             input :name, :text

--- a/lib/brando/content/shared_library.ex
+++ b/lib/brando/content/shared_library.ex
@@ -27,35 +27,41 @@ defmodule Brando.Content.SharedLibrary do
   @public_opts [prefix: "public"]
   @kinds [:module, :container, :palette]
 
-  @definitions %{
-    module: %{
-      schema: Module,
-      access_schema: SiteEnabledModule,
-      access_field: :module_id,
-      block_field: :module_id,
-      block_origin_field: :module_origin,
-      source_field: :source_module_id,
-      preloads: [:vars, refs: Brando.Content.Ref.preloads()]
-    },
-    container: %{
-      schema: Container,
-      access_schema: SiteEnabledContainer,
-      access_field: :container_id,
-      block_field: :container_id,
-      block_origin_field: :container_origin,
-      source_field: :source_container_id,
-      preloads: []
-    },
-    palette: %{
-      schema: Palette,
-      access_schema: SiteEnabledPalette,
-      access_field: :palette_id,
-      block_field: :palette_id,
-      block_origin_field: :palette_origin,
-      source_field: :source_palette_id,
-      preloads: []
+  # A function, not a module attribute. `Ref.preloads/0` resolved inside an
+  # attribute is a compile-time call into a Blueprint schema, which puts this
+  # module inside Blueprint's compile-connected component — see issue #2737. The
+  # map is small and built per lookup; the lookups are not hot.
+  defp definitions do
+    %{
+      module: %{
+        schema: Module,
+        access_schema: SiteEnabledModule,
+        access_field: :module_id,
+        block_field: :module_id,
+        block_origin_field: :module_origin,
+        source_field: :source_module_id,
+        preloads: [:vars, refs: Brando.Content.Ref.preloads()]
+      },
+      container: %{
+        schema: Container,
+        access_schema: SiteEnabledContainer,
+        access_field: :container_id,
+        block_field: :container_id,
+        block_origin_field: :container_origin,
+        source_field: :source_container_id,
+        preloads: []
+      },
+      palette: %{
+        schema: Palette,
+        access_schema: SiteEnabledPalette,
+        access_field: :palette_id,
+        block_field: :palette_id,
+        block_origin_field: :palette_origin,
+        source_field: :source_palette_id,
+        preloads: []
+      }
     }
-  }
+  end
 
   @doc "Returns the public IDs enabled for `site` and `kind`."
   def enabled_ids(%Site{id: site_id}, kind) when kind in @kinds do
@@ -646,7 +652,7 @@ defmodule Brando.Content.SharedLibrary do
   defp result_to_ok({:ok, _entry}), do: :ok
   defp result_to_ok({:error, _changeset} = error), do: error
 
-  defp definition(kind), do: Map.fetch!(@definitions, kind)
+  defp definition(kind), do: Map.fetch!(definitions(), kind)
 
   defp normalize_origin(origin) when origin in [:local, "local", nil], do: :local
   defp normalize_origin(origin) when origin in [:shared, "shared"], do: :shared

--- a/lib/brando/content/var_attrs.ex
+++ b/lib/brando/content/var_attrs.ex
@@ -1,0 +1,77 @@
+defmodule Brando.Content.VarAttrs do
+  @moduledoc """
+  The castable var field lists, and the subset the block editor round-trips
+  through hidden inputs for an unsaved var.
+
+  A leaf module on purpose. `BrandoAdmin.Components.Form.Block.Render` reads
+  `carried/0` into a module attribute — the list has to be a compile-time
+  constant or LiveView re-sends the whole comprehension on every diff — and
+  reading it off `Brando.Content.Block` gave the block editor a compile-time edge
+  into a Blueprint schema, which is inside Blueprint's compile-connected
+  component. This module depends on nothing, so the same value costs no edge.
+  See issue #2737.
+
+  `Brando.Content.Block` re-exports both lists; call them there when you are
+  already in schema code.
+  """
+
+  @all [
+    :type,
+    :label,
+    :placeholder,
+    :key,
+    :value,
+    :value_boolean,
+    :placement,
+    :new_row,
+    :instructions,
+    :color_picker,
+    :color_opacity,
+    :link_text,
+    :link_type,
+    :link_identifier_schemas,
+    :link_target_blank,
+    :link_allow_custom_text,
+    :width,
+    :sequence,
+    :creator_id,
+    :module_id,
+    :page_id,
+    :block_id,
+    :palette_id,
+    :identifier_id,
+    :global_set_id,
+    :table_template_id,
+    # Media a var can carry. The editor renders and commits all four
+    # (`render_var.ex`, `block.ex`'s `commit_var_data`), so omitting any of them
+    # here means the cast silently drops it and the value never reaches the DB.
+    :image_id,
+    :file_id,
+    :video_id,
+    :gallery_id,
+    # Upload/picker configuration for media vars, set through the var's config UI
+    :config_target,
+    :gallery_image_config_target,
+    :gallery_video_config_target,
+    :gallery_allowed_types
+  ]
+
+  # Ownership and parentage, excluded from what the DOM is allowed to carry:
+  # `creator_id` is forced server-side by `Block.var_changeset/4`, and the owner
+  # FKs are set by whichever schema's `cast_assoc(:vars, …)` builds the var.
+  # `palette_id` and `identifier_id` are deliberately absent — for a palette or
+  # identifier var, those *are* the value.
+  @owner [:creator_id, :module_id, :page_id, :block_id, :global_set_id, :table_template_id]
+
+  @doc "Every var field `Brando.Content.Block` casts."
+  @spec all() :: [atom()]
+  def all, do: @all
+
+  @doc "The owner and creator fields the DOM is never allowed to supply."
+  @spec owner() :: [atom()]
+  def owner, do: @owner
+
+  @doc "The subset of `all/0` that `Render.carried_var/1` round-trips for an unsaved var."
+  @spec carried() :: [atom()]
+  def carried, do: @all -- @owner
+end

--- a/lib/brando/content/var_attrs.ex
+++ b/lib/brando/content/var_attrs.ex
@@ -3,7 +3,7 @@ defmodule Brando.Content.VarAttrs do
   The castable var field lists, and the subset the block editor round-trips
   through hidden inputs for an unsaved var.
 
-  A leaf module on purpose. `BrandoAdmin.Components.Form.Block.Render` reads
+  A leaf module on purpose. The block editor's ref renderer reads
   `carried/0` into a module attribute — the list has to be a compile-time
   constant or LiveView re-sends the whole comprehension on every diff — and
   reading it off `Brando.Content.Block` gave the block editor a compile-time edge

--- a/lib/brando_admin.ex
+++ b/lib/brando_admin.ex
@@ -29,7 +29,13 @@ defmodule BrandoAdmin do
 
       on_mount {BrandoAdmin.Hooks, :urls}
 
-      if Application.compile_env(Brando.config(:otp_app), :sql_sandbox) do
+      # `Brando.RuntimeConfig.get/1`, not `Brando.config/1`: this runs during macro
+      # expansion in every admin LiveView, so calling into `Brando` here gives each
+      # of them a compile-time edge to it — and `Brando` sits inside Blueprint's
+      # compile-connected component, so the edge closes a cycle that pulls the
+      # whole admin into one recompilation unit. `RuntimeConfig` is the leaf that
+      # exists for exactly this, and reads the same value. See issue #2737.
+      if Application.compile_env(Brando.RuntimeConfig.get(:otp_app), :sql_sandbox) do
         on_mount {BrandoAdmin.Mounts.LiveAcceptance, {:default, __MODULE__}}
       end
 

--- a/lib/brando_admin/components/form/block/render.ex
+++ b/lib/brando_admin/components/form/block/render.ex
@@ -8,7 +8,7 @@ defmodule BrandoAdmin.Components.Form.Block.Render do
   import Phoenix.LiveView.TagEngine
   import PolymorphicEmbed.HTML.Component
 
-  alias Brando.Content.Block, as: ContentBlock
+  alias Brando.Content.VarAttrs
   alias Brando.Content.Var.Layout
   alias BrandoAdmin.Components.Content
   alias BrandoAdmin.Components.Form.Block
@@ -2146,7 +2146,10 @@ defmodule BrandoAdmin.Components.Form.Block.Render do
   # Resolved at compile time, not per render. A function call in the template
   # cannot be change-tracked — LiveView has no way to know the list is constant,
   # so it re-evaluates and re-sends the whole comprehension on every diff.
-  @carried_var_fields ContentBlock.carried_var_attrs()
+  # Read off the leaf `Brando.Content.VarAttrs`, not off `Brando.Content.Block`:
+  # this is a compile-time call, and `Block` is a Blueprint schema inside
+  # Blueprint's compile-connected component — see issue #2737.
+  @carried_var_fields VarAttrs.carried()
 
   def carried_var(assigns) do
     # Blank, not just nil: once a validate round trip has happened the id comes

--- a/lib/brando_admin/js_commands.ex
+++ b/lib/brando_admin/js_commands.ex
@@ -1,0 +1,95 @@
+defmodule BrandoAdmin.JSCommands do
+  @moduledoc """
+  The admin's shared `Phoenix.LiveView.JS` command builders — dropdowns, modals,
+  drawers.
+
+  A leaf on purpose: it depends on nothing but `Phoenix.LiveView.JS`. Blueprint's
+  `listings` DSL evaluates a `selection_action`'s event at compile time, so a
+  schema that declares one takes a compile-time dependency on wherever these
+  live. When that was `BrandoAdmin.Utils` — which uses the translator and imports
+  `Phoenix.Component` — a core content schema recompiled with the admin. See
+  issue #2737.
+
+  `BrandoAdmin.Utils` delegates to these, so admin code can keep calling them
+  there.
+  """
+  alias Phoenix.LiveView.JS
+
+  def toggle_dropdown(js \\ %JS{}, dropdown_id) do
+    JS.toggle(js,
+      to: dropdown_id,
+      in: {"transition ease-out duration-300", "opacity-0 y-100", "opacity-100 y-0"},
+      out: {"transition ease-in duration-300", "opacity-100 y-0", "opacity-0 y-100"},
+      time: 300
+    )
+  end
+
+  def show_dropdown(js \\ %JS{}, dropdown_id) do
+    JS.show(js,
+      to: dropdown_id,
+      transition: {"transition ease-out duration-300", "opacity-0 y-100", "opacity-100 y-0"},
+      time: 300
+    )
+  end
+
+  def hide_dropdown(js \\ %JS{}, dropdown_id) do
+    JS.hide(js,
+      to: dropdown_id,
+      transition: {"transition ease-in duration-300", "opacity-100 y-0", "opacity-0 y-100"},
+      time: 300
+    )
+  end
+
+  def show_modal(js \\ %JS{}, modal_id) do
+    js
+    |> JS.show(
+      to: "#{modal_id}",
+      display: "flex",
+      blocking: false,
+      time: 0
+    )
+    |> JS.show(
+      to: "#{modal_id} .modal-backdrop",
+      transition: {"transition ease-out duration-200", "opacity-0", "opacity-100"},
+      blocking: false,
+      time: 200
+    )
+    |> JS.show(
+      to: "#{modal_id} .modal-dialog",
+      blocking: false,
+      transition: {"transition ease-out duration-200", "opacity-0 y-100", "opacity-100 y-0"},
+      time: 200
+    )
+  end
+
+  def hide_modal(js \\ %JS{}, modal_id) do
+    js
+    |> JS.hide(
+      to: "#{modal_id} .modal-dialog",
+      transition: {"transition ease-in duration-100", "opacity-100 y-0", "opacity-0 y-100"},
+      blocking: true,
+      time: 100
+    )
+    |> JS.hide(
+      to: "#{modal_id} .modal-backdrop",
+      transition: {"transition ease-in duration-100", "opacity-100", "opacity-0"},
+      blocking: false,
+      time: 100
+    )
+    |> JS.hide(
+      to: "#{modal_id}",
+      transition: {"transition", "opacity-100", "opacity-100"},
+      blocking: false,
+      time: 100
+    )
+  end
+
+  def toggle_drawer(js \\ %JS{}, drawer_id) do
+    JS.toggle(js,
+      to: drawer_id,
+      in: {"transition ease-out duration-300", "x-100", "x-0"},
+      out: {"transition ease-in duration-300", "x-0", "x-100"},
+      time: 300
+    )
+  end
+end

--- a/lib/brando_admin/js_commands.ex
+++ b/lib/brando_admin/js_commands.ex
@@ -1,18 +1,17 @@
 defmodule BrandoAdmin.JSCommands do
-  @moduledoc """
-  The admin's shared `Phoenix.LiveView.JS` command builders — dropdowns, modals,
-  drawers.
-
-  A leaf on purpose: it depends on nothing but `Phoenix.LiveView.JS`. Blueprint's
-  `listings` DSL evaluates a `selection_action`'s event at compile time, so a
-  schema that declares one takes a compile-time dependency on wherever these
-  live. When that was `BrandoAdmin.Utils` — which uses the translator and imports
-  `Phoenix.Component` — a core content schema recompiled with the admin. See
-  issue #2737.
-
-  `BrandoAdmin.Utils` delegates to these, so admin code can keep calling them
-  there.
-  """
+  # The admin's shared `Phoenix.LiveView.JS` command builders — dropdowns,
+  # modals, drawers.
+  #
+  # A leaf on purpose: it depends on nothing but `Phoenix.LiveView.JS`.
+  # Blueprint's `listings` DSL evaluates a `selection_action`'s event at compile
+  # time, so a schema that declares one takes a compile-time dependency on
+  # wherever these live. When that was BrandoAdmin.Utils — which uses the
+  # translator and imports `Phoenix.Component` — a core content schema
+  # recompiled with the admin. See issue #2737.
+  #
+  # BrandoAdmin.Utils delegates to these, so admin code can keep calling them
+  # there.
+  @moduledoc false
   alias Phoenix.LiveView.JS
 
   def toggle_dropdown(js \\ %JS{}, dropdown_id) do

--- a/lib/brando_admin/live/upload_manager.ex
+++ b/lib/brando_admin/live/upload_manager.ex
@@ -29,7 +29,10 @@ defmodule BrandoAdmin.UploadManager do
   # e2e/acceptance runs use the Ecto SQL sandbox — the manager writes to the
   # DB at consume, so it must join the test's sandbox connection like every
   # other admin LiveView (see BrandoAdmin.live_view/0).
-  if Application.compile_env(Brando.config(:otp_app), :sql_sandbox) do
+  # `RuntimeConfig`, not `Brando.config/1`: this is evaluated while the module is
+  # being compiled, and `Brando` is inside Blueprint's compile-connected
+  # component — see the same note in `BrandoAdmin.live_view/0` and issue #2737.
+  if Application.compile_env(Brando.RuntimeConfig.get(:otp_app), :sql_sandbox) do
     on_mount({BrandoAdmin.Mounts.LiveAcceptance, {:default, __MODULE__}})
   end
 

--- a/lib/brando_admin/utils.ex
+++ b/lib/brando_admin/utils.ex
@@ -5,6 +5,7 @@ defmodule BrandoAdmin.Utils do
   import Phoenix.Component
   import Phoenix.LiveView, only: [send_update: 2]
 
+  alias BrandoAdmin.JSCommands
   alias Phoenix.LiveView.JS
 
   @type component_ref :: {module(), term()}
@@ -127,83 +128,17 @@ defmodule BrandoAdmin.Utils do
     "#{field.id}-#{uid}"
   end
 
-  def toggle_dropdown(js \\ %JS{}, dropdown_id) do
-    JS.toggle(js,
-      to: dropdown_id,
-      in: {"transition ease-out duration-300", "opacity-0 y-100", "opacity-100 y-0"},
-      out: {"transition ease-in duration-300", "opacity-100 y-0", "opacity-0 y-100"},
-      time: 300
-    )
-  end
-
-  def show_dropdown(js \\ %JS{}, dropdown_id) do
-    JS.show(js,
-      to: dropdown_id,
-      transition: {"transition ease-out duration-300", "opacity-0 y-100", "opacity-100 y-0"},
-      time: 300
-    )
-  end
-
-  def hide_dropdown(js \\ %JS{}, dropdown_id) do
-    JS.hide(js,
-      to: dropdown_id,
-      transition: {"transition ease-in duration-300", "opacity-100 y-0", "opacity-0 y-100"},
-      time: 300
-    )
-  end
-
-  def show_modal(js \\ %JS{}, modal_id) do
-    js
-    |> JS.show(
-      to: "#{modal_id}",
-      display: "flex",
-      blocking: false,
-      time: 0
-    )
-    |> JS.show(
-      to: "#{modal_id} .modal-backdrop",
-      transition: {"transition ease-out duration-200", "opacity-0", "opacity-100"},
-      blocking: false,
-      time: 200
-    )
-    |> JS.show(
-      to: "#{modal_id} .modal-dialog",
-      blocking: false,
-      transition: {"transition ease-out duration-200", "opacity-0 y-100", "opacity-100 y-0"},
-      time: 200
-    )
-  end
-
-  def hide_modal(js \\ %JS{}, modal_id) do
-    js
-    |> JS.hide(
-      to: "#{modal_id} .modal-dialog",
-      transition: {"transition ease-in duration-100", "opacity-100 y-0", "opacity-0 y-100"},
-      blocking: true,
-      time: 100
-    )
-    |> JS.hide(
-      to: "#{modal_id} .modal-backdrop",
-      transition: {"transition ease-in duration-100", "opacity-100", "opacity-0"},
-      blocking: false,
-      time: 100
-    )
-    |> JS.hide(
-      to: "#{modal_id}",
-      transition: {"transition", "opacity-100", "opacity-100"},
-      blocking: false,
-      time: 100
-    )
-  end
-
-  def toggle_drawer(js \\ %JS{}, drawer_id) do
-    JS.toggle(js,
-      to: drawer_id,
-      in: {"transition ease-out duration-300", "x-100", "x-0"},
-      out: {"transition ease-in duration-300", "x-0", "x-100"},
-      time: 300
-    )
-  end
+  # The JS command builders live in the leaf `BrandoAdmin.JSCommands`, which needs
+  # nothing but `Phoenix.LiveView.JS`. Blueprint `listings` blocks build their
+  # actions at compile time, so a schema declaring one used to acquire a
+  # compile-time dependency on this module — and through it on the whole admin.
+  # See issue #2737. Delegated so every existing call site keeps working.
+  defdelegate toggle_dropdown(js \\ %JS{}, dropdown_id), to: JSCommands
+  defdelegate show_dropdown(js \\ %JS{}, dropdown_id), to: JSCommands
+  defdelegate hide_dropdown(js \\ %JS{}, dropdown_id), to: JSCommands
+  defdelegate show_modal(js \\ %JS{}, modal_id), to: JSCommands
+  defdelegate hide_modal(js \\ %JS{}, modal_id), to: JSCommands
+  defdelegate toggle_drawer(js \\ %JS{}, drawer_id), to: JSCommands
 
   @doc """
   Derives the Form component ID from a form name string or a Phoenix.HTML.Form struct.


### PR DESCRIPTION
Closes #2737. The cycle is gone entirely, and the CI gate is back to `--fail-above 0`.

```
before:  Cycle of length 251 (11 compile, 138 export)
after:   No cycles found
```

## The issue's diagnosis was wrong

#2737 concluded the loop was structural — "essentially what `use Brando.Blueprint` is" — and raised the gate to tolerate it. It is not. Every edge holding it together was an accidental compile-time call from one module into another whose own dependencies led back to it. Removing them took no architectural change.

| Edge | Why it was compile-time | Fix |
|---|---|---|
| `BrandoAdmin.live_view/0`, `UploadManager` | `Brando.config/1` called during macro expansion, so **every** admin LiveView took a compile edge to `Brando` | read the leaf `Brando.RuntimeConfig` |
| `SharedLibrary.@definitions`, `Content.@module_cache_opts` | `Ref.preloads/0` resolved into a module attribute | functions instead of attributes |
| `Block.Render` | `Content.Block.carried_var_attrs/0` into an attribute — it has to be a compile-time constant or LiveView re-sends the comprehension every diff | new leaf `Brando.Content.VarAttrs`; `Content.Block` re-exports |
| `Content.Module` | its export listing action called `BrandoAdmin.Utils.show_modal/2` at compile time, so a core content schema recompiled with the admin | new leaf `BrandoAdmin.JSCommands`; `BrandoAdmin.Utils` delegates, no call sites changed |
| `Content.Palette` | `default %Palette.Color{}` in its form — a struct literal is resolved while the *enclosing* schema compiles | `default` also takes a 2-arity function, which defers it |

That last one — a single struct literal in a form default — was holding the remaining 251-module loop on its own.

## Why it matters

A compile-connected cycle means touching any module in the loop can recompile all 251. Nothing was broken at runtime; the cost was build time, and a permanently weakened gate.

## Guarding against a repeat

`Brando.Blueprint.Forms`' docs now describe the hazard, since `default %Struct{}` is the shape most likely to reintroduce it. The pattern in general: a compile-time call — module attribute, `%Struct{}` literal, or a function call during macro expansion — that crosses into a module the callee's own dependencies reach back to.

## Testing

Full unit suite (1845) and full e2e suite (133) green. The palette `default` change is covered by `content-configuration.spec.js`, which exercises "Add entry" on the palette subform — the one thing that consumes it.
