### PR TITLE
Harden region-owner preview reactivation

### DIFF
--- a/e2e/e2e/playwright/tests/blocks/block-region-preview.spec.js
+++ b/e2e/e2e/playwright/tests/blocks/block-region-preview.spec.js
@@ -1,0 +1,90 @@
+import { test, expect } from '../../test-support/setupAuth'
+import { syncLV, toggleLivePreview, getPreviewFrame, waitForPreviewReady } from '../../utils'
+
+for (const syntax of ['liquid', 'heex']) {
+  for (const nested of [false, true]) {
+    test(`${syntax} regions retain unsaved content after owner reactivation${nested ? ' inside a container' : ''}`, async ({ page }) => {
+      test.setTimeout(90000)
+      const name = `Region preview ${syntax}`
+      const ref = name => ({
+        name, description: name, uid: `preview-${syntax}-${name}`,
+        data: { type: 'blocks', data: { module_set: 'Footnotes' } },
+      })
+      const response = await page.request.post('/__e2e/db/factory', {
+        data: {
+          schema: 'Brando.Content.Module', creator_id: 1, fields: ['id'],
+          attributes: {
+            name: { en: name, no: name }, namespace: { en: '09 NOTES & REGIONS', no: '09 NOTES & REGIONS' },
+            help_text: { en: 'Preview fixture' }, class: 'region-preview', type: syntax,
+            code: syntax === 'liquid'
+              ? '<article class="region-preview"><aside>{% ref refs.sidebar %}</aside><section>{% ref refs.related %}</section></article>'
+              : '<article class="region-preview"><aside><.ref block={@block} ref={:sidebar} /></aside><section><.ref block={@block} ref={:related} /></section></article>',
+            refs: [ref('sidebar'), ref('related')], vars: [], multi: false, datasource: false,
+          },
+        },
+      })
+      expect(response.ok(), await response.text()).toBeTruthy()
+      await page.goto('/admin/pages/create')
+      await syncLV(page)
+      await page.getByLabel('Title', { exact: true }).fill(name)
+      await page.getByLabel('URI', { exact: true }).fill(`regions-${syntax}-${nested}`)
+      await page.getByRole('button', { name: 'Add block', exact: true }).click()
+      if (nested) {
+        await page.getByRole('button', { name: 'Container', exact: true }).click()
+        await syncLV(page)
+        await page.locator('[data-block-type="container"] .block-plus').first().click()
+      }
+      await page.getByRole('button', { name, exact: true }).click()
+      await syncLV(page)
+
+      const drawer = page.locator('.block-slot-drawer.visible')
+      const setText = async (editor, text) => {
+        await editor.click()
+        await expect(editor).toBeFocused()
+        await editor.press('ControlOrMeta+a')
+        await editor.press('Backspace')
+        await page.keyboard.insertText(text)
+        await expect(editor).toHaveText(text)
+      }
+      const addText = async text => {
+        const count = await drawer.locator('.tiptap[contenteditable=true]').count()
+        await drawer.getByRole('button', { name: 'Add block', exact: true }).last().click()
+        await page.getByRole('button', { name: 'Note text', exact: true }).click()
+        await expect(drawer.locator('.tiptap[contenteditable=true]')).toHaveCount(count + 1)
+        await setText(drawer.locator('.tiptap[contenteditable=true]').last(), text)
+        await syncLV(page)
+      }
+      await page.getByRole('button', { name: 'sidebar Edit blocks · Footnotes', exact: true }).click()
+      await addText('First sidebar block')
+      await addText('Second sidebar block')
+      await drawer.getByRole('button', { name: 'Done', exact: true }).click()
+      await page.getByRole('button', { name: 'related Edit blocks · Footnotes', exact: true }).click()
+      await addText('Related block')
+      await drawer.getByRole('button', { name: 'Done', exact: true }).click()
+
+      await toggleLivePreview(page)
+      await waitForPreviewReady(page)
+      const frame = getPreviewFrame(page)
+      await expect(frame.locator('.region-preview aside p')).toHaveText(['First sidebar block', 'Second sidebar block'])
+      await page.getByRole('button', { name: 'sidebar Edit blocks · Footnotes', exact: true }).click()
+      await setText(drawer.locator('.tiptap[contenteditable=true]').first(), 'Unsaved sidebar edit')
+      await drawer.getByRole('button', { name: 'Done', exact: true }).click()
+      await expect(frame.locator('.region-preview aside p')).toHaveText(['Unsaved sidebar edit', 'Second sidebar block'])
+
+      // Disabling the owner hides its region buttons; keep addressing the
+      // stable block UID when toggling it back on.
+      const ownerUid = await page.getByRole('button', {
+        name: 'sidebar Edit blocks · Footnotes', exact: true,
+      }).evaluate(button => button.closest('.block').dataset.blockUid)
+      const owner = page.locator(`.block[data-block-uid="${ownerUid}"]`)
+      const toggle = owner.locator('.switch.small.inverse .slider').first()
+      await toggle.click()
+      await expect(frame.locator('.region-preview')).toHaveCount(0)
+      await toggle.click()
+      await expect(frame.locator('.region-preview aside p')).toHaveText(['Unsaved sidebar edit', 'Second sidebar block'])
+      await expect(frame.locator('.region-preview section p')).toHaveText(['Related block'])
+      await expect(frame.locator('body')).not.toContainText('[$ slot:')
+      await expect(frame.locator('body')).not.toContainText('[$ content $]')
+    })
+  }
+}

