### PR TITLE
Fix container rendering and E2E Save selectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -487,6 +487,9 @@
 
 #### Fixes
 
+- Container blocks render without reading a module-only `multi` flag, restoring
+  insertion, nested content and copy/paste after the footnote changes.
+
 - **Modal dialogs sized their prose like page content, and stacked their footer
   buttons edge to edge.** `.modal-body` inherited `body`'s `@fontsize base` —
   20px on desktop, 23px at xl — so loose text in a dialog came out oversized

--- a/e2e/e2e/playwright/tests/blocks/block-config-vars-persistence.spec.js
+++ b/e2e/e2e/playwright/tests/blocks/block-config-vars-persistence.spec.js
@@ -44,7 +44,7 @@ test.describe('Block config var persistence', () => {
   }
 
   const reopenEntry = async (page) => {
-    await page.getByRole('button', { name: 'Save' }).click()
+    await page.getByRole('button', { name: 'Save', exact: true }).click()
     await expect(page).toHaveURL(/\/admin\/pages$/, { timeout: 30000 })
     await syncLV(page)
     await expect(page.locator('.alert.error')).not.toBeVisible({ timeout: 5000 })

--- a/e2e/e2e/playwright/tests/blocks/block-delete-undo.spec.js
+++ b/e2e/e2e/playwright/tests/blocks/block-delete-undo.spec.js
@@ -23,7 +23,7 @@ test.describe('Block delete undo', () => {
   }
 
   const saveAndReopen = async (page, title) => {
-    await page.getByRole('button', { name: 'Save' }).click()
+    await page.getByRole('button', { name: 'Save', exact: true }).click()
     await expect(page).toHaveURL(/\/admin\/pages$/, { timeout: 30000 })
     await syncLV(page)
     await expect(page.locator('.alert.error')).not.toBeVisible({ timeout: 5000 })

--- a/e2e/e2e/playwright/tests/blocks/block-gallery-image-replace.spec.js
+++ b/e2e/e2e/playwright/tests/blocks/block-gallery-image-replace.spec.js
@@ -59,7 +59,7 @@ test.describe('Gallery block image replacement', () => {
     })
 
     // Save the page — this is the operation that previously failed
-    await page.getByRole('button', { name: 'Save' }).click()
+    await page.getByRole('button', { name: 'Save', exact: true }).click()
 
     // Wait for save + image processing to complete and redirect away from create page
     await expect(page).not.toHaveURL(/\/create$/, { timeout: 30000 })

--- a/e2e/e2e/playwright/tests/blocks/block-media-save-persistence.spec.js
+++ b/e2e/e2e/playwright/tests/blocks/block-media-save-persistence.spec.js
@@ -41,7 +41,7 @@ test.describe('Block media save persistence', () => {
   }
 
   const saveAndReopen = async (page, title) => {
-    await page.getByRole('button', { name: 'Save' }).click()
+    await page.getByRole('button', { name: 'Save', exact: true }).click()
     await expect(page).not.toHaveURL(/\/create$/, { timeout: 30000 })
     await syncLV(page)
     await expect(page.locator('.alert.error')).not.toBeVisible({ timeout: 5000 })
@@ -78,7 +78,7 @@ test.describe('Block media save persistence', () => {
     await page.locator('.header-block textarea').first().fill('Edited after reload')
     await syncLV(page)
 
-    await page.getByRole('button', { name: 'Save' }).click()
+    await page.getByRole('button', { name: 'Save', exact: true }).click()
     await expect(page).toHaveURL(/\/admin\/pages$/, { timeout: 30000 })
     await syncLV(page)
     await expect(page.locator('.alert.error')).not.toBeVisible({ timeout: 5000 })

--- a/e2e/e2e/playwright/tests/blocks/block-multi-live-preview.spec.js
+++ b/e2e/e2e/playwright/tests/blocks/block-multi-live-preview.spec.js
@@ -125,7 +125,7 @@ test.describe('Live Preview with multi modules', () => {
     await addChild(page, page.locator('[data-module-multi="true"]').first(), 'Team Member')
     await syncLV(page)
 
-    await page.getByRole('button', { name: 'Save' }).click()
+    await page.getByRole('button', { name: 'Save', exact: true }).click()
     await expect(page).toHaveURL(/\/admin\/pages$/, { timeout: 30000 })
     await syncLV(page)
     await page.getByRole('link', { name: 'Multi Preview Saved →' }).click()

--- a/e2e/e2e/playwright/tests/blocks/block-nested-child-persistence.spec.js
+++ b/e2e/e2e/playwright/tests/blocks/block-nested-child-persistence.spec.js
@@ -50,7 +50,7 @@ test.describe('Nested child block persistence', () => {
   }
 
   const saveAndReopen = async (page, title) => {
-    await page.getByRole('button', { name: 'Save' }).click()
+    await page.getByRole('button', { name: 'Save', exact: true }).click()
     await expect(page).toHaveURL(/\/admin\/pages$/, { timeout: 30000 })
     await syncLV(page)
     await expect(page.locator('.alert.error')).not.toBeVisible({ timeout: 5000 })

--- a/e2e/e2e/playwright/tests/blocks/block-ref-config-persistence.spec.js
+++ b/e2e/e2e/playwright/tests/blocks/block-ref-config-persistence.spec.js
@@ -78,7 +78,7 @@ test.describe('Block ref config persistence', () => {
     await page.waitForTimeout(400)
     await syncLV(page)
 
-    await page.getByRole('button', { name: 'Save' }).click()
+    await page.getByRole('button', { name: 'Save', exact: true }).click()
     await expect(page).toHaveURL(/\/admin\/pages$/, { timeout: 30000 })
     await syncLV(page)
     await expect(page.locator('.alert.error')).not.toBeVisible({ timeout: 5000 })

--- a/e2e/e2e/playwright/tests/blocks/block-reorder.spec.js
+++ b/e2e/e2e/playwright/tests/blocks/block-reorder.spec.js
@@ -104,7 +104,7 @@ test.describe('Block reordering (root blocks)', () => {
     await expect(previewHeaders.nth(2)).toContainText('Beta')
 
     // Save, reopen, verify the order actually persisted.
-    await page.getByRole('button', { name: 'Save' }).click()
+    await page.getByRole('button', { name: 'Save', exact: true }).click()
     await expect(page).toHaveURL(/\/admin\/pages$/, { timeout: 30000 })
     await syncLV(page)
     await expect(page.locator('.alert.error')).not.toBeVisible({ timeout: 5000 })
@@ -129,7 +129,7 @@ test.describe('Block reordering (root blocks)', () => {
     await dragBlock(page, sortHandle(page, 0), page.locator('.entry-block').nth(2), 'bottom')
     await expectHeaderOrder(page, ['Alpha', 'Beta', 'Gamma'])
 
-    await page.getByRole('button', { name: 'Save' }).click()
+    await page.getByRole('button', { name: 'Save', exact: true }).click()
     await expect(page).toHaveURL(/\/admin\/pages$/, { timeout: 30000 })
     await syncLV(page)
     await expect(page.locator('.alert.error')).not.toBeVisible({ timeout: 5000 })
@@ -184,7 +184,7 @@ test.describe('Block reordering (root blocks)', () => {
     )
     await expectMemberOrder(['Charlie', 'Alice', 'Bob'])
 
-    await page.getByRole('button', { name: 'Save' }).click()
+    await page.getByRole('button', { name: 'Save', exact: true }).click()
     await expect(page).toHaveURL(/\/admin\/pages$/, { timeout: 30000 })
     await syncLV(page)
 

--- a/e2e/e2e/playwright/tests/blocks/block-var-uploads.spec.js
+++ b/e2e/e2e/playwright/tests/blocks/block-var-uploads.spec.js
@@ -52,7 +52,7 @@ test.describe('Render var uploads', () => {
     await expect(page.getByRole('button', { name: 'Edit image' })).toBeVisible({ timeout: 5000 })
 
     // Save the page
-    await page.getByRole('button', { name: 'Save' }).click()
+    await page.getByRole('button', { name: 'Save', exact: true }).click()
     await syncLV(page)
 
     // Verify save succeeded
@@ -113,7 +113,7 @@ test.describe('Render var uploads', () => {
     await expect(page.getByRole('button', { name: 'Edit file' })).toBeVisible({ timeout: 5000 })
 
     // Save the page
-    await page.getByRole('button', { name: 'Save' }).click()
+    await page.getByRole('button', { name: 'Save', exact: true }).click()
     await syncLV(page)
 
     // Verify save succeeded

--- a/e2e/e2e/playwright/tests/blocks/block-video-map-persistence.spec.js
+++ b/e2e/e2e/playwright/tests/blocks/block-video-map-persistence.spec.js
@@ -48,7 +48,7 @@ test.describe('Video and map block save persistence', () => {
   }
 
   const saveAndReopen = async (page, title) => {
-    await page.getByRole('button', { name: 'Save' }).click()
+    await page.getByRole('button', { name: 'Save', exact: true }).click()
     await expect(page).not.toHaveURL(/\/create$/, { timeout: 30000 })
     await syncLV(page)
     await expect(page.locator('.alert.error')).not.toBeVisible({ timeout: 5000 })

--- a/e2e/e2e/playwright/tests/pages/page-vars-upload.spec.js
+++ b/e2e/e2e/playwright/tests/pages/page-vars-upload.spec.js
@@ -50,7 +50,7 @@ test.describe('Entry-level page var uploads', () => {
   }
 
   const saveAndReopen = async (page, title) => {
-    await page.getByRole('button', { name: 'Save' }).click()
+    await page.getByRole('button', { name: 'Save', exact: true }).click()
     await syncLV(page)
     await expect(page.locator('.alert.error')).not.toBeVisible({ timeout: 5000 })
     await expect(page).not.toHaveURL(/\/create$/, { timeout: 10000 })

--- a/lib/brando_admin/components/form/block/render.ex
+++ b/lib/brando_admin/components/form/block/render.ex
@@ -687,7 +687,7 @@ defmodule BrandoAdmin.Components.Form.Block.Render do
             </section>
           <% end %>
         </.form>
-        <%= if @multi && @has_children? do %>
+        <%= if @has_children? do %>
           {render_slot(@inner_block)}
           <.plus
             click={@insert_child_block}


### PR DESCRIPTION
Container insertion crashed the editor because `container/1` read the module-only `multi` assign. Render container children from `has_children?`, restoring empty containers, child insertion and nested copy/paste and preview.

Update the affected E2E Save locators to match the toolbar's accessible name exactly. Partial matching now also finds “Save options” and “Save (⌘S)”, so those tests stopped before exercising persistence.

Validation: all 15 scenarios that failed in PR #2760 pass without retries. The video test and the previously skipped map test also pass with fresh seeds in a separate database. Compilation with warnings as errors, formatting and whitespace checks pass. The full CI E2E job must pass before this follow-up is merged.

Follow-up to #2760.
