### PR TITLE
Recover unused named regions and footnotes

### DIFF
--- a/assets/css/components/Form/Input/Blocks/BlockSlot.css
+++ b/assets/css/components/Form/Input/Blocks/BlockSlot.css
@@ -53,6 +53,22 @@
 .footnote-storage { margin: 0; padding: 0; }
 .footnote-storage > .blocks-content { margin: 0; padding: 0; }
 
+.unused-collections {
+  margin: 12px 0 24px; padding: 18px 20px; border: 1px solid #ccad76;
+  border-radius: 9px; background: #fff9ed; color: #052752;
+  h3 { font-size: 15px; font-weight: 600; margin: 0 0 7px; span { margin-left: 6px; } }
+  > p { font-size: 13px; line-height: 1.5; margin: 0 0 12px; }
+  ul { list-style: none; padding: 0; margin: 0; }
+  li { display: flex; align-items: center; justify-content: space-between; flex-wrap: wrap; gap: 12px; padding: 10px 0; }
+  li + li { border-top: 1px solid #05275218; }
+  .unused-collection-label { display: grid; gap: 3px; min-width: 0; strong { overflow-wrap: anywhere; } > span { font-size: 12px; opacity: .7; } }
+  .unused-collection-actions { display: flex; flex-wrap: wrap; gap: 8px; }
+  button { border: 1px solid #05275230; border-radius: 5px; padding: 7px 11px; background: white; color: inherit; font-size: 13px; }
+  button:hover { border-color: #052752; }
+  button:focus-visible, select:focus-visible { outline: 2px solid #0047e5; outline-offset: 3px; }
+  .region-remap-form { border-top: 1px solid #05275218; margin-top: 8px; padding-top: 14px; label { display: block; font-size: 13px; margin-bottom: 8px; } select { width: 100%; padding: 8px; margin-bottom: 12px; } button + button { margin-left: 8px; } }
+}
+
 .tiptap .tiptap-footnote {
   display: inline-flex; align-items: center; justify-content: center; vertical-align: super;
   min-width: 21px; min-height: 21px; padding: 2px 5px; margin: 0 2px; border: 0;

--- a/assets/src/hooks/TipTap/index.js
+++ b/assets/src/hooks/TipTap/index.js
@@ -93,10 +93,12 @@ export default (app) => ({
   },
 
   setupFootnoteHandler() {
-    this.handleEvent(`b:tiptap:insert_footnote:${this.el.id}`, ({ uid }) => {
+    this.handleEvent(`b:tiptap:insert_footnote:${this.el.id}`, ({ uid, restore }) => {
       // Keep the saved ProseMirror selection, but leave focus in the drawer
       // which has just opened above this editor.
-      this._editor?.chain().insertContent({ type: 'footnote', attrs: { uid } }).run()
+      const chain = this._editor?.chain()
+      if (restore) chain?.focus()
+      chain?.insertContent({ type: 'footnote', attrs: { uid } }).run()
       renumberFootnotes(this.el)
       this.commitInput(() => {
         const drawer = document.getElementById(`block-slot-drawer-${uid}`)

--- a/docs/FOOTNOTES.md
+++ b/docs/FOOTNOTES.md
@@ -93,8 +93,29 @@ reading.” Place it in an ordinary module template using the normal ref syntax:
 Content lives in an internal `:slot` block under its owner, matched by the ref's
 name. Replacing a ref row does not replace its content. Renaming or removing a
 region ref retains the subtree, but it is no longer rendered at that insertion
-point. There is currently no separate interface for managing unmatched regions
-or notes whose last reference has been removed.
+point. The owner shows these collections under **Unused content**.
+
+## Recovering unused content
+
+An unused collection still holds its content. Removing or renaming a region
+definition, or removing the last inline reference to a note, never deletes its
+body automatically. The editor lists unmatched regions and unreferenced notes
+on their owning block, or beside the owning Blueprint rich-text field.
+
+- **Open** lets you inspect and edit the retained content.
+- **Remap** connects an unmatched region to an empty current region on the same
+  block. Only destinations whose module set allows all its children are offered.
+  The region and its children keep their identities and order, including pending
+  edits. Populated destinations cannot be overwritten or merged.
+- **Restore reference** inserts a marker for the existing note in its original
+  text owner. It is available while that text ref or field still exists.
+- **Delete** removes the collection explicitly. The block bin can undo this
+  until the entry is saved.
+
+Region remaps participate in collaboration and recovery copies. Their virtual,
+signed `slot_remap` field authorizes only the selected region and owner; saves
+recheck the current module definition and destination policy. Plain posted slot
+metadata cannot rename persisted collections. No additional migration is needed.
 
 ## Rendering and numbering
 

--- a/e2e/e2e/playwright/tests/blocks/block-unused-collections.spec.js
+++ b/e2e/e2e/playwright/tests/blocks/block-unused-collections.spec.js
@@ -1,0 +1,185 @@
+import { test, expect } from '../../test-support/setupAuth'
+import { syncLV } from '../../utils'
+
+test.setTimeout(120000)
+
+const fixture = async (page, schema, attributes) => {
+  const response = await page.request.post('/__e2e/db/factory', {
+    data: { schema, attributes, creator_id: 1, fields: ['id'] },
+  })
+  expect(response.ok(), await response.text()).toBeTruthy()
+  return response.json()
+}
+
+const setText = async (page, editor, text) => {
+  await editor.click()
+  await expect(editor).toBeFocused()
+  await editor.press('ControlOrMeta+a')
+  await editor.press('Backspace')
+  await page.keyboard.insertText(text)
+  await expect(editor).toHaveText(text)
+}
+
+const addModule = async (page, name) => {
+  await page.locator('.blocks-wrapper:not(.footnote-storage) > .blocks-content > .block-plus-wrapper button.block-plus').click()
+  await page.getByRole('button', { name, exact: true }).click()
+  await syncLV(page)
+}
+
+const createPage = async (page, title) => {
+  await page.goto('/admin/pages/create')
+  await syncLV(page)
+  await page.getByLabel('Title', { exact: true }).fill(title)
+  await page.getByLabel('URI', { exact: true }).fill(title.toLowerCase().replaceAll(' ', '-'))
+}
+
+const savePage = async (page, title) => {
+  await page.getByRole('button', { name: 'Save (⌘S)', exact: true }).click()
+  await expect(page).toHaveURL(/\/admin\/pages$/)
+  await page.getByRole('link', { name: `${title} →`, exact: true }).click()
+  await syncLV(page)
+}
+
+test('a renamed region keeps its content through remap, collaboration, recovery and save', async ({ page, secondUserPage }, testInfo) => {
+  const module = await fixture(page, 'Brando.Content.Module', {
+    name: { en: 'Recoverable region', no: 'Recoverable region' },
+    namespace: { en: '09 NOTES & REGIONS', no: '09 NOTES & REGIONS' },
+    help_text: { en: 'Region recovery fixture' }, class: 'recoverable-region', type: 'liquid',
+    code: '<aside>{% ref refs.sidebar %}</aside>', multi: false, datasource: false,
+    refs: [{ name: 'sidebar', description: 'Reading', uid: 'recoverable-region-ref', data: { type: 'blocks', data: { module_set: 'Footnotes' } } }],
+    vars: [],
+  })
+  const title = 'Recover a region'
+  await createPage(page, title)
+  await addModule(page, 'Recoverable region')
+  await page.getByRole('button', { name: 'Reading Edit blocks · Footnotes', exact: true }).click()
+  const drawer = page.locator('.block-slot-drawer.visible')
+  await drawer.getByRole('button', { name: 'Add block', exact: true }).click()
+  await page.getByRole('button', { name: 'Note text', exact: true }).click()
+  await setText(page, drawer.locator('.tiptap[contenteditable=true]'), 'Original region content')
+  await drawer.getByRole('button', { name: 'Done', exact: true }).click()
+  await savePage(page, title)
+  const entryUrl = page.url()
+  const uid = await page.locator('[data-block-slot]').getAttribute('data-block-slot')
+
+  await page.goto(`/admin/config/content/modules/update/${module.id}`)
+  await page.getByRole('tab', { name: /^References/ }).click()
+  await page.getByRole('button', { name: 'Edit reference sidebar', exact: true }).click()
+  const refDialog = page.locator('#module-default-ref-0')
+  await refDialog.getByLabel('Template name').fill('related')
+  await refDialog.getByRole('button', { name: 'Done', exact: true }).click()
+  await page.getByRole('tab', { name: /^Template/ }).click()
+  await page.locator('.cm-content:visible').click()
+  await page.keyboard.press('ControlOrMeta+a')
+  await page.keyboard.insertText('<aside>{% ref refs.related %}</aside>')
+  await page.getByTestId('submit').click()
+  await page.locator('#module-destructive-modal').getByRole('button', { name: 'Save anyway', exact: true }).click()
+  await expect(page).toHaveURL(/\/admin\/config\/content\/modules$/)
+
+  await page.goto(entryUrl)
+  const unused = page.locator('.unused-collections')
+  await expect(unused).toContainText('sidebar')
+  await expect(page.locator(`[data-block-slot="${uid}"]`)).toHaveCount(1)
+  await unused.getByRole('button', { name: 'Open', exact: true }).click()
+  await expect(drawer.locator('.tiptap[contenteditable=true]')).toHaveText('Original region content')
+  await setText(page, drawer.locator('.tiptap[contenteditable=true]'), 'Recovered with my unsaved edit')
+  await drawer.getByRole('button', { name: 'Done', exact: true }).click()
+  await secondUserPage.goto(entryUrl)
+  await expect(secondUserPage.locator('.unused-collections')).toBeVisible()
+
+  await unused.getByRole('button', { name: 'Remap', exact: true }).click()
+  await unused.getByLabel('Move this content to an empty region').selectOption('related')
+  await unused.screenshot({ path: testInfo.outputPath('unused-region.png') })
+  await unused.getByRole('button', { name: 'Remap region', exact: true }).click()
+  await expect(unused).toHaveCount(0)
+  await expect(page.locator(`[data-block-slot="${uid}"] input[name$="[slot_name]"]`)).toHaveValue('related')
+  await expect(secondUserPage.locator('.unused-collections')).toHaveCount(0)
+  await expect(secondUserPage.locator(`[data-block-slot="${uid}"] input[name$="[slot_name]"]`)).toHaveValue('related')
+
+  await expect(page.getByTestId('draft-status')).toContainText('Recovery copy saved at', { timeout: 25000 })
+  await page.reload()
+  await page.getByRole('button', { name: 'Review recovery copy', exact: true }).click()
+  await page.getByRole('button', { name: 'Restore recovery copy', exact: true }).click()
+  await expect(page.getByTestId('draft-panel')).toHaveCount(0)
+  await expect(page.locator(`[data-block-slot="${uid}"] input[name$="[slot_name]"]`)).toHaveValue('related')
+  await savePage(page, title)
+  await expect(unused).toHaveCount(0)
+  await page.getByRole('button', { name: 'Reading Edit blocks · Footnotes', exact: true }).click()
+  await expect(drawer.locator('.tiptap[contenteditable=true]')).toHaveText('Recovered with my unsaved edit')
+  await expect(page.locator(`[data-block-slot="${uid}"]`)).toHaveCount(1)
+})
+
+test('an unreferenced block note can be restored, deleted, undone and saved', async ({ page }) => {
+  const title = 'Recover a block note'
+  await createPage(page, title)
+  await addModule(page, 'Article with notes')
+  const editor = page.locator('.entry-block .tiptap[contenteditable=true]').first()
+  await setText(page, editor, 'Body text')
+  await page.getByRole('button', { name: 'Add footnote', exact: true }).click()
+  const drawer = page.locator('.block-slot-drawer.visible')
+  await setText(page, drawer.locator('.tiptap[contenteditable=true]'), 'Keep this source')
+  await drawer.getByRole('button', { name: 'Done', exact: true }).click()
+  await savePage(page, title)
+  const uid = await page.locator('.tiptap-footnote').getAttribute('data-footnote-uid')
+  await setText(page, editor, 'Body without a reference')
+  await editor.blur()
+  const unused = page.locator('.unused-collections')
+  await expect(unused).toContainText('Keep this source')
+  await unused.getByRole('button', { name: 'Restore reference', exact: true }).click()
+  await expect(page.locator(`.tiptap-footnote[data-footnote-uid="${uid}"]`)).toHaveCount(1)
+  await expect(unused).toHaveCount(0)
+  await setText(page, editor, 'Body without a reference')
+  await editor.blur()
+  await unused.getByRole('button', { name: 'Delete', exact: true }).click()
+  await expect(page.locator(`[data-block-slot="${uid}"]`)).toHaveCount(0)
+  await page.getByTestId('block-bin').getByRole('button', { name: 'Undo', exact: true }).click()
+  await expect(unused).toBeVisible()
+  await unused.getByRole('button', { name: 'Open', exact: true }).click()
+  await expect(drawer.locator('.tiptap[contenteditable=true]')).toHaveText('Keep this source')
+  await drawer.getByRole('button', { name: 'Done', exact: true }).click()
+  await unused.getByRole('button', { name: 'Delete', exact: true }).click()
+  await savePage(page, title)
+  await expect(unused).toHaveCount(0)
+  await expect(page.locator(`[data-block-slot="${uid}"]`)).toHaveCount(0)
+})
+
+test('Blueprint notes expose the same recovery controls beside their text field', async ({ page }, testInfo) => {
+  const client = await fixture(page, 'E2eProject.Projects.Client', { name: 'Note client', slug: 'note-client', status: 'published', language: 'en' })
+  const project = await fixture(page, 'E2eProject.Projects.Project', {
+    title: 'Unused field note', slug: 'unused-field-note', introduction: '<p>Introduction</p>',
+    client_id: client.id, status: 'draft', language: 'en',
+  })
+  const url = `/admin/projects/projects/update/${project.id}`
+  await page.goto(url)
+  const editor = page.locator('[data-footnote-field="introduction"] .tiptap[contenteditable=true]')
+  await editor.click()
+  await page.getByRole('button', { name: 'Add footnote', exact: true }).click()
+  const drawer = page.locator('.block-slot-drawer.visible')
+  await setText(page, drawer.locator('.tiptap[contenteditable=true]'), 'An introduction source')
+  await drawer.getByRole('button', { name: 'Done', exact: true }).click()
+  await page.getByRole('button', { name: 'Save (⌘S)', exact: true }).click()
+  await expect(page).toHaveURL(/\/admin\/projects\/projects$/)
+  await page.goto(url)
+  const uid = await page.locator('.tiptap-footnote').getAttribute('data-footnote-uid')
+  await setText(page, editor, 'Rewritten introduction')
+  await editor.blur()
+  const unused = page.locator('#project_introduction-unused-notes .unused-collections')
+  await expect(unused).toContainText('An introduction source')
+  await unused.screenshot({ path: testInfo.outputPath('unused-note.png') })
+  await unused.getByRole('button', { name: 'Restore reference', exact: true }).click()
+  await expect(page.locator(`.tiptap-footnote[data-footnote-uid="${uid}"]`)).toHaveCount(1)
+  await expect(unused).toHaveCount(0)
+  await setText(page, editor, 'Rewritten introduction')
+  await editor.blur()
+  await unused.getByRole('button', { name: 'Delete', exact: true }).click()
+  await expect(page.locator(`[data-block-slot="${uid}"]`)).toHaveCount(0)
+  await page.getByTestId('block-bin').getByRole('button', { name: 'Undo', exact: true }).click()
+  await expect(unused).toContainText('An introduction source')
+  await unused.getByRole('button', { name: 'Restore reference', exact: true }).click()
+  await page.getByRole('button', { name: 'Save (⌘S)', exact: true }).click()
+  await expect(page).toHaveURL(/\/admin\/projects\/projects$/)
+  await page.goto(url)
+  await expect(unused).toHaveCount(0)
+  await page.getByRole('button', { name: 'Edit footnote 1', exact: true }).click()
+  await expect(drawer.locator('.tiptap[contenteditable=true]')).toHaveText('An introduction source')
+})

--- a/lib/brando/content/block.ex
+++ b/lib/brando/content/block.ex
@@ -38,6 +38,7 @@ defmodule Brando.Content.Block do
     :slot_name,
     :slot_kind,
     :slot_module_set,
+    :slot_remap,
     :source,
     :identifier_metas
   ]
@@ -57,6 +58,7 @@ defmodule Brando.Content.Block do
     attribute :slot_name, :string
     attribute :slot_kind, :enum, values: [:region, :footnote]
     attribute :slot_module_set, :string
+    attribute :slot_remap, :string, virtual: true
     attribute :active, :boolean, default: true
     attribute :collapsed, :boolean, default: false
     attribute :description, :string

--- a/lib/brando/content/block_slots.ex
+++ b/lib/brando/content/block_slots.ex
@@ -6,6 +6,7 @@ defmodule Brando.Content.BlockSlots do
   they do not own them, so replacing a ref cannot delete its content.
   """
   alias Brando.Content.Block
+  alias Brando.Content.BlockSlots.Lifecycle
   alias Ecto.Changeset
 
   def children(%{children: children}) when is_list(children), do: children
@@ -92,18 +93,35 @@ defmodule Brando.Content.BlockSlots do
         Changeset.add_error(changeset, :children, "contains a module that is not allowed in this collection")
       end
     else
-      validate_owned_slots(changeset)
+      changeset |> validate_owned_slots() |> Lifecycle.validate_remaps()
     end
   end
 
   # Slot identity is server-owned. A ref being renamed or switched off does
   # not re-home its old notes, and posted hidden fields cannot change policy.
-  defp keep_slot_identity(%{data: %{id: nil}} = changeset), do: changeset
-
   defp keep_slot_identity(changeset) do
-    Enum.reduce([:type, :slot_kind, :slot_name, :slot_module_set], changeset, fn field, cs ->
-      Changeset.put_change(cs, field, Map.get(cs.data, field))
-    end)
+    cond do
+      Changeset.get_field(changeset, :slot_remap) not in [nil, ""] ->
+        case Lifecycle.remap_claim(changeset) do
+          {:ok, claim} ->
+            changeset
+            |> Changeset.put_change(:type, :slot)
+            |> Changeset.put_change(:slot_kind, :region)
+            |> Changeset.put_change(:slot_name, claim.name)
+            |> Changeset.put_change(:slot_module_set, claim.set)
+
+          :error ->
+            Changeset.add_error(changeset, :slot_remap, "is not a valid region remap")
+        end
+
+      is_nil(changeset.data.id) ->
+        changeset
+
+      true ->
+        Enum.reduce([:type, :slot_kind, :slot_name, :slot_module_set], changeset, fn field, cs ->
+          Changeset.put_change(cs, field, Map.get(cs.data, field))
+        end)
+    end
   end
 
   defp same_module?(a, b),
@@ -159,6 +177,9 @@ defmodule Brando.Content.BlockSlots do
     note_owner? = Enum.any?(configured, fn {_name, config} -> config.blocks == field end)
 
     cond do
+      block && block.slot_remap not in [nil, ""] ->
+        Changeset.add_error(changeset, :block, "only module-owned regions can be remapped")
+
       block && note_owner? && block.type != :slot ->
         Changeset.add_error(changeset, :block, "this field only stores its configured footnotes")
 

--- a/lib/brando/content/block_slots/lifecycle.ex
+++ b/lib/brando/content/block_slots/lifecycle.ex
@@ -1,0 +1,168 @@
+defmodule Brando.Content.BlockSlots.Lifecycle do
+  @moduledoc "Inspection and explicit recovery of collections whose insertion point is gone."
+  alias Brando.Content.BlockSlots
+  alias Ecto.Changeset
+
+  @salt "brando-region-remap"
+
+  def marker_uids(html) when is_binary(html) do
+    html
+    |> Floki.parse_fragment!()
+    |> Floki.find("sup[data-footnote-uid], span[data-footnote-uid]")
+    |> Floki.attribute("data-footnote-uid")
+    |> MapSet.new()
+  end
+
+  def marker_uids(_), do: MapSet.new()
+
+  def definitions(%{module_id: nil}), do: []
+
+  def definitions(owner) do
+    case Brando.Content.fetch_module(owner.module_id, owner.module_origin || :local) do
+      %{refs: refs} when is_list(refs) -> refs
+      _ -> []
+    end
+  end
+
+  def unused(owner, definitions) do
+    Enum.filter(BlockSlots.children(owner), &unused?(&1, owner, definitions))
+  end
+
+  def unused?(%{type: :slot, slot_kind: :region, slot_name: name}, _owner, definitions),
+    do: !Enum.any?(definitions, &match?(%{name: ^name, data: %{type: "blocks"}}, &1))
+
+  def unused?(%{type: :slot, slot_kind: :footnote, slot_name: name, uid: uid}, owner, definitions) do
+    !text_ref?(definitions, name) || !MapSet.member?(marker_uids(text(owner, name)), uid)
+  end
+
+  def unused?(_, _, _), do: false
+
+  def text_ref?(refs, name), do: Enum.any?(refs, &match?(%{name: ^name, data: %{type: "text"}}, &1))
+
+  def text(owner, name) do
+    Enum.find_value(owner.refs, fn
+      %{name: ^name, data: %{type: "text", data: %{text: text}}} -> text
+      _ -> nil
+    end)
+  end
+
+  def unused_notes(slots, field, html) do
+    referenced = marker_uids(html)
+    name = to_string(field)
+
+    Enum.filter(slots, fn slot ->
+      slot.type == :slot && slot.slot_kind == :footnote && slot.slot_name == name &&
+        !MapSet.member?(referenced, slot.uid)
+    end)
+  end
+
+  def label(%{slot_kind: :region, slot_name: name}), do: name
+
+  def label(slot) do
+    text =
+      slot
+      |> BlockSlots.children()
+      |> Enum.flat_map(fn child -> List.wrap(child.refs) end)
+      |> Enum.find_value(fn
+        %{data: %{type: "text", data: %{text: html}}} when is_binary(html) ->
+          text = html |> Floki.parse_fragment!() |> Floki.text() |> String.trim()
+          if text != "", do: text
+
+        _ ->
+          nil
+      end)
+
+    case text do
+      nil -> slot.slot_name
+      text -> if String.length(text) > 80, do: String.slice(text, 0, 80) <> "…", else: text
+    end
+  end
+
+  def remap_targets(owner, definitions, uid) do
+    case Enum.find(unused(owner, definitions), &(&1.uid == uid && &1.slot_kind == :region)) do
+      nil -> []
+      slot -> Enum.filter(definitions, &remap_target?(&1, owner, slot))
+    end
+  end
+
+  defp remap_target?(%{name: name, data: %{type: "blocks", data: %{module_set: set}}}, owner, slot) do
+    destination = BlockSlots.named(owner, name)
+    allowed = BlockSlots.modules(set)
+
+    name != slot.slot_name && (is_nil(destination) || BlockSlots.children(destination) == []) &&
+      Enum.all?(BlockSlots.children(slot), &BlockSlots.allowed_child?(&1, allowed))
+  end
+
+  defp remap_target?(_, _, _), do: false
+
+  @doc "Authorize a specific remap after checking the current owner tree and module definition."
+  def remap(owner, definitions, uid, name) do
+    with %{data: %{data: %{module_set: set}}} <- Enum.find(remap_targets(owner, definitions, uid), &(&1.name == name)),
+         slot when not is_nil(slot) <- Enum.find(BlockSlots.children(owner), &(&1.uid == uid)) do
+      claim = %{
+        uid: uid,
+        id: slot.id,
+        owner_uid: owner.uid,
+        from: slot.slot_name,
+        name: name,
+        set: set,
+        prefix: Brando.Tenant.current_prefix()
+      }
+
+      token = Phoenix.Token.sign(Brando.endpoint(), @salt, claim)
+      destination = BlockSlots.named(owner, name)
+
+      {:ok, destination && destination.uid, %{"slot_name" => name, "slot_module_set" => set, "slot_remap" => token}}
+    else
+      _ -> {:error, :invalid_destination}
+    end
+  end
+
+  # The signed operation travels with DOM recovery, drafts and op snapshots.
+  # Ordinary posted metadata still cannot change a persisted slot's identity.
+  # Current definitions and the actual parent are checked again on every save.
+  def remap_claim(%Changeset{} = cs) do
+    token = Changeset.get_field(cs, :slot_remap)
+
+    with true <- is_binary(token),
+         {:ok, claim} <- Phoenix.Token.verify(Brando.endpoint(), @salt, token, max_age: :infinity),
+         true <- claim.uid == Changeset.get_field(cs, :uid),
+         true <- claim.id == cs.data.id,
+         true <- claim.prefix == Brando.Tenant.current_prefix(),
+         true <- Changeset.get_field(cs, :slot_kind) == :region,
+         true <- is_nil(cs.data.id) || cs.data.slot_name in [claim.from, claim.name] do
+      {:ok, claim}
+    else
+      _ -> :error
+    end
+  end
+
+  def validate_remaps(owner_cs) do
+    remapped = Enum.filter(Changeset.get_assoc(owner_cs, :children), &Changeset.get_field(&1, :slot_remap))
+
+    if remapped == [] do
+      owner_cs
+    else
+      owner = Changeset.apply_changes(owner_cs)
+      definitions = definitions(owner)
+
+      valid? =
+        Enum.all?(remapped, fn cs ->
+          with {:ok, claim} <- remap_claim(cs),
+               true <- claim.owner_uid == owner.uid,
+               true <-
+                 !Enum.any?(definitions, &match?(%{name: name, data: %{type: "blocks"}} when name == claim.from, &1)),
+               true <-
+                 Enum.count(BlockSlots.children(owner), &(&1.slot_kind == :region && &1.slot_name == claim.name)) == 1,
+               true <- BlockSlots.allowed_for_refs?(Changeset.apply_changes(cs), definitions) do
+            allowed = BlockSlots.modules(claim.set)
+            Enum.all?(BlockSlots.children(cs), &BlockSlots.allowed_child?(&1, allowed))
+          else
+            _ -> false
+          end
+        end)
+
+      if valid?, do: owner_cs, else: Changeset.add_error(owner_cs, :children, "the region remap is no longer available")
+    end
+  end
+end

--- a/lib/brando/content/blocks.ex
+++ b/lib/brando/content/blocks.ex
@@ -1245,6 +1245,7 @@ defmodule Brando.Content.Blocks do
       sequence: sequence,
       creator_id: user_id,
       parent_id: nil,
+      slot_remap: nil,
       children: [],
       vars: [],
       table_rows: [],

--- a/lib/brando/drafts/modules.ex
+++ b/lib/brando/drafts/modules.ex
@@ -76,6 +76,10 @@ defmodule Brando.Drafts.Modules do
   defp compare_fields(label, old, current) do
     Enum.flat_map(old, fn {name, type} ->
       cond do
+        # A Blocks ref only names an insertion point. Its content is owned by
+        # a separate slot, retained and exposed by the unused-content controls.
+        # Keeping an obsolete region binding must not reject that whole owner.
+        label == "Reference" && type == "blocks" && !Map.has_key?(current, name) -> []
         not Map.has_key?(current, name) -> ["#{label} “#{name}” was removed or renamed."]
         compatible_type?(type, current[name]) -> []
         true -> ["#{label} “#{name}” changed type."]

--- a/lib/brando/drafts/params.ex
+++ b/lib/brando/drafts/params.ex
@@ -29,7 +29,8 @@ defmodule Brando.Drafts.Params do
             not is_nil(Map.get(value, key)) and not match?(%Ecto.Association.NotLoaded{}, Map.get(value, key))
         end)
 
-      value |> Map.take(mod.__schema__(:fields) ++ assocs) |> snapshot()
+      virtuals = if mod == Brando.Content.Block && value.slot_remap, do: [:slot_remap], else: []
+      value |> Map.take(mod.__schema__(:fields) ++ assocs ++ virtuals) |> snapshot()
     else
       value |> Map.from_struct() |> snapshot()
     end

--- a/lib/brando_admin/components/form.ex
+++ b/lib/brando_admin/components/form.ex
@@ -127,6 +127,28 @@ defmodule BrandoAdmin.Components.Form do
   # Ship field changes — triggered by child components (e.g. multi-select on close)
   def update(%{event: "draft_dirty"}, socket), do: {:ok, Drafts.dirty(socket)}
 
+  def update(%{event: event, field: field} = message, socket)
+      when event in ["inspect_field_notes", "field_note_action"] do
+    case Brando.Blueprint.Forms.Footnotes.field(socket.assigns.schema, field) do
+      nil ->
+        :ok
+
+      config ->
+        input = socket.assigns.form[config.field]
+
+        send_update(
+          BlockField,
+          message
+          |> Map.put(:id, "#{socket.assigns.id}-blocks-#{config.blocks}")
+          |> Map.put(:field, config.field)
+          |> Map.put(:html, input.value)
+          |> Map.put(:input_id, "#{input.id}-rich-text")
+        )
+    end
+
+    {:ok, socket}
+  end
+
   def update(%{event: "draft_part", capture_id: id, kind: kind, field: field, data: data}, socket),
     do: {:ok, Drafts.part(socket, id, kind, field, data)}
 

--- a/lib/brando_admin/components/form/block.ex
+++ b/lib/brando_admin/components/form/block.ex
@@ -45,6 +45,7 @@ defmodule BrandoAdmin.Components.Form.Block do
   alias Brando.Cache
   alias Brando.Content.Blocks, as: ContentBlocks
   alias Brando.Content.BlockSlots
+  alias Brando.Content.BlockSlots.Lifecycle, as: CollectionLifecycle
   alias BrandoAdmin.Components.Form.Block.Events
   alias BrandoAdmin.Components.Form.BlockField
   alias BrandoAdmin.Components.Form.BlockField.Ops
@@ -66,6 +67,10 @@ defmodule BrandoAdmin.Components.Form.Block do
     |> assign(:open_slot_uid, nil)
     |> assign(:slot_open, false)
     |> assign(:slot_title, nil)
+    |> assign(:unused_collections, [])
+    |> assign(:remap_slot_uid, nil)
+    |> assign(:remap_targets, [])
+    |> assign(:remap_error, nil)
     |> assign_new(:paste_multi_module_id, fn -> nil end)
     |> Events.attach_block_events()
     |> then(&{:ok, &1})
@@ -589,18 +594,35 @@ defmodule BrandoAdmin.Components.Form.Block do
     |> assign_hidden_block_fields()
     |> assign(:form_is_new, false)
     |> assign(:form_has_changes, false)
-    |> assign(:active, Changeset.get_field(changeset, :active))
-    |> assign(:deleted, Changeset.get_field(changeset, :marked_as_deleted))
+    |> assign(:active, Changeset.get_field(block_cs, :active))
+    |> assign(:deleted, Changeset.get_field(block_cs, :marked_as_deleted))
     |> assign(:children_forms, Map.new(children_forms, &{Changeset.get_field(&1.source, :uid), &1}))
     |> assign(:block_list, Enum.map(children, & &1.uid))
     |> assign(:changesets, Enum.map(children, &{&1.uid, nil}))
     |> assign(:has_children?, children != [])
+    |> assign(:slot_name, Changeset.get_field(block_cs, :slot_name))
+    |> assign(:slot_kind, Changeset.get_field(block_cs, :slot_kind))
+    |> assign(:slot_module_set, Changeset.get_field(block_cs, :slot_module_set))
+    |> assign_unused_collections()
     |> maybe_push_remount(msg)
     |> then(&{:ok, &1})
   end
 
   def update(%{event: "close_slot"}, socket) do
     {:ok, assign(socket, :open_slot_uid, nil)}
+  end
+
+  def update(%{event: "region_remap_targets", uid: uid, targets: targets}, socket) do
+    {:ok, assign(socket, remap_slot_uid: uid, remap_targets: targets, remap_error: nil)}
+  end
+
+  def update(%{event: "region_remapped"}, socket) do
+    {:ok, socket |> assign(remap_slot_uid: nil, remap_error: nil) |> assign_unused_collections()}
+  end
+
+  def update(%{event: "region_remap_failed"}, socket) do
+    {:ok,
+     assign(socket, :remap_error, gettext("This destination is no longer available. Choose an empty compatible region."))}
   end
 
   def update(%{event: "insert_block", module_id: module_id} = message, %{assigns: %{type: :slot}} = socket) do
@@ -997,6 +1019,7 @@ defmodule BrandoAdmin.Components.Form.Block do
     |> maybe_get_live_preview_status()
     |> assign_hidden_block_fields()
     |> assign(:block_initialized, true)
+    |> assign_unused_collections()
     |> then(&{:ok, &1})
   end
 
@@ -1076,7 +1099,7 @@ defmodule BrandoAdmin.Components.Form.Block do
       block_form ->
         field_names =
           if block_form[:type].value == :slot,
-            do: @hidden_block_fields ++ [:slot_kind, :slot_name, :slot_module_set],
+            do: @hidden_block_fields ++ [:slot_kind, :slot_name, :slot_module_set, :slot_remap],
             else: @hidden_block_fields
 
         fields =
@@ -1821,6 +1844,88 @@ defmodule BrandoAdmin.Components.Form.Block do
     end
   end
 
+  def assign_unused_collections(%{assigns: %{type: :module, multi: false}} = socket) do
+    owner = collection_owner(socket)
+    definitions = CollectionLifecycle.definitions(owner)
+
+    unused =
+      owner
+      |> CollectionLifecycle.unused(definitions)
+      |> Enum.map(fn slot ->
+        %{
+          uid: slot.uid,
+          kind: slot.slot_kind,
+          name: slot.slot_name,
+          label: CollectionLifecycle.label(slot),
+          restore?: slot.slot_kind == :footnote && CollectionLifecycle.text_ref?(definitions, slot.slot_name)
+        }
+      end)
+
+    assign(socket, :unused_collections, unused)
+  end
+
+  def assign_unused_collections(socket), do: socket
+
+  defp collection_owner(socket) do
+    owner = socket.assigns.form.source |> get_block_changeset(socket.assigns.belongs_to) |> Changeset.apply_changes()
+    slots = Enum.map(socket.assigns.block_list, &Changeset.apply_changes(socket.assigns.children_forms[&1].source))
+    %{owner | children: slots}
+  end
+
+  def unused_collection_action(socket, action, %{"uid" => uid} = params) do
+    socket = assign_unused_collections(socket)
+
+    case Enum.find(socket.assigns.unused_collections, &(&1.uid == uid)) do
+      nil ->
+        socket
+
+      slot ->
+        case action do
+          "open_unused_collection" ->
+            assign(socket, open_slot_uid: uid, slot_title: slot.name)
+
+          "delete_unused_collection" ->
+            {:ok, socket} = update(%{event: "delete_block", uid: uid, dom_id: nil}, socket)
+            assign(socket, open_slot_uid: nil)
+
+          "restore_note_reference" when slot.restore? ->
+            case instance_ref(socket, slot.name) do
+              %{uid: ref_uid} ->
+                push_event(socket, "b:tiptap:insert_footnote:block-#{ref_uid}-rich-text", %{uid: uid, restore: true})
+
+              _ ->
+                socket
+            end
+
+          "choose_region_remap" when slot.kind == :region ->
+            request_region_remap(socket, "region_remap_targets", uid, %{})
+
+          "remap_region" when slot.kind == :region ->
+            request_region_remap(socket, "remap_region", uid, %{name: params["name"]})
+
+          _ ->
+            socket
+        end
+    end
+  end
+
+  def unused_collection_action(socket, _, _), do: socket
+
+  defp request_region_remap(socket, event, uid, extra) do
+    send_update(
+      BlockField,
+      Map.merge(extra, %{
+        id: "#{socket.assigns.form_id}-blocks-#{socket.assigns.block_field}",
+        event: event,
+        owner_uid: socket.assigns.uid,
+        uid: uid,
+        reply_to: socket.assigns.myself
+      })
+    )
+
+    socket
+  end
+
   def create_footnote(socket, %{"ref_name" => name, "tiptap_id" => tiptap_id}) do
     case {collection_ref(socket, name), instance_ref(socket, name)} do
       {%{data: %{type: "text", data: %{footnotes: true} = data}}, %{uid: ref_uid}}
@@ -1931,6 +2036,7 @@ defmodule BrandoAdmin.Components.Form.Block do
       |> assign(:changesets, insert_child_changeset(socket.assigns.changesets, uid, sequence))
       |> assign(:open_slot_uid, uid)
       |> assign(:slot_title, title)
+      |> assign_unused_collections()
       |> emit_block_op({:insert_child, socket.assigns.uid, uid, sequence, Ops.block_diff_params(slot)})
     end
   end
@@ -2053,6 +2159,7 @@ defmodule BrandoAdmin.Components.Form.Block do
     |> assign(:form, form)
     |> assign_hidden_block_fields()
     |> emit_block_op({:update, socket.assigns.uid, Ops.block_diff_params(form.source)})
+    |> assign_unused_collections()
   end
 
   @doc """

--- a/lib/brando_admin/components/form/block/events.ex
+++ b/lib/brando_admin/components/form/block/events.ex
@@ -21,6 +21,19 @@ defmodule BrandoAdmin.Components.Form.Block.Events do
   def handle_block_event("open_block_slot", %{"ref_name" => name}, socket),
     do: {:halt, Block.open_named_slot(socket, name)}
 
+  def handle_block_event(event, params, socket)
+      when event in [
+             "open_unused_collection",
+             "delete_unused_collection",
+             "restore_note_reference",
+             "choose_region_remap",
+             "remap_region"
+           ],
+      do: {:halt, Block.unused_collection_action(socket, event, params)}
+
+  def handle_block_event("cancel_region_remap", _, socket),
+    do: {:halt, assign(socket, remap_slot_uid: nil, remap_error: nil)}
+
   def handle_block_event("create_footnote", params, socket),
     do: {:halt, Block.create_footnote(socket, params)}
 

--- a/lib/brando_admin/components/form/block/render.ex
+++ b/lib/brando_admin/components/form/block/render.ex
@@ -198,6 +198,14 @@ defmodule BrandoAdmin.Components.Form.Block.Render do
           end
         }
       />
+      <.unused_collections
+        id={"unused-collections-#{@uid}"}
+        items={@unused_collections}
+        target={@myself}
+        remap_uid={@remap_slot_uid}
+        remap_targets={@remap_targets}
+        remap_error={@remap_error}
+      />
       <.collection_children {assigns} />
     </div>
     """
@@ -462,6 +470,70 @@ defmodule BrandoAdmin.Components.Form.Block.Render do
         level={@level + 1}
       />
     </div>
+    """
+  end
+
+  attr :id, :string, required: true
+  attr :items, :list, required: true
+  attr :target, :any, required: true
+  attr :remap_uid, :string, default: nil
+  attr :remap_targets, :list, default: []
+  attr :remap_error, :string, default: nil
+
+  def unused_collections(assigns) do
+    ~H"""
+    <section :if={@items != []} id={@id} class="unused-collections" aria-labelledby={"#{@id}-title"}>
+      <h3 id={"#{@id}-title"}>{gettext("Unused content")} <span>{length(@items)}</span></h3>
+      <p>{gettext("This content is kept here, but no longer has a region or a reference in the text.")}</p>
+      <ul>
+        <li :for={item <- @items} data-unused-uid={item.uid}>
+          <span class="unused-collection-label">
+            <strong>{item.label}</strong>
+            <span>{if item.kind == :region, do: gettext("Unmatched region"), else: gettext("Unreferenced footnote")}</span>
+          </span>
+          <div class="unused-collection-actions">
+            <button type="button" phx-click="open_unused_collection" phx-value-uid={item.uid} phx-target={@target}>{gettext(
+              "Open"
+            )}</button>
+            <button
+              :if={item.kind == :region}
+              type="button"
+              phx-click="choose_region_remap"
+              phx-value-uid={item.uid}
+              phx-target={@target}
+            >{gettext("Remap")}</button>
+            <button
+              :if={item.restore?}
+              type="button"
+              phx-click="restore_note_reference"
+              phx-value-uid={item.uid}
+              phx-target={@target}
+            >{gettext("Restore reference")}</button>
+            <button type="button" phx-click="delete_unused_collection" phx-value-uid={item.uid} phx-target={@target}>{gettext(
+              "Delete"
+            )}</button>
+          </div>
+        </li>
+      </ul>
+      <.form
+        :if={@remap_uid}
+        for={%{}}
+        id={"#{@id}-remap"}
+        phx-submit="remap_region"
+        phx-target={@target}
+        class="region-remap-form"
+      >
+        <input type="hidden" name="uid" value={@remap_uid} />
+        <label for={"#{@id}-destination"}>{gettext("Move this content to an empty region")}</label>
+        <select :if={@remap_targets != []} id={"#{@id}-destination"} name="name" required>
+          <option :for={{label, name} <- @remap_targets} value={name}>{label} ({name})</option>
+        </select>
+        <p :if={@remap_targets == []}>{gettext("There are no empty compatible regions on this block.")}</p>
+        <p :if={@remap_error} role="alert">{@remap_error}</p>
+        <button :if={@remap_targets != []} type="submit">{gettext("Remap region")}</button>
+        <button type="button" phx-click="cancel_region_remap" phx-target={@target}>{gettext("Cancel")}</button>
+      </.form>
+    </section>
     """
   end
 

--- a/lib/brando_admin/components/form/block_field.ex
+++ b/lib/brando_admin/components/form/block_field.ex
@@ -61,6 +61,7 @@ defmodule BrandoAdmin.Components.Form.BlockField do
 
   alias Brando.Content.Blocks, as: ContentBlocks
   alias Brando.Content.BlockSlots
+  alias Brando.Content.BlockSlots.Lifecycle, as: CollectionLifecycle
   alias BrandoAdmin.Components.Form.Block
   alias BrandoAdmin.Components.Form.BlockField.ModulePicker
   alias BrandoAdmin.Components.Form.BlockField.Ops
@@ -71,10 +72,83 @@ defmodule BrandoAdmin.Components.Form.BlockField do
   require Logger
 
   def mount(socket) do
-    {:ok, assign(socket, outline_items: [], open_slot_uid: nil, slot_title: nil)}
+    {:ok, assign(socket, outline_items: [], open_slot_uid: nil, slot_title: nil, note_observers: %{})}
   end
 
   def update(%{event: "close_slot"}, socket), do: {:ok, assign(socket, :open_slot_uid, nil)}
+
+  def update(%{event: "inspect_field_notes", field: field, html: html, reply_to: reply_to}, socket) do
+    if Map.has_key?(socket.assigns.footnote_fields, field) do
+      {:ok,
+       socket
+       |> update(:note_observers, &Map.put(&1, field, %{html: html, reply_to: reply_to}))
+       |> notify_note_observers()}
+    else
+      {:ok, socket}
+    end
+  end
+
+  def update(
+        %{event: "field_note_action", field: field, html: html, uid: uid, action: action, input_id: input_id},
+        socket
+      ) do
+    unused = CollectionLifecycle.unused_notes(field_note_slots(socket), field, html)
+
+    if Map.has_key?(socket.assigns.footnote_fields, field) && Enum.any?(unused, &(&1.uid == uid)) do
+      case action do
+        "open_unused_collection" ->
+          {:ok, assign(socket, open_slot_uid: uid, slot_title: gettext("Footnote"))}
+
+        "restore_note_reference" ->
+          {:ok, push_event(socket, "b:tiptap:insert_footnote:#{input_id}", %{uid: uid, restore: true})}
+
+        "delete_unused_collection" ->
+          update(%{event: "delete_block", uid: uid}, assign(socket, :open_slot_uid, nil))
+
+        _ ->
+          {:ok, socket}
+      end
+    else
+      {:ok, socket}
+    end
+  end
+
+  def update(%{event: "region_remap_targets", owner_uid: owner_uid, uid: uid, reply_to: reply_to}, socket) do
+    targets =
+      with {:ok, owner} <- collection_owner(socket, owner_uid) do
+        owner
+        |> CollectionLifecycle.remap_targets(CollectionLifecycle.definitions(owner), uid)
+        |> Enum.map(&{&1.description || &1.name, &1.name})
+      else
+        _ -> []
+      end
+
+    send_update(reply_to, event: "region_remap_targets", uid: uid, targets: targets)
+    {:ok, socket}
+  end
+
+  def update(%{event: "remap_region", owner_uid: owner_uid, uid: uid, name: name, reply_to: reply_to}, socket) do
+    with {:ok, owner} <- collection_owner(socket, owner_uid),
+         {:ok, destination_uid, params} <-
+           CollectionLifecycle.remap(owner, CollectionLifecycle.definitions(owner), uid, name),
+         {:ok, _} <- Ops.apply_op(socket.assigns.block_ops, {:remap_slot, uid, destination_uid, params}) do
+      root_uid = Ops.root_of(socket.assigns.block_ops, owner_uid)
+
+      socket =
+        socket
+        |> apply_block_op({:remap_slot, uid, destination_uid, params})
+        |> replace_root_from_store(root_uid)
+        |> ship_or_flush(root_uid)
+        |> refresh_live_preview()
+
+      send_update(reply_to, event: "region_remapped")
+      {:ok, socket}
+    else
+      _ ->
+        send_update(reply_to, event: "region_remap_failed")
+        {:ok, socket}
+    end
+  end
 
   def update(%{event: "create_footnote", field: field, params: params}, socket) do
     with %{enabled: true, module_set: set} <- socket.assigns.footnote_fields[field],
@@ -899,6 +973,39 @@ defmodule BrandoAdmin.Components.Form.BlockField do
     end
   end
 
+  defp collection_owner(socket, uid) do
+    if Ops.known?(socket.assigns.block_ops, uid) do
+      root_uid = Ops.root_of(socket.assigns.block_ops, uid)
+      {:ok, params} = Ops.materialize_root(socket.assigns.block_ops, root_uid)
+
+      root =
+        socket
+        |> materialize_base_struct(root_uid)
+        |> socket.assigns.block_module.changeset(params, socket.assigns.current_user.id, true)
+        |> Changeset.get_assoc(:block, :struct)
+
+      case find_block_by_uid([root], uid) do
+        %{type: :module, multi: false} = owner -> {:ok, owner}
+        _ -> {:error, :invalid_owner}
+      end
+    else
+      {:error, :unknown_owner}
+    end
+  end
+
+  defp replace_root_from_store(socket, root_uid) do
+    {:ok, params} = Ops.materialize_root(socket.assigns.block_ops, root_uid)
+
+    form =
+      socket
+      |> materialize_base_struct(root_uid)
+      |> socket.assigns.block_module.changeset(params, socket.assigns.current_user.id, true)
+      |> to_form(as: "entry_block", id: "entry_block_form-#{root_uid}")
+
+    send_update(Block, id: "block-#{root_uid}", event: "replace_form", form: form, remount_js: true)
+    put_seed_form(socket, root_uid, form)
+  end
+
   # The op chokepoint: every mutation (structural or content, local or
   # remote) lands here. A rejected op means a caller drifted from the store —
   # log it loudly, keep the socket usable.
@@ -929,6 +1036,39 @@ defmodule BrandoAdmin.Components.Form.BlockField do
     socket
     |> assign(:block_ops, ops_state)
     |> assign(:root_order, ops_state.order)
+    |> notify_note_observers()
+  end
+
+  defp field_note_slots(socket) do
+    Enum.map(socket.assigns.block_ops.order, fn uid ->
+      {:ok, params} = Ops.materialize_root(socket.assigns.block_ops, uid)
+
+      socket
+      |> materialize_base_struct(uid)
+      |> socket.assigns.block_module.changeset(params, socket.assigns.current_user.id, true)
+      |> Changeset.get_assoc(:block, :struct)
+    end)
+  end
+
+  defp notify_note_observers(socket) do
+    observers = socket.assigns[:note_observers] || %{}
+
+    if map_size(observers) > 0 do
+      slots = field_note_slots(socket)
+
+      Enum.each(observers, fn {field, observer} ->
+        items =
+          slots
+          |> CollectionLifecycle.unused_notes(field, observer.html)
+          |> Enum.map(
+            &%{uid: &1.uid, kind: :footnote, name: &1.slot_name, label: CollectionLifecycle.label(&1), restore?: true}
+          )
+
+        send_update(observer.reply_to, event: "notes", items: items)
+      end)
+    end
+
+    socket
   end
 
   # Seed forms exist for one purpose: a Block component reads its form from

--- a/lib/brando_admin/components/form/block_field/ops.ex
+++ b/lib/brando_admin/components/form/block_field/ops.ex
@@ -76,6 +76,7 @@ defmodule BrandoAdmin.Components.Form.BlockField.Ops do
           | {:reorder, [uid()]}
           | {:reorder_children, parent :: uid(), [uid()]}
           | {:move_to_parent, uid(), new_parent :: uid(), non_neg_integer() | :end}
+          | {:remap_slot, uid(), uid() | nil, params()}
           | {:delete, uid()}
 
   @doc """
@@ -246,6 +247,23 @@ defmodule BrandoAdmin.Components.Form.BlockField.Ops do
            | parents: Map.put(state.parents, uid, new_parent_uid),
              child_order: Map.put(state.child_order, new_parent_uid, List.insert_at(siblings, clamp(at, siblings), uid))
          }}
+    end
+  end
+
+  # One operation replaces an empty destination and updates the retained slot.
+  # Its children never move, keeping their IDs, edits and snapshot ownership.
+  def apply_op(%__MODULE__{} = state, {:remap_slot, uid, destination_uid, params}) do
+    valid_destination? =
+      is_nil(destination_uid) ||
+        (destination_uid != uid && known?(state, destination_uid) &&
+           state.parents[uid] == state.parents[destination_uid] &&
+           Map.get(state.child_order, destination_uid, []) == [])
+
+    if known?(state, uid) && Map.has_key?(state.parents, uid) && valid_destination? do
+      {:ok, state} = apply_op(state, {:update, uid, params})
+      if destination_uid, do: apply_op(state, {:delete, destination_uid}), else: {:ok, state}
+    else
+      {:error, :invalid_slot_remap}
     end
   end
 
@@ -678,6 +696,11 @@ defmodule BrandoAdmin.Components.Form.BlockField.Ops do
       Map.new(mod.__schema__(:fields), fn field ->
         {to_string(field), struct |> Map.get(field) |> change_value()}
       end)
+
+    field_params =
+      if mod == Brando.Content.Block && struct.slot_remap,
+        do: Map.put(field_params, "slot_remap", struct.slot_remap),
+        else: field_params
 
     mod.__schema__(:associations)
     |> Enum.filter(&(&1 in @snapshot_assocs))

--- a/lib/brando_admin/components/form/input.ex
+++ b/lib/brando_admin/components/form/input.ex
@@ -379,6 +379,14 @@ defmodule BrandoAdmin.Components.Form.Input do
           </div>
           <.input type={:hidden} field={@field} class="tiptap-text" phx-debounce={300} />
         </div>
+        <.live_component
+          :if={@footnotes}
+          module={BrandoAdmin.Components.Form.UnusedNotes}
+          id={"#{@field.id}-unused-notes"}
+          field={@field.field}
+          html={@field.value}
+          form_target={@target}
+        />
         <button
           :if={@ai_enabled?}
           type="button"

--- a/lib/brando_admin/components/form/unused_notes.ex
+++ b/lib/brando_admin/components/form/unused_notes.ex
@@ -1,0 +1,42 @@
+defmodule BrandoAdmin.Components.Form.UnusedNotes do
+  @moduledoc "Field-local controls for notes stored in a separate block field."
+  use BrandoAdmin, :live_component
+
+  alias BrandoAdmin.Components.Form.Block.Render
+
+  def mount(socket), do: {:ok, assign(socket, :items, [])}
+
+  def update(%{event: "notes", items: items}, socket), do: {:ok, assign(socket, :items, items)}
+
+  def update(assigns, socket) do
+    socket = assign(socket, assigns)
+
+    send_update(socket.assigns.form_target,
+      event: "inspect_field_notes",
+      field: socket.assigns.field,
+      reply_to: socket.assigns.myself
+    )
+
+    {:ok, socket}
+  end
+
+  def handle_event(action, %{"uid" => uid}, socket)
+      when action in ["open_unused_collection", "restore_note_reference", "delete_unused_collection"] do
+    send_update(socket.assigns.form_target,
+      event: "field_note_action",
+      field: socket.assigns.field,
+      uid: uid,
+      action: action
+    )
+
+    {:noreply, socket}
+  end
+
+  def render(assigns) do
+    ~H"""
+    <div id={@id}>
+      <Render.unused_collections id={"#{@id}-list"} items={@items} target={@myself} />
+    </div>
+    """
+  end
+end

--- a/test/brando/content/block_slot_lifecycle_test.exs
+++ b/test/brando/content/block_slot_lifecycle_test.exs
@@ -1,0 +1,289 @@
+defmodule Brando.Content.BlockSlotLifecycleTest do
+  use ExUnit.Case, async: false
+  use Brando.ConnCase
+
+  alias Brando.Content.{Block, Ref}
+  alias Brando.Content.Blocks, as: ContentBlocks
+  alias Brando.Content.BlockSlots.Lifecycle
+  alias Brando.Factory
+  alias Brando.Villain.Blocks.{BlocksBlock, TextBlock}
+  alias BrandoAdmin.Components.Form.BlockField.Ops
+  alias Ecto.Changeset
+
+  defp region_ref(name, set \\ "all"),
+    do: %Ref{name: name, uid: Brando.Utils.generate_uid(), data: %BlocksBlock{data: %BlocksBlock.Data{module_set: set}}}
+
+  defp text_ref(html),
+    do: %Ref{name: "text", uid: Brando.Utils.generate_uid(), data: %TextBlock{data: %TextBlock.Data{text: html}}}
+
+  defp block(attrs),
+    do:
+      struct(
+        %Block{
+          uid: Brando.Utils.generate_uid(),
+          type: :module,
+          refs: [],
+          vars: [],
+          children: [],
+          table_rows: [],
+          block_identifiers: []
+        },
+        attrs
+      )
+
+  defp slot(name, children \\ []),
+    do: block(type: :slot, slot_kind: :region, slot_name: name, slot_module_set: "all", children: children)
+
+  setup do
+    user = Factory.insert(:random_user)
+    attrs = [name: %{"en" => "Lifecycle"}, namespace: %{"en" => "tests"}, help_text: %{"en" => "Tests"}]
+    child_module = Factory.insert(:module, attrs)
+    module = Factory.insert(:module, attrs ++ [refs: [region_ref("sidebar")]])
+    page = Factory.insert(:page, creator: user)
+
+    children =
+      for n <- [1, 2],
+          do: block(module_id: child_module.id, creator_id: user.id, description: "Child #{n}", sequence: n - 1)
+
+    region = slot("sidebar", children)
+
+    owner =
+      block(
+        module_id: module.id,
+        creator_id: user.id,
+        source: Brando.Pages.Page.Blocks,
+        refs: [region_ref("sidebar")],
+        children: [region]
+      )
+
+    entry = Brando.Repo.insert!(%Brando.Pages.Page.Blocks{entry_id: page.id, block: owner, sequence: 0})
+
+    # Exercise the actual module-sync routine: definitions rename the ref,
+    # instance refs and the owned subtree must both remain recoverable.
+    module = module |> Changeset.change() |> Changeset.put_assoc(:refs, [region_ref("related")]) |> Brando.Repo.update!()
+    Brando.Cache.Query.evict(module)
+    entry = reload(entry.id)
+    entry.block |> ContentBlocks.sync_module(module) |> Brando.Repo.update!()
+    entry = reload(entry.id)
+    {:ok, user: user, entry: entry, module: module, child_module: child_module}
+  end
+
+  defp reload(id) do
+    Brando.Repo.get!(Brando.Pages.Page.Blocks, id)
+    |> Brando.Repo.preload(
+      block: [
+        :vars,
+        refs: Ref.preloads(),
+        table_rows: :vars,
+        block_identifiers: :identifier,
+        children: &ContentBlocks.preload_child_trees/1
+      ]
+    )
+  end
+
+  defp remap_ops(entry, module) do
+    [source] = entry.block.children
+    {:ok, destination, params} = Lifecycle.remap(entry.block, module.refs, source.uid, "related")
+    ops = Ops.from_entry_blocks([entry])
+    {:ok, ops} = Ops.apply_op(ops, {:update, hd(source.children).uid, %{"description" => "Unsaved child edit"}})
+    {:ok, ops} = Ops.apply_op(ops, {:remap_slot, source.uid, destination, params})
+    ops
+  end
+
+  defp materialize(entry, ops, user) do
+    {:ok, params} = Ops.materialize_root(ops, entry.block.uid)
+    Brando.Pages.Page.Blocks.changeset(entry, params, user.id, true)
+  end
+
+  test "module sync retains the renamed region and detection uses current definitions", %{entry: entry, module: module} do
+    assert Enum.sort(Enum.map(entry.block.refs, & &1.name)) == ["related", "sidebar"]
+    assert [%{slot_name: "sidebar"}] = Lifecycle.unused(entry.block, module.refs)
+    assert length(hd(entry.block.children).children) == 2
+    assert Lifecycle.unused(entry.block, [region_ref("sidebar")]) == []
+    assert [%{slot_name: "sidebar"}] = Lifecycle.unused(entry.block, [%Ref{name: "sidebar", data: %TextBlock{}}])
+
+    fields = %{"blocks" => [Brando.Drafts.Params.snapshot(entry)]}
+    assert {recovered, []} = Brando.Drafts.Modules.check(fields, Brando.Drafts.Modules.manifest(fields))
+    assert hd(recovered["blocks"])["block"]["children"] == hd(fields["blocks"])["block"]["children"]
+  end
+
+  test "remapping survives save and preserves the slot and child IDs with pending edits", context do
+    %{entry: entry, module: module, user: user} = context
+    [old_slot] = entry.block.children
+    cs = materialize(entry, remap_ops(entry, module), user)
+    assert cs.valid?, inspect(cs.errors)
+    assert {:ok, _} = Brando.Repo.update(cs)
+    saved = reload(entry.id)
+    assert [new_slot] = saved.block.children
+    assert new_slot.id == old_slot.id
+    assert new_slot.uid == old_slot.uid
+    assert new_slot.slot_name == "related"
+    assert Enum.map(new_slot.children, & &1.id) == Enum.map(old_slot.children, & &1.id)
+    assert hd(new_slot.children).description == "Unsaved child edit"
+    assert Lifecycle.unused(saved.block, module.refs) == []
+    assert new_slot.slot_remap == nil
+  end
+
+  test "remapping survives remote snapshots, delete undo and draft reconciliation", %{
+    entry: entry,
+    module: module,
+    user: user
+  } do
+    ops = remap_ops(entry, module)
+    [region] = entry.block.children
+
+    {:ok, remote} =
+      Ops.apply_remote_snapshot(
+        Ops.from_entry_blocks([entry]),
+        entry.block.uid,
+        Ops.subtree_snapshot(ops, entry.block.uid)
+      )
+
+    assert Ops.materialize_root(remote, entry.block.uid) == Ops.materialize_root(ops, entry.block.uid)
+    snapshot = Ops.bin_snapshot(remote, region.uid)
+    {:ok, deleted} = Ops.apply_op(remote, {:delete, region.uid})
+    {:ok, restored} = Ops.restore_snapshot(deleted, snapshot)
+    assert Ops.materialize_root(restored, entry.block.uid) == Ops.materialize_root(ops, entry.block.uid)
+
+    fields = %{"blocks" => [materialize(entry, restored, user) |> Brando.Drafts.Params.snapshot()]}
+    assert {recovered, []} = Brando.Drafts.Modules.check(fields, Brando.Drafts.Modules.manifest(fields))
+    params = Brando.Drafts.Restore.reconcile(hd(recovered["blocks"]), entry)
+
+    restored_cs = Brando.Pages.Page.Blocks.changeset(entry, params, user.id, true)
+    assert restored_cs.valid?
+    assert {:ok, _} = Brando.Repo.update(restored_cs)
+    assert hd(reload(entry.id).block.children).slot_name == "related"
+  end
+
+  test "plain hidden metadata and forged remap operations cannot reassign persisted slots", %{
+    entry: entry,
+    module: module,
+    user: user
+  } do
+    [region] = entry.block.children
+    original = Ops.from_entry_blocks([entry])
+
+    {:ok, changed} =
+      Ops.apply_op(original, {:update, region.uid, %{"slot_name" => "related", "slot_module_set" => "other"}})
+
+    kept = materialize(entry, changed, user) |> Changeset.get_assoc(:block, :struct) |> Map.fetch!(:children) |> hd()
+    assert kept.slot_name == "sidebar"
+    assert kept.slot_module_set == "all"
+
+    {:ok, forged} = Ops.apply_op(original, {:update, region.uid, %{"slot_remap" => "forged"}})
+    refute materialize(entry, forged, user).valid?
+    {:ok, _, signed} = Lifecycle.remap(entry.block, module.refs, region.uid, "related")
+
+    other =
+      slot("sidebar")
+      |> Map.put(:id, region.id + 1)
+      |> Changeset.change(signed |> Map.new(fn {k, v} -> {String.to_existing_atom(k), v} end))
+
+    assert Lifecycle.remap_claim(other) == :error
+  end
+
+  test "populated, incompatible and missing destinations are refused", %{
+    entry: entry,
+    module: module,
+    child_module: child_module
+  } do
+    [source] = entry.block.children
+    populated = slot("related", [block(module_id: child_module.id)])
+    owner = %{entry.block | children: [source, populated]}
+    assert Lifecycle.remap(owner, module.refs, source.uid, "related") == {:error, :invalid_destination}
+    assert Lifecycle.remap(entry.block, module.refs, source.uid, "missing") == {:error, :invalid_destination}
+
+    assert Lifecycle.remap(entry.block, [region_ref("related", "nonexistent-set")], source.uid, "related") ==
+             {:error, :invalid_destination}
+
+    assert Lifecycle.remap(entry.block, [region_ref("sidebar"), region_ref("related")], source.uid, "related") ==
+             {:error, :invalid_destination}
+  end
+
+  test "a remap is rejected if its owner or destination definition changes before save", context do
+    %{entry: entry, module: module, user: user} = context
+    ops = remap_ops(entry, module)
+    {:ok, params} = Ops.materialize_root(ops, entry.block.uid)
+    wrong_owner = put_in(params, ["block", "uid"], Brando.Utils.generate_uid())
+    refute Brando.Pages.Page.Blocks.changeset(entry, wrong_owner, user.id, true).valid?
+
+    module = module |> Changeset.change() |> Changeset.put_assoc(:refs, []) |> Brando.Repo.update!()
+    Brando.Cache.Query.evict(module)
+    refute materialize(entry, ops, user).valid?
+  end
+
+  test "an unsaved region can be remapped, saved and duplicated without reusing its authorization", context do
+    %{entry: entry, module: module, user: user} = context
+
+    owner =
+      entry.block |> Changeset.change() |> ContentBlocks.duplicate_block(user_id: user.id) |> Changeset.apply_changes()
+
+    entry = %Brando.Pages.Page.Blocks{entry_id: entry.entry_id, block: owner, sequence: 1}
+    [region] = owner.children
+    {:ok, _, params} = Lifecycle.remap(owner, module.refs, region.uid, "related")
+    {:ok, ops} = Ops.apply_op(Ops.new([]), {:insert, owner.uid, 0, Ops.snapshot_params(Changeset.change(entry))})
+    {:ok, ops} = Ops.apply_op(ops, {:remap_slot, region.uid, nil, params})
+    {:ok, params} = Ops.materialize_root(ops, owner.uid)
+    cs = Brando.Pages.Page.Blocks.changeset(%Brando.Pages.Page.Blocks{}, params, user.id, true)
+    assert cs.valid?, inspect(Changeset.traverse_errors(cs, fn {message, _} -> message end))
+
+    copy =
+      cs |> Changeset.get_assoc(:block) |> ContentBlocks.duplicate_block(user_id: user.id) |> Changeset.apply_changes()
+
+    assert [%{slot_name: "related", slot_remap: nil}] = copy.children
+    assert {:ok, saved} = Brando.Repo.insert(cs)
+    assert hd(reload(saved.id).block.children).slot_name == "related"
+  end
+
+  test "a remapped region can be explicitly deleted before saving", context do
+    %{entry: entry, module: module, user: user} = context
+    [region] = entry.block.children
+    {:ok, ops} = Ops.apply_op(remap_ops(entry, module), {:delete, region.uid})
+    cs = materialize(entry, ops, user)
+    assert cs.valid?
+    assert {:ok, _} = Brando.Repo.update(cs)
+    assert reload(entry.id).block.children == []
+  end
+
+  test "an already instantiated empty destination is replaced atomically", %{entry: entry, module: module, user: user} do
+    [source] = entry.block.children
+    empty = slot("related") |> Map.put(:parent_id, entry.block.id) |> Brando.Repo.insert!()
+    entry = reload(entry.id)
+    {:ok, destination, params} = Lifecycle.remap(entry.block, module.refs, source.uid, "related")
+    assert destination == empty.uid
+    {:ok, ops} = Ops.apply_op(Ops.from_entry_blocks([entry]), {:remap_slot, source.uid, destination, params})
+    cs = materialize(entry, ops, user)
+    assert cs.valid?
+    assert {:ok, _} = Brando.Repo.update(cs)
+    assert [%{id: id, slot_name: "related"}] = reload(entry.id).block.children
+    assert id == source.id
+    refute Brando.Repo.get(Block, empty.id)
+  end
+
+  test "footnotes become unused only when their last owner-local marker is gone" do
+    note = %{slot("text") | slot_kind: :footnote, uid: "note"}
+    marker = ~s(<sup data-footnote-uid="note">•</sup>)
+    definitions = [text_ref("")]
+
+    for html <- [marker, marker <> marker] do
+      assert Lifecycle.unused(block(refs: [text_ref(html)], children: [note]), definitions) == []
+      assert Lifecycle.unused_notes([note], :text, html) == []
+    end
+
+    assert [^note] = Lifecycle.unused(block(refs: [text_ref("<p>No reference</p>")], children: [note]), definitions)
+    assert [^note] = Lifecycle.unused_notes([note], :text, "")
+    assert Lifecycle.unused_notes([note], :other, "") == []
+    assert [^note] = Lifecycle.unused(block(refs: [text_ref(marker)], children: [note]), [])
+  end
+
+  test "region recovery does not bypass review of removed or retyped content refs", %{entry: entry} do
+    params = Brando.Drafts.Params.snapshot(entry)
+
+    for ref <- [text_ref("Retained prose"), %{text_ref("Former text") | name: "related"}] do
+      fields =
+        put_in(%{"blocks" => [params]}, ["blocks", Access.at(0), "block", "refs"], [Brando.Drafts.Params.snapshot(ref)])
+
+      assert {%{"blocks" => []}, [_]} = Brando.Drafts.Modules.check(fields, Brando.Drafts.Modules.manifest(fields))
+    end
+  end
+end


### PR DESCRIPTION
Renaming or removing a Blocks ref, or removing a note’s last inline reference, kept the collection’s content but left editors unable to find it. Show an Unused content section on its owner with Open, Delete and undo, region Remap, and Restore reference for notes. Blueprint rich-text fields expose the same note controls beside their field.

Region remapping preserves the original slot and child identities, order and pending edits. It uses the current operation store and only accepts an empty compatible destination on the same owner. A signed virtual field carries that explicit authorization through collaboration, DOM recovery and recovery copies; saves recheck ownership and current definitions. Removed Blocks bindings remain recoverable without bypassing draft review for removed or retyped content refs. No database migration is needed.

#2763 contains the preview reactivation fix and is already merged. This PR now targets `next`.

Closes #2762.

Validation:
- Full CI unit suites pass on Elixir 1.17.2, 1.18.1, 1.19.5 and 1.20.3. The inherited preview check now safely handles persisted blocks with unloaded children; its failing child-edit tests also pass locally.
- 149 focused unit checks passed, including actual module sync and save, remap authorization, empty/populated/incompatible targets, unsaved regions, duplication, op snapshots, undo, draft compatibility and editor event contracts.
- 11 browser scenarios passed without retries: region remap through two editors, recovery-copy restore and save; block and Blueprint note restore/delete/undo/save; existing footnote media/recovery flows; Liquid and HEEx preview reactivation at root and inside containers.
- E2E consumer asset build, formatting, compilation with warnings as errors, strict Blueprint Credo and compile-connected cycle checks passed. Inspected the region and field-note controls visually.
