### PR TITLE
feat(admin): accessible form validation (#1996)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -275,6 +275,31 @@
   `Brando.Content.ModuleDiff` therefore types its arguments as `map()` and
   matches on shape rather than on `%Module{}`.
 
+- **Accessible form validation in the admin** (#1996). The admin is essentially
+  one large form application and shipped exactly one ARIA attribute in its whole
+  form layer: no error association, no live regions, no required exposure, no
+  dialog semantics, no focus management.
+
+  - `Input.input/1` — the single place every control in the admin is rendered —
+    now emits `aria-invalid`, `aria-describedby` and `aria-required`. Required
+    comes from the blueprint's `__required_attrs__/0`; hidden inputs get nothing.
+  - `Primitives.error_tag/1` renders one `role="alert"` container instead of a
+    span per message, present whether or not it has anything to say (a live
+    region added *with* its content is not reliably announced). This also fixes
+    two errors on one field being drawn on top of each other, and each claiming
+    the same DOM id.
+  - Modals are `role="dialog" aria-modal="true"`, named by their own heading. The
+    new `Brando.Modal` hook takes focus on open, wraps Tab, and returns focus to
+    whatever opened them.
+  - A failed save focuses the first invalid control instead of only scrolling to
+    it.
+
+  **If you style `.field-error`:** the messages are now wrapped in a
+  `.field-errors` container, and positioning moved to it. A selector like
+  `.label-wrapper > span.field-error` no longer matches.
+
+  Not yet done: associating a field's `help-text` instructions with its control.
+
 #### Features
 
 - **Module migration tracking, and a warning before a module save destroys

--- a/assets/css/components/Form/FieldBase.css
+++ b/assets/css/components/Form/FieldBase.css
@@ -165,10 +165,19 @@
     visibility: hidden;
   }
 
-  > span.field-error {
-    font-size: 12px;
+  /* The errors live in one `role="alert"` container so screen readers announce
+     them as they appear, and so `aria-describedby` has a single id to point at.
+     Positioning moved from the individual messages to the container: when there
+     was more than one, each was absolutely positioned at right: 0 and they were
+     drawn on top of each other. */
+  > .field-errors {
     position: absolute;
     right: 0;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 2px;
+    font-size: 12px;
   }
 
   label {

--- a/assets/src/hooks.js
+++ b/assets/src/hooks.js
@@ -16,6 +16,7 @@ import FormHook from './hooks/Form'
 import ListingHook from './hooks/Listing'
 import LivePreviewHook from './hooks/LivePreview'
 import MapURLParserHook from './hooks/MapURLParser'
+import ModalHook from './hooks/Modal'
 import MuxUploaderHook from './hooks/MuxUploader'
 import BunnyUploaderHook from './hooks/BunnyUploader'
 import CloudflareUploaderHook from './hooks/CloudflareUploader'
@@ -63,6 +64,7 @@ export default (app) => {
     'Brando.Listing': ListingHook(app),
     'Brando.LivePreview': LivePreviewHook(app),
     'Brando.MapURLParser': MapURLParserHook(app),
+    'Brando.Modal': ModalHook(app),
     'Brando.MuxUploader': MuxUploaderHook(app),
     'Brando.BunnyUploader': BunnyUploaderHook(app),
     'Brando.CloudflareUploader': CloudflareUploaderHook(app),

--- a/assets/src/hooks/Admin/index.js
+++ b/assets/src/hooks/Admin/index.js
@@ -46,15 +46,21 @@ export default app => ({
 
     this.handleEvent('b:scroll_to_first_error', () => {
       const $fieldErrors = Dom.all('.field-error')
-      if ($fieldErrors.length) {
-        const firstError = $fieldErrors[0]
-        // const $tabWithError = firstError.closest('.form-tab')
-        // console.log($tabWithError)
-        // if (!Dom.hasClass($tabWithError, 'active')) {
-        //   this.pushEvent
-        //   console.log('has active!')
-        // }
-        app.scrollTo({ y: firstError, offsetY: 50 })
+      if (!$fieldErrors.length) return
+
+      const firstError = $fieldErrors[0]
+      app.scrollTo({ y: firstError, offsetY: 50 })
+
+      // Scrolling alone leaves a keyboard or screen-reader user wherever they
+      // were — usually the submit button — with no indication of which field
+      // is wrong. Put the caret in the offending control instead; its
+      // `aria-describedby` points back at this message, so it is read out on
+      // arrival. The wait lets the scroll settle first, otherwise focus()
+      // fights it with its own jump.
+      const wrapper = firstError.closest('.field-wrapper')
+      const control = wrapper && wrapper.querySelector('[aria-invalid="true"]')
+      if (control) {
+        setTimeout(() => control.focus({ preventScroll: true }), 300)
       }
     })
 

--- a/assets/src/hooks/Modal/index.js
+++ b/assets/src/hooks/Modal/index.js
@@ -1,0 +1,135 @@
+/**
+ * Modal hook — keyboard and screen-reader behaviour for `Content.modal/1`.
+ *
+ * A modal in the admin is a pre-rendered element that is shown and hidden,
+ * either by `JS.show`/`JS.hide` (inline display) or by the server toggling the
+ * `visible` class. Neither moves keyboard focus, so before this hook a modal
+ * opened with focus still sitting behind it: Tab walked the page underneath,
+ * and a screen reader never announced that a dialog had opened.
+ *
+ * The hook watches for the open/closed transition rather than a LiveView event,
+ * because there is no single event to watch — the same modal can be opened by a
+ * `JS.show` command on the client or by an assign on the server.
+ *
+ * It deliberately does not handle Escape: `Content.modal/1` already binds
+ * `phx-window-keydown` for that, and its close command is the one that knows
+ * whether to hide on the client or tell the server.
+ */
+
+// `BrandoAdmin.JSCommands.show_modal/2` fades the dialog in over 200ms; nothing
+// inside it has a layout box until that finishes.
+const MODAL_TRANSITION_MS = 250
+
+const FOCUSABLE = [
+  'a[href]',
+  'button:not([disabled])',
+  'input:not([disabled]):not([type="hidden"])',
+  'select:not([disabled])',
+  'textarea:not([disabled])',
+  '[tabindex]:not([tabindex="-1"])'
+].join(',')
+
+export default app => ({
+  mounted() {
+    this.opener = null
+    this.wasOpen = this.isOpen()
+
+    // Tab is handled on the modal itself: the wrap only applies while focus is
+    // already inside, and letting it bubble to the document would fight with
+    // other keydown handlers on the page.
+    this.onKeydown = event => {
+      if (event.key !== 'Tab' || !this.isOpen()) return
+      this.wrapTab(event)
+    }
+    this.el.addEventListener('keydown', this.onKeydown)
+
+    // `style` covers JS.show/JS.hide (inline display); `class` covers the
+    // server-gated `visible` variant. Watching both means the hook does not
+    // need to know which mechanism a given modal uses.
+    this.observer = new MutationObserver(() => this.syncOpenState())
+    this.observer.observe(this.el, { attributes: true, attributeFilter: ['style', 'class'] })
+
+    if (this.wasOpen) this.onOpened()
+  },
+
+  updated() {
+    this.syncOpenState()
+  },
+
+  destroyed() {
+    this.el.removeEventListener('keydown', this.onKeydown)
+    this.observer?.disconnect()
+    clearTimeout(this.focusTimer)
+    // A modal removed from the DOM while open would otherwise strand focus on
+    // nothing, dropping the caret back to <body>.
+    if (this.wasOpen) this.restoreFocus()
+  },
+
+  isOpen() {
+    if (this.el.classList.contains('visible')) return true
+    // `JS.hide` leaves `display: none` inline; `JS.show` sets it to flex.
+    return this.el.style.display !== '' && this.el.style.display !== 'none'
+  },
+
+  syncOpenState() {
+    const open = this.isOpen()
+    if (open === this.wasOpen) return
+    this.wasOpen = open
+    open ? this.onOpened() : this.restoreFocus()
+  },
+
+  onOpened() {
+    // Remember who opened it *before* moving focus, so closing returns the user
+    // to the control they were on rather than to the top of the page.
+    const active = document.activeElement
+    this.opener = active && !this.el.contains(active) ? active : this.opener
+
+    // `show_modal/1` reveals the dialog with a 200ms transition, and this runs
+    // the instant `display` changes — before its contents have a layout box, so
+    // `focusable()` sees nothing. Land on the dialog immediately (which is what
+    // names it to a screen reader), then move to the first control once the
+    // transition has actually put one on screen.
+    this.el.setAttribute('tabindex', '-1')
+    this.el.focus()
+
+    clearTimeout(this.focusTimer)
+    this.focusTimer = setTimeout(() => {
+      if (!this.isOpen()) return
+      // Only take focus if it is still on the dialog itself — if the user has
+      // already tabbed or clicked somewhere inside, leave them there.
+      if (document.activeElement !== this.el) return
+      this.focusable()[0]?.focus()
+    }, MODAL_TRANSITION_MS)
+  },
+
+  restoreFocus() {
+    const opener = this.opener
+    this.opener = null
+    // Only take focus back if it is still inside the modal; if something else
+    // has deliberately moved it since, leave it alone.
+    if (!this.el.contains(document.activeElement)) return
+    if (opener && document.contains(opener)) opener.focus()
+  },
+
+  focusable() {
+    return Array.from(this.el.querySelectorAll(FOCUSABLE)).filter(
+      el => el.offsetParent !== null || el === document.activeElement
+    )
+  },
+
+  wrapTab(event) {
+    const items = this.focusable()
+    if (items.length === 0) return
+
+    const first = items[0]
+    const last = items[items.length - 1]
+
+    if (event.shiftKey && document.activeElement === first) {
+      event.preventDefault()
+      last.focus()
+    } else if (!event.shiftKey && document.activeElement === last) {
+      event.preventDefault()
+      first.focus()
+    }
+  }
+})

--- a/e2e/e2e/playwright/tests/accessibility/form-a11y.spec.js
+++ b/e2e/e2e/playwright/tests/accessibility/form-a11y.spec.js
@@ -1,0 +1,93 @@
+import { test, expect } from '../../test-support/setupAuth'
+import { syncLV } from '../../utils'
+
+// Issue #1996. The admin is essentially one large form application, and before
+// this it shipped a single ARIA attribute in the whole form layer: a submitted
+// form announced nothing, a keyboard user was scrolled to an error they could
+// not reach, and a modal opened with focus still behind it.
+
+test.describe('Accessible form validation', () => {
+  test('a failed save marks the field invalid, announces why, and moves focus to it', async ({
+    page
+  }) => {
+    await page.goto('/admin/pages/create')
+    await syncLV(page)
+
+    // Required attributes are not validated while an entry is a draft, and a new
+    // page starts as one — so publish it first, or the blank save succeeds.
+    await page.locator('label').filter({ hasText: 'Published' }).click()
+
+    const title = page.getByLabel('Title', { exact: true })
+
+    // Nothing has been typed, so nothing is invalid yet — a blank create form
+    // must not read as a form full of errors.
+    await expect(title).not.toHaveAttribute('aria-invalid', 'true')
+    // ...but it is announced as required.
+    await expect(title).toHaveAttribute('aria-required', 'true')
+
+    // The message container exists before it has anything to say: a live region
+    // added together with its content is not reliably announced.
+    const errors = page.locator('#page_title-error')
+    await expect(errors).toHaveAttribute('role', 'alert')
+    await expect(title).toHaveAttribute('aria-describedby', 'page_title-error')
+
+    await page.getByTestId('submit').click()
+    await syncLV(page)
+
+    await expect(title).toHaveAttribute('aria-invalid', 'true')
+    await expect(errors).not.toBeEmpty()
+
+    // The caret lands in the offending control, not on the submit button —
+    // and `aria-describedby` means arriving there reads the message out.
+    await expect(title).toBeFocused()
+  })
+
+  test('correcting the field clears the announcement', async ({ page }) => {
+    await page.goto('/admin/pages/create')
+    await syncLV(page)
+    await page.locator('label').filter({ hasText: 'Published' }).click()
+
+    const title = page.getByLabel('Title', { exact: true })
+    await page.getByTestId('submit').click()
+    await syncLV(page)
+    await expect(title).toHaveAttribute('aria-invalid', 'true')
+
+    await title.fill('An acceptable title')
+    await syncLV(page)
+
+    await expect(title).not.toHaveAttribute('aria-invalid', 'true')
+    await expect(page.locator('#page_title-error')).toBeEmpty()
+  })
+})
+
+test.describe('Modal focus management', () => {
+  test('a modal announces itself as a dialog, takes focus, and gives it back', async ({ page }) => {
+    await page.goto('/admin/config/content/modules')
+    await syncLV(page)
+
+    const opener = page.getByRole('button', { name: 'Import modules' })
+    await opener.focus()
+    await opener.click()
+
+    const modal = page.locator('#module-import-modal')
+    await expect(modal).toBeVisible()
+    await expect(modal).toHaveAttribute('role', 'dialog')
+    await expect(modal).toHaveAttribute('aria-modal', 'true')
+    // The dialog is named by its own heading rather than by nothing at all.
+    await expect(modal).toHaveAttribute('aria-labelledby', 'module-import-modal-title')
+    await expect(page.locator('#module-import-modal-title')).toHaveText('Import modules')
+
+    // Focus moved into the dialog, so Tab walks it rather than the page behind.
+    await expect
+      .poll(() =>
+        modal.evaluate(el => el === document.activeElement || el.contains(document.activeElement))
+      )
+      .toBe(true)
+
+    await page.keyboard.press('Escape')
+    await expect(modal).not.toBeVisible()
+
+    // ...and closing hands focus back to whatever opened it.
+    await expect(opener).toBeFocused()
+  })
+})

--- a/lib/brando_admin/components/content.ex
+++ b/lib/brando_admin/components/content.ex
@@ -125,6 +125,10 @@ defmodule BrandoAdmin.Components.Content do
         @auto && "auto",
         @show && "visible"
       ]}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby={"#{@id}-title"}
+      phx-hook="Brando.Modal"
       phx-window-keydown={@close}
       phx-key="escape"
       {@rest}
@@ -136,7 +140,7 @@ defmodule BrandoAdmin.Components.Content do
             "modal-header",
             @center_header && "centered"
           ]}>
-            <h2>{@title}</h2>
+            <h2 id={"#{@id}-title"}>{@title}</h2>
             <div class="header-wrap">
               <%= if @header != [] do %>
                 {render_slot(@header)}

--- a/lib/brando_admin/components/form/input.ex
+++ b/lib/brando_admin/components/form/input.ex
@@ -521,6 +521,7 @@ defmodule BrandoAdmin.Components.Form.Input do
       |> assign_new(:checked_value, fn -> "true" end)
       |> assign_new(:unchecked_value, fn -> "false" end)
       |> process_input_id()
+      |> assign_a11y()
 
     assigns =
       assign(
@@ -532,11 +533,30 @@ defmodule BrandoAdmin.Components.Form.Input do
     if assigns.hidden_input do
       ~H"""
       <input type={:hidden} name={@field.name} id={"#{@id}-unchecked"} value={@unchecked_value} {@rest} />
-      <input type={@type} name={@field.name} id={"#{@id}"} value={@checked_value} checked={@checked} {@rest} />
+      <input
+        type={@type}
+        name={@field.name}
+        id={"#{@id}"}
+        value={@checked_value}
+        checked={@checked}
+        aria-invalid={@aria_invalid}
+        aria-describedby={@aria_describedby}
+        aria-required={@aria_required}
+        {@rest}
+      />
       """
     else
       ~H"""
-      <input type={@type} name={@field.name} id={"#{@id}"} value={@checked_value} {@rest} />
+      <input
+        type={@type}
+        name={@field.name}
+        id={"#{@id}"}
+        value={@checked_value}
+        aria-invalid={@aria_invalid}
+        aria-describedby={@aria_describedby}
+        aria-required={@aria_required}
+        {@rest}
+      />
       """
     end
   end
@@ -558,9 +578,18 @@ defmodule BrandoAdmin.Components.Form.Input do
       |> assign(:id, assigns.id || assigns.field.id)
       |> assign(:name, assigns.name || assigns.field.name)
       |> process_input_id()
+      |> assign_a11y()
 
     ~H"""
-    <textarea type={@type} name={@name} id={@id} {@rest}><%= @value %></textarea>
+    <textarea
+      type={@type}
+      name={@name}
+      id={@id}
+      aria-invalid={@aria_invalid}
+      aria-describedby={@aria_describedby}
+      aria-required={@aria_required}
+      {@rest}
+    ><%= @value %></textarea>
     """
   end
 
@@ -578,11 +607,63 @@ defmodule BrandoAdmin.Components.Form.Input do
       |> assign(:name, assigns.name || assigns.field.name)
       |> assign(:hook, (assigns.publish && "Brando.PublishInput") || nil)
       |> process_input_id()
+      |> assign_a11y()
 
     ~H"""
-    <input type={@type} name={@name} id={@id} value={@value} phx-hook={@hook} {@rest} />
+    <input
+      type={@type}
+      name={@name}
+      id={@id}
+      value={@value}
+      phx-hook={@hook}
+      aria-invalid={@aria_invalid}
+      aria-describedby={@aria_describedby}
+      aria-required={@aria_required}
+      {@rest}
+    />
     """
   end
+
+  # Every control the admin renders passes through `input/1`, so the accessible
+  # state of a field is decided here rather than in the ~20 wrapper components.
+  #
+  # `Primitives.field_base/1` renders the message container as
+  # `"<field id>-error"`, and both derive that id from the field the same way
+  # (`process_input_id/1` mirrors `Primitives.field_id/1`), so the reference is
+  # always to an element that exists. It points there unconditionally: the
+  # container is rendered whether or not it currently holds a message, and an
+  # empty one contributes nothing to the accessible description.
+  #
+  # A hidden input has no accessible presence to annotate, so it is skipped —
+  # marking it invalid would announce a field the user cannot see or reach.
+  defp assign_a11y(%{type: :hidden} = assigns) do
+    assigns
+    |> assign(:aria_invalid, nil)
+    |> assign(:aria_describedby, nil)
+    |> assign(:aria_required, nil)
+  end
+
+  defp assign_a11y(assigns) do
+    field = assigns.field
+
+    assigns
+    |> assign(:aria_invalid, (field_invalid?(field) && "true") || nil)
+    |> assign(:aria_describedby, "#{assigns.id}-error")
+    |> assign(:aria_required, (field_required?(field) && "true") || nil)
+  end
+
+  # Gated on `used_input?/1` exactly as `Primitives.error_tag/1` is. Reading
+  # `field.errors` alone marks every required field invalid the moment a blank
+  # create form renders — a screen reader would read a form full of errors
+  # before the user has typed anything, and there is no message to go with it.
+  defp field_invalid?(%FormField{} = field), do: Phoenix.Component.used_input?(field) and field.errors != []
+  defp field_invalid?(_), do: false
+
+  defp field_required?(%FormField{form: %{source: %Ecto.Changeset{data: %schema{}}}, field: name}) do
+    function_exported?(schema, :__required_attrs__, 0) and name in schema.__required_attrs__()
+  end
+
+  defp field_required?(_), do: false
 
   defp process_input_id(%{uid: nil, id_prefix: _id_prefix} = assigns), do: assign(assigns, :id, assigns.field.id)
 

--- a/lib/brando_admin/components/form/primitives.ex
+++ b/lib/brando_admin/components/form/primitives.ex
@@ -624,9 +624,17 @@ defmodule BrandoAdmin.Components.Form.Primitives do
     assigns = assign(assigns, :f_id, field_id(assigns))
 
     ~H"""
-    <span :for={error <- @errors} id={"#{@f_id}-error"} class="field-error">
-      {@translate_fn.(error)}
-    </span>
+    <%!-- One container, rendered whether or not there are errors, because a live
+          region has to already be in the accessibility tree when content is
+          inserted into it — a `role="alert"` element that appears *with* its
+          message is not reliably announced. It also carries the single id that
+          `Input.input/1` points `aria-describedby` at; the messages used to be
+          sibling spans that each claimed the same id. --%>
+    <div id={"#{@f_id}-error"} class="field-errors" role="alert">
+      <span :for={error <- @errors} class="field-error">
+        {@translate_fn.(error)}
+      </span>
+    </div>
     """
   end
 

--- a/test/brando_admin/components/form/error_display_test.exs
+++ b/test/brando_admin/components/form/error_display_test.exs
@@ -65,7 +65,18 @@ defmodule BrandoAdmin.Components.Form.ErrorDisplayTest do
     test "stays silent while the field is untouched" do
       html = error_tag(untouched_form([{:meta_image_id, "can't be blank"}]))
 
-      refute html =~ "field-error"
+      # The `role="alert"` container is always rendered — a live region has to be
+      # in the accessibility tree before content lands in it — so what proves
+      # silence is that it holds no message, not that it is absent.
+      refute html =~ ~s(class="field-error")
+      refute html =~ "can&#39;t be blank"
+    end
+
+    test "keeps the announcement region in the DOM even with nothing to say" do
+      html = error_tag(untouched_form([]))
+
+      assert html =~ ~s(role="alert")
+      assert html =~ ~s(id="page_meta_image_id-error")
     end
 
     test "interpolates a group constraint's fields as their form labels" do

--- a/test/brando_admin/components/form/input_accessibility_test.exs
+++ b/test/brando_admin/components/form/input_accessibility_test.exs
@@ -1,0 +1,131 @@
+defmodule BrandoAdmin.Components.Form.InputAccessibilityTest do
+  @moduledoc """
+  Every control the admin renders goes through `Input.input/1`, so the accessible
+  state of a field is decided in one place. These pin what it emits — issue #1996.
+  """
+  use ExUnit.Case, async: false
+
+  import Ecto.Changeset, only: [cast: 3, add_error: 3]
+  import Phoenix.Component, only: [to_form: 2]
+  import Phoenix.LiveViewTest, only: [render_component: 2]
+
+  alias BrandoAdmin.Components.Form.Input
+  alias BrandoAdmin.Components.Form.Primitives
+
+  defp form(params, errors) do
+    %Brando.Pages.Page{}
+    |> cast(params, [:title, :meta_description])
+    |> then(fn changeset ->
+      Enum.reduce(errors, changeset, fn {field, message}, acc -> add_error(acc, field, message) end)
+    end)
+    # Ecto's FormData only exposes errors once the changeset has an action.
+    |> Map.put(:action, :validate)
+    |> to_form(as: :page)
+  end
+
+  defp render_input(form, field, opts \\ []) do
+    render_component(
+      &Input.input/1,
+      Enum.into(opts, %{
+        field: form[field],
+        id: nil,
+        name: nil,
+        type: Keyword.get(opts, :type, :text),
+        hidden_input: true
+      })
+    )
+  end
+
+  describe "aria-describedby" do
+    test "points at the field's message container" do
+      html = render_input(form(%{}, []), :title)
+
+      assert html =~ ~s(aria-describedby="page_title-error")
+    end
+
+    test "matches the id `field_base/1` gives that container" do
+      form = form(%{"title" => ""}, title: "can't be blank")
+
+      input = render_input(form, :title)
+
+      wrapper =
+        render_component(&Primitives.field_base/1, %{
+          field: form[:title],
+          label: "Title",
+          inner_block: []
+        })
+
+      assert input =~ ~s(aria-describedby="page_title-error")
+      assert wrapper =~ ~s(id="page_title-error")
+    end
+  end
+
+  describe "aria-invalid" do
+    test "is absent on an untouched field, even when the changeset carries an error" do
+      # A blank create form has errors on every required field before the user
+      # has typed anything. Announcing those would read the whole form as
+      # broken on arrival, with no messages to explain it.
+      html = render_input(form(%{}, title: "can't be blank"), :title)
+
+      refute html =~ "aria-invalid"
+    end
+
+    test "is set once the field has been submitted with an error" do
+      html = render_input(form(%{"title" => ""}, title: "can't be blank"), :title)
+
+      assert html =~ ~s(aria-invalid="true")
+    end
+
+    test "is absent on a submitted field with no error" do
+      html = render_input(form(%{"title" => "Fine"}, []), :title)
+
+      refute html =~ "aria-invalid"
+    end
+  end
+
+  describe "aria-required" do
+    test "is set for an attribute the blueprint declares required" do
+      assert :title in Brando.Pages.Page.__required_attrs__()
+
+      assert render_input(form(%{}, []), :title) =~ ~s(aria-required="true")
+    end
+
+    test "is absent for an optional attribute" do
+      refute :meta_description in Brando.Pages.Page.__required_attrs__()
+
+      refute render_input(form(%{}, []), :meta_description) =~ "aria-required"
+    end
+  end
+
+  describe "hidden inputs" do
+    test "carry no accessible annotation at all" do
+      # There is nothing for a user to see or reach, so marking one invalid
+      # would announce a field that does not exist for them.
+      html = render_input(form(%{"title" => ""}, title: "can't be blank"), :title, type: :hidden)
+
+      refute html =~ "aria-invalid"
+      refute html =~ "aria-describedby"
+      refute html =~ "aria-required"
+    end
+  end
+
+  describe "textarea and checkbox" do
+    test "a textarea is annotated like any other control" do
+      html = render_input(form(%{"title" => ""}, title: "can't be blank"), :title, type: :textarea)
+
+      assert html =~ "<textarea"
+      assert html =~ ~s(aria-invalid="true")
+      assert html =~ ~s(aria-describedby="page_title-error")
+    end
+
+    test "a checkbox is annotated on the visible control, not the hidden partner" do
+      html = render_input(form(%{"title" => ""}, title: "can't be blank"), :title, type: :checkbox)
+
+      # The paired hidden input that carries the unchecked value must stay bare.
+      [hidden, visible] = String.split(html, "<input", trim: true)
+
+      refute hidden =~ "aria-invalid"
+      assert visible =~ ~s(aria-invalid="true")
+    end
+  end
+end


### PR DESCRIPTION
Closes #1996 — a `blocker` since 2023 on a one-line body and a link to a Smashing Magazine article. This is the concrete checklist behind it.

## The audit

The admin is essentially one large form application. It shipped **exactly one ARIA attribute in its entire form layer** (`role="alert"` on the revisions drawer). No error association, no live regions, no required exposure, no dialog semantics, no focus management.

## What changed

- **`Input.input/1`** is the single place every control in the admin is rendered, so `aria-invalid`, `aria-describedby` and `aria-required` are decided there rather than in the ~20 wrapper components. Required comes from the blueprint's `__required_attrs__/0`. Invalid uses the same `used_input?` gate as `error_tag/1` — which is what keeps a blank create form from reading as a form full of errors before anything has been typed. Hidden inputs get nothing, since there is no accessible presence to annotate.

- **`Primitives.error_tag/1`** renders one `role="alert"` container instead of a span per message, present whether or not it currently has anything to say — a live region added *together with* its content is not reliably announced. It also gives `aria-describedby` a single id to point at. The messages used to be sibling spans that each claimed the same id, with CSS positioning every one of them at `right: 0` — so two errors on a field were drawn on top of each other.

- **Modals** are `role="dialog" aria-modal="true"`, named by their own heading. The new `Brando.Modal` hook takes focus on open, wraps Tab inside, and returns focus to whatever opened them. It watches for the open transition rather than a LiveView event, because a modal can be opened either by a `JS.show` command on the client or by an assign on the server — there is no single event to hook.

- **A failed save focuses** the first invalid control instead of only scrolling to it. Arriving there reads the message out, through the `aria-describedby` above.

## Breaking (styling only)

Error messages are now wrapped in a `.field-errors` container and positioning moved to it. A selector like `.label-wrapper > span.field-error` no longer matches.

## Testing

- 10 new unit tests pinning what `Input.input/1` emits in each case, plus a new assertion that the announcement region stays in the DOM with nothing to say.
- 3 new E2E tests in `tests/accessibility/form-a11y.spec.js`: a rejected save marks/announces/focuses, correcting clears it, and a modal announces itself, takes focus and gives it back.
- Full unit suite 1800, full E2E suite 136, both green.

## Not in scope

Associating a field's `help-text` instructions with its control. Unlike the rest, that cannot be done from the one central function — it needs threading through each wrapper — so it is left as a follow-up rather than half-applied.