--- a/lib/brando_admin/components/form/block.ex
+++ b/lib/brando_admin/components/form/block.ex
@@ -1995,10 +1995,14 @@ defmodule BrandoAdmin.Components.Form.Block do
     block_changeset = get_block_changeset(changeset, belongs_to)
     updated_block_changeset = get_block_changeset(updated_changeset, belongs_to)
 
+    # Reading an unloaded association through get_field/2 raises for persisted
+    # blocks. Inspect the stored tree without asking Ecto to load the relation.
+    children = Map.get(updated_block_changeset.changes, :children, updated_block_changeset.data.children)
+
     owns_children? =
       Changeset.get_field(block_changeset, :type) in [:container, :slot] ||
         Changeset.get_field(block_changeset, :multi) == true ||
-        match?([_ | _], Changeset.get_field(updated_block_changeset, :children))
+        match?([_ | _], children)
 
     owns_children? &&
       Changeset.get_field(block_changeset, :active) == false &&

--- a/lib/brando_admin/components/form/block.ex
+++ b/lib/brando_admin/components/form/block.ex
@@ -1987,16 +1987,18 @@ defmodule BrandoAdmin.Components.Form.Block do
   `""`, so reactivating it leaves the preview with nothing to splice and the raw
   placeholder on screen.
 
