### PR TITLE
fix: reinstate the zero-cycle gate after #2642 and #2737 merged

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -270,6 +270,11 @@
   during macro expansion — that crosses into a module the callee's own
   dependencies reach back to.
 
+  A `trait` declaration is one of those compile-time references, so a trait that
+  calls back into a module holding the schema's struct closes the same loop:
+  `Brando.Content.ModuleDiff` therefore types its arguments as `map()` and
+  matches on shape rather than on `%Module{}`.
+
 #### Features
 
 - **Module migration tracking, and a warning before a module save destroys

--- a/lib/brando/content/module_diff.ex
+++ b/lib/brando/content/module_diff.ex
@@ -28,7 +28,6 @@ defmodule Brando.Content.ModuleDiff do
   The classes are ordered: `classify/1` returns the most severe one that applies.
   """
 
-  alias Brando.Content.Module
   alias Brando.Villain.Blocks
   alias Ecto.Changeset
 
@@ -71,14 +70,22 @@ defmodule Brando.Content.ModuleDiff do
   @doc """
   Diffs a persisted module against its pending revision.
 
-  The second argument may be a `%Module{}` or a changeset on one — a changeset is
-  applied first, so this works straight off an unsaved admin form.
+  Both arguments are `Brando.Content.Module` structs; the second may instead be a
+  changeset on one, which is applied first, so this works straight off an unsaved
+  admin form.
+
+  Deliberately typed as `map()` rather than `Module.t()`, and matching on shape
+  rather than on `%Module{}`. `Brando.Content.Module` declares
+  `trait Brando.Trait.ModuleVersioned`, which is a compile-time reference, and
+  that trait calls this module — so a struct pattern or typespec here is an
+  export dependency straight back to the schema, closing a compile-connected
+  cycle across the whole content layer. See issue #2737.
   """
-  @spec diff(Module.t(), Module.t() | Changeset.t()) :: t()
-  def diff(%Module{} = old, %Changeset{} = changeset),
+  @spec diff(map(), map() | Changeset.t()) :: t()
+  def diff(old, %Changeset{} = changeset) when is_map(old),
     do: diff(old, Changeset.apply_changes(changeset))
 
-  def diff(%Module{} = old, %Module{} = new) do
+  def diff(old, new) when is_map(old) and is_map(new) do
     old_refs = ref_map(old)
     new_refs = ref_map(new)
     old_vars = var_map(old)


### PR DESCRIPTION
`next` currently fails its own `--fail-above 0` cycle gate. Merging #2751 and #2750 put the compile-connected cycle back — one edge, and **neither branch showed it alone**:

```
Content.Module --compile--> Trait.ModuleVersioned
               --runtime--> ModuleDiff
                --export--> Content.Module
```

#2751 (#2737) took the count to zero on its own base. #2750 (#2642) added the `ModuleVersioned` trait on a base where the cycle already existed with two other edges, so this one was invisible there. The combination is the first time it mattered — which is exactly what a sequential merge surfaces and what two independently-green PRs cannot.

## The fix

A `trait` declaration is a compile-time reference to the trait module. That trait calls `Brando.Content.ModuleDiff`, which pattern-matched `%Module{}` and spec'd `Module.t()` — both **export** dependencies straight back to the schema, closing the loop.

`ModuleDiff` now takes `map()` and matches on shape. It only ever reads fields off the struct, so behaviour is unchanged; the docstring records why the looser type is deliberate, so it does not get "tightened" back later.

## Verification

```
mix xref graph --format cycles --label compile-connected --fail-above 0
No cycles found
```

Full unit suite 1847, formatting clean.