-  Containers are not the only blocks that own children: a `multi` module renders
-  its children through the same annotated slot, so it needs the same treatment.
+  This applies at any depth, including ordinary modules with owned collections.
+  Empty containers and multi modules still emit a content placeholder, so their
+  ability to own children matters even before the first child is inserted.
   """
-  def should_force_live_preview_update?(changeset, updated_changeset, :root) do
-    block_changeset = Changeset.get_assoc(changeset, :block)
-    updated_block_changeset = Changeset.get_assoc(updated_changeset, :block)
+  def should_force_live_preview_update?(changeset, updated_changeset, belongs_to) do
+    block_changeset = get_block_changeset(changeset, belongs_to)
+    updated_block_changeset = get_block_changeset(updated_changeset, belongs_to)
 
     owns_children? =
-      Changeset.get_field(block_changeset, :type) == :container ||
-        Changeset.get_field(block_changeset, :multi) == true
+      Changeset.get_field(block_changeset, :type) in [:container, :slot] ||
+        Changeset.get_field(block_changeset, :multi) == true ||
+        match?([_ | _], Changeset.get_field(updated_block_changeset, :children))
 
     owns_children? &&
       Changeset.get_field(block_changeset, :active) == false &&

--- a/lib/brando_admin/components/form/block/events.ex
+++ b/lib/brando_admin/components/form/block/events.ex
@@ -790,11 +790,16 @@ defmodule BrandoAdmin.Components.Form.Block.Events do
       block_for_changeset
       |> Brando.Content.Block.block_changeset(params, current_user_id)
       |> Map.put(:action, :validate)
+
+    force_render? = Block.should_force_live_preview_update?(changeset, updated_changeset, socket.assigns.belongs_to)
+
+    updated_changeset =
+      updated_changeset
       |> Block.render_and_update_block_changeset(
         entry,
         has_vars?,
         has_table_rows?,
-        false,
+        force_render?,
         socket.assigns.live_preview_active?
       )
 
@@ -888,8 +893,7 @@ defmodule BrandoAdmin.Components.Form.Block.Events do
       |> block_module.changeset(params, current_user_id)
       |> Map.put(:action, :validate)
 
-    # if this is a container and it's flipped from active = false to true,
-    # then we must force an update to the live preview to get the rendered children.
+    # Reactivated owners have no child DOM left for an incremental render to preserve.
     force_render? = Block.should_force_live_preview_update?(changeset, updated_changeset, :root)
 
     updated_changeset =

--- a/test/brando_admin/components/form/block/preview_test.exs
+++ b/test/brando_admin/components/form/block/preview_test.exs
@@ -1,0 +1,63 @@
+defmodule BrandoAdmin.Components.Form.Block.PreviewTest do
+  use ExUnit.Case, async: true
+
+  alias Brando.Content.Block, as: ContentBlock
+  alias BrandoAdmin.Components.Form.Block
+  alias Ecto.Changeset
+
+  defp wrap(block, :root) do
+    %Brando.Pages.Page.Blocks{}
+    |> Changeset.change()
+    |> Changeset.put_assoc(:block, block)
+  end
+
+  defp wrap(block, _), do: Changeset.change(block)
+
+  for belongs_to <- [:root, :container, :slot] do
+    test "reactivation includes owned children (#{belongs_to})" do
+      belongs_to = unquote(belongs_to)
+      slot = %ContentBlock{uid: "region", type: :slot, children: []}
+
+      for attrs <- [
+            %{type: :container, children: []},
+            %{type: :module, multi: true, children: []},
+            %{type: :module, multi: false, children: [slot]},
+            %{type: :slot, children: []}
+          ] do
+        block = struct(ContentBlock, Map.put(attrs, :uid, "owner"))
+        inactive = wrap(%{block | active: false}, belongs_to)
+        active = wrap(%{block | active: true}, belongs_to)
+
+        assert Block.should_force_live_preview_update?(inactive, active, belongs_to)
+        refute Block.should_force_live_preview_update?(active, active, belongs_to)
+        refute Block.should_force_live_preview_update?(active, inactive, belongs_to)
+      end
+    end
+  end
+
+  test "leaf modules need no child render, including when children are not preloaded" do
+    for block <- [%ContentBlock{uid: "leaf"}, %ContentBlock{uid: "leaf", children: []}] do
+      inactive = Changeset.change(%{block | active: false})
+      active = Changeset.change(block)
+      refute Block.should_force_live_preview_update?(inactive, active, :container)
+    end
+  end
+
+  test "slot owners request a full preview from the operation store" do
+    for attrs <- [
+          %{type: :module, multi: false, has_children?: true, belongs_to: :root},
+          %{type: :module, multi: false, has_children?: true, belongs_to: :container},
+          %{type: :slot, belongs_to: :root},
+          %{type: :module, belongs_to: :slot}
+        ] do
+      socket =
+        %Phoenix.LiveView.Socket{}
+        |> Phoenix.Component.assign(Map.merge(attrs, %{live_preview_active?: true, form_id: "page"}))
+
+      Block.maybe_update_live_preview_block(socket)
+
+      assert_receive {:phoenix, :send_update,
+                      {{BrandoAdmin.Components.Form, "page"}, %{id: "page", event: "update_live_preview"}}}
+    end
+  end
+end

--- a/test/brando_admin/components/form/block/preview_test.exs
+++ b/test/brando_admin/components/form/block/preview_test.exs
@@ -36,7 +36,9 @@ defmodule BrandoAdmin.Components.Form.Block.PreviewTest do
   end
 
   test "leaf modules need no child render, including when children are not preloaded" do
-    for block <- [%ContentBlock{uid: "leaf"}, %ContentBlock{uid: "leaf", children: []}] do
+    persisted = Ecto.put_meta(%ContentBlock{id: 123, uid: "persisted-leaf"}, state: :loaded)
+
+    for block <- [%ContentBlock{uid: "leaf"}, %ContentBlock{uid: "leaf", children: []}, persisted] do
       inactive = Changeset.change(%{block | active: false})
       active = Changeset.change(block)
       refute Block.should_force_live_preview_update?(inactive, active, :container)


### PR DESCRIPTION
Reactivation now recognizes ordinary modules with owned collections as well as containers and multi modules, and applies the same decision to nested child blocks. Empty child-owning blocks still receive a complete render when needed.

Keep the existing full preview refresh for named regions and footnotes: it materializes current content from the operation store, and the incremental browser renderer does not yet splice named-slot placeholders. This hardens the outdated predicate identified in #2762 without removing that protection.

Persisted leaf blocks may have an unloaded children association. The predicate reads the stored tree without triggering Ecto association loading; the existing child-edit/save regressions cover this case.

Validation: ten focused ExUnit tests pass, covering persisted child edits and assertions that collection owners request the full refresh. Four browser scenarios pass without retries: two populated regions retain order and unsaved edits after deactivation/reactivation, for Liquid and HEEx owners both at root and inside a container. The E2E consumer asset build, compilation with warnings as errors, formatting and whitespace checks pass.

Part one of #2762. Unused-content management is in #2764.
