### PR TITLE
Add a 0.54 documentation index and rescope the coverage backlog

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,9 @@ config :my_app, MyApp.Endpoint,
 
 ## Dependencies
 
-  * `sharp`/`sharp-cli` for image processing.
-    Installation instructions: https://github.com/brandocms/brando/issues/183
-  * `gifsicle` for GIF resizing.
+Brando 0.54 processes images through the Image library and Vix/libvips. The
+current processor does not require the former `sharp-cli` or `gifsicle` tools.
+See [Videos](guides/videos.md) for video processing and provider requirements.
 
 ## I18n
 
@@ -71,6 +71,10 @@ Generate templates:
     $ mix brando.gen
 
 ## Documentation
+
+Start with the [Brando 0.54 guide index](guides/overview.md) for task-oriented
+reading paths. The [coverage audit](https://github.com/brandocms/brando/blob/next/docs/documentation-coverage.md) identifies
+partial and unfinished guides and the remaining writing work.
 
 - [Migrating to Brando 0.54](guides/migrating_to_054.md) — ordered source,
   database, derived-data, and Gettext upgrade workflow.

--- a/docs/documentation-coverage.md
+++ b/docs/documentation-coverage.md
@@ -53,7 +53,7 @@ guide exists, though source/API documentation may be available.
 
 Other existing guides cover Blueprint migrations, tenancy/environments, videos,
 and deployment. `guides/revisions.md` is also a heading-only stub, although it
-was not named separately in the original checklist. In total, ten of the 23
+was not named separately in the original checklist. In total, nine of the 23
 guide files present at this baseline are heading-only stubs.
 
 ## Prioritized writing packages

--- a/docs/documentation-coverage.md
+++ b/docs/documentation-coverage.md
@@ -1,0 +1,91 @@
+# Documentation coverage and remaining work
+
+Issue [#627](https://github.com/brandocms/brando/issues/627) is now scoped to the
+0.54 documentation entry points and this coverage baseline. It is not an
+unbounded promise to document every subsystem in one PR.
+
+Audit baseline: `next` at `67191f96d`, 6 September 2026. This records guide content,
+not the existence of a Markdown filename or an ExDoc module. The reader entry
+point is [Brando 0.54 guides](../guides/overview.md).
+
+## Completion criteria for the rescoped issue
+
+- Account for all 23 top-level topics in the original issue, including redirects
+  under SEO.
+- Distinguish usable guides, partial coverage, heading-only stubs, and missing
+  dedicated guides.
+- Publish a task-oriented index from both README and ExDoc.
+- State remaining deliverables and their verification requirements; do not mark
+  a topic complete merely because its file exists.
+
+## Original topic inventory
+
+**Guide** means substantial usable guidance exists, without claiming an exhaustive
+audit of every example. **Partial** means selected APIs or recipes are covered.
+**Stub** means the dedicated file has only a heading. **Missing** means no dedicated
+guide exists, though source/API documentation may be available.
+
+| Original topic | Coverage at baseline | Existing guidance and remaining deliverable |
+| --- | --- | --- |
+| Datasources | Partial | [Datasource examples](../guides/datasources.md), [Blueprint DSL](../guides/blueprints.md#datasources). Cover list/selection/single callback contracts, ordering, vars, runtime context, and invalidation with current examples. |
+| Villain | Guide | [Block editor](../guides/block_editor.md), [parser](../guides/villain_parser.md), [text styles](../guides/villain_text_styles.md). Keep both Liquex and HEEx examples in sync with rendering tests. |
+| Identity | Partial | [JSON-LD identity](../guides/jsonld.md#identity-type-specific-fields). Add translated identity setup, links, frontend access, defaults, and cache refresh. Source: `lib/brando/sites/identity.ex`, `lib/brando/sites.ex`. |
+| SEO and redirects | Partial | [Permalink redirects](../guides/blueprints.md#permalink-redirects) covers automatic redirects. Add the SEO configuration form, fallback values, manual patterns/captures, language scoping, and redirect testing. Source: `lib/brando/sites/seo.ex`, `lib/brando/sites/redirects.ex`. |
+| Sitemap | Stub | `guides/sitemaps.md`. Explain sitemap DSL, publication/status filtering, language URLs, generation schedule, storage, and an output check. Source: `lib/brando/sitemap.ex`. |
+| CDN | Stub | `guides/cdn.md`. Cover field/default S3 settings, image/file upload flow, media URL versus object key, tenant paths, and verification. Source: `lib/brando/cdn/cdn.ex`. |
+| Users | Partial | [Authorization](../guides/authorization.md) covers access and group management. Add account creation, login eligibility, sessions, deactivation, and deletion/content transfer. Source: `lib/brando/users/users.ex`. |
+| Pages/Sections | Stub | `guides/pages.md`. Define current pages, hierarchy, templates, vars, fragments, homepage URLs, breadcrumbs, and frontend rendering. Source: `lib/brando/pages/pages.ex`. |
+| Generator | Stub | `guides/generators.md`. Give a fresh-install path and task catalog with generated files, follow-up commands, and overwrite boundaries. Source: `lib/mix/tasks/`. |
+| Authorization | Guide | [Authorization](../guides/authorization.md). Covers opt-in groups, legacy compatibility, scopes, policies, enforcement, and testing. |
+| META schemas | Partial | [Meta](../guides/meta.md), [Blueprint metadata](../guides/blueprints.md#metadata-and-json-ld). Correct stale callback examples and show a complete controller/layout result with fallbacks. |
+| JSONLD schemas | Guide | [JSON-LD](../guides/jsonld.md). Covers graph relationships, controller integration, supported schema fields, and custom schemas. |
+| Image fields | Partial | [Blueprint assets](../guides/blueprints.md#assets) and internal [upload architecture](UPLOADER.md). Add a public recipe for field configuration, Image/Vix processing, focal crop, sizes/srcset, and rendering. |
+| File fields | Partial | [Blueprint assets](../guides/blueprints.md#assets), internal [upload architecture](UPLOADER.md). Add allowed types/limits, replacement, download URLs, and persisted field behavior. |
+| Live Preview | Stub | `guides/live_preview.md`. Explain configuration, unsaved data, preloads, assigns, invalidation, independent targets, and sharing. Implementation is tracked in [#2485](https://github.com/brandocms/brando/issues/2485); update coverage when its guide lands. |
+| Soft delete | Partial | [Query status/deletion](../guides/querying.md#status-language-and-soft-deletion), [traits](../guides/blueprints.md#traits). Add delete/restore, obfuscated unique fields, conflicts, and purge behavior. Source: `lib/brando/traits/soft_delete.ex`. |
+| Sequence | Partial | [Traits](../guides/blueprints.md#traits), [ordering](../guides/querying.md#ordering). Add append/strict semantics, stable ordering, nested rows, and authorized reorder. Source: `lib/brando/traits/sequenced.ex`. |
+| Gallery | Partial | [Blueprint assets](../guides/blueprints.md#assets), internal [upload architecture](UPLOADER.md). Add mixed image/video configuration, ordering, usage overrides, independent duplication, and rendering. |
+| Status | Partial | [Query status/deletion](../guides/querying.md#status-language-and-soft-deletion). Explain draft/pending/published/disabled values as defined by the current status type, required-field behavior, and publication side effects. Source: `lib/brando/traits/status.ex`. |
+| Scheduled publishing | Stub | `guides/scheduled_publishing.md`. Separate publishing an entry status from scheduling a revision, including time zones, cancellation, retries, permissions, and tenant context. Source: `lib/brando/publisher.ex`. |
+| I18n | Stub | `guides/i18n.md`. Explain admin/content languages, Gettext, translated entries/alternates, route scoping, and frontend helpers. Existing migration guidance covers Gettext upgrades only. |
+| Navigation | Stub | `guides/navigation.md`. Give a complete menu, nested item, identifier-backed link, language lookup, rendering, and cache refresh example. Source: `lib/brando/navigation/navigation.ex`. |
+| Query | Guide | [Querying](../guides/querying.md). Covers generated contexts, options, association loading, caching, revisions, and mutations. |
+
+Other existing guides cover Blueprint migrations, tenancy/environments, videos,
+and deployment. `guides/revisions.md` is also a heading-only stub, although it
+was not named separately in the original checklist. In total, ten of the 23
+guide files present at this baseline are heading-only stubs.
+
+## Prioritized writing packages
+
+Each package is suitable for a focused follow-up PR. These are remaining work,
+not completed acceptance criteria for the current implementation.
+
+1. **Onboarding and everyday content:** complete generators/install, pages and
+   fragments, navigation, and I18n. Walk through a fresh consumer setup, one
+   translated page and menu, and a saved/reloaded content edit. Replace the
+   README's historical shell-installer path with the verified 0.54 workflow.
+2. **Media and delivery:** public image, file, gallery, and CDN recipes. Use the
+   current Image/Vix processor, current video providers, and the sticky upload
+   manager; verify consumer rendering and distinguish local paths from CDN keys.
+3. **Preview and publishing:** live preview (#2485), revisions, scheduled
+   publishing, and status lifecycle. Show unsaved previews, selected revisions,
+   cancellation, invalid saves, and execution in the intended environment.
+4. **Site output and lifecycle:** identity, SEO/manual redirects, sitemaps,
+   datasource expansion, metadata correction, soft-delete/restore, and sequence.
+   Verify rendered output, language boundaries, and dependency/cache invalidation.
+5. **Account workflows:** extend authorization guidance with actual user session,
+   deactivation, and content-transfer behavior, with a restricted-account example.
+
+A guide is ready when it states prerequisites, uses current public APIs, includes
+one complete practical example, explains its important failure/empty state, and
+has its commands or example behavior checked against the consumer or focused
+tests. API inventories and internal agent skills complement these guides; they
+do not replace the application developer's walkthrough.
+
+## Maintaining the index
+
+Keep `guides/overview.md`, ExDoc's extras in `mix.exs`, and this table aligned when
+a guide lands. Build docs with `mix docs`, check local Markdown links and anchors,
+and inspect the generated overview. Record unresolved baseline warnings rather
+than describing a warning-filled build as warning-free.

--- a/guides/overview.md
+++ b/guides/overview.md
@@ -1,0 +1,65 @@
+# Brando 0.54 guides
+
+Brando combines Phoenix and Ecto with a Blueprint system for content schemas,
+admin forms, and structured content. This index covers the developing **0.54**
+API on the `next` branch. Use documentation from your application's Brando
+version when maintaining an older installation.
+
+## Start with your task
+
+| I want to… | Start here | Then read |
+| --- | --- | --- |
+| Upgrade an existing application | [Migrating to 0.54](migrating_to_054.md) | [Blueprint migrations](blueprint_migrations.md) |
+| Define a content type and its admin screens | [Blueprints](blueprints.md) | [Querying and mutations](querying.md) |
+| Build reusable page content | [Block editor](block_editor.md) | [Villain parser](villain_parser.md) |
+| Configure video storage or playback | [Videos](videos.md) | [Blueprint assets](blueprints.md#assets) |
+| Control who can read and edit content | [Authorization](authorization.md) | [Sites and environments](tenancy_and_environments.md) |
+| Configure a site or publish a static build | [Sites and environments](tenancy_and_environments.md) | [Deployment](deployment.md) |
+| Add search and sharing metadata | [Blueprint metadata](blueprints.md#metadata-and-json-ld) | [JSON-LD](jsonld.md) |
+
+For a new installation, start with the installer mode examples in
+[Sites and environments](tenancy_and_environments.md). They explain classic,
+single-site, and multi-site configuration. A complete fresh-install walkthrough,
+including frontend asset setup, is still an open documentation task.
+
+## Schemas and application code
+
+[Blueprints](blueprints.md) explains attributes, relations, assets, traits,
+identifiers, URLs, forms, listings, and validation. Start with an existing
+application Blueprint when adding a similar content type.
+
+[Blueprint migrations](blueprint_migrations.md) covers generated migrations,
+snapshots, rollback, and legacy storage. [Querying](querying.md) covers context
+queries and mutations, filtering, ordering, pagination, association loading,
+caching, and status/language/deletion options.
+
+## Content and media
+
+The [block editor](block_editor.md) guide introduces modules, refs, vars, and
+frontend rendering. [Villain parser](villain_parser.md) covers custom output;
+[text styles](villain_text_styles.md) covers reusable rich-text styles.
+
+The [video guide](videos.md) covers upload strategies and providers. Image,
+file, and gallery field declarations are introduced in
+[Blueprint assets](blueprints.md#assets). Full field-by-field media recipes are
+still needed; the presence of an API module does not imply a complete guide.
+
+## Operations and access
+
+[Authorization](authorization.md) explains scoped groups, resource policies,
+application enforcement, and the distinction between legacy and group modes.
+[Sites and environments](tenancy_and_environments.md) covers installation modes,
+routing, content environments, asset sets, and static publication.
+[Deployment](deployment.md) covers application deployment through Florist.
+
+## Documentation still being written
+
+Pages/fragments, navigation, live preview, revisions, scheduled publishing,
+sitemaps, CDN, language setup, and generators need complete standalone guides.
+The older datasource and metadata examples also need review and expansion.
+For those areas, consult the relevant API module and the consuming application's
+configuration; heading-only guide files are not implementation instructions.
+
+The repository's [documentation coverage audit](https://github.com/brandocms/brando/blob/next/docs/documentation-coverage.md)
+records the original #627 topics, the existing source of guidance, and concrete
+acceptance criteria for the remaining work. Update the audit when a guide lands.

--- a/lib/brando.ex
+++ b/lib/brando.ex
@@ -1,4 +1,5 @@
 defmodule Brando do
+  @external_resource "README.md"
   @moduledoc File.read!("README.md")
   @version Mix.Project.config()[:version]
 

--- a/mix.exs
+++ b/mix.exs
@@ -19,9 +19,11 @@ defmodule Brando.Mixfile do
       # Docs
       name: "Brando",
       docs: [
+        main: "overview",
         source_ref: "v#{@version}",
         source_url: "https://github.com/brandocms/brando",
         extras: [
+          "guides/overview.md",
           "guides/migrating_to_054.md",
           "guides/tenancy_and_environments.md",
           "guides/blueprints.md",
@@ -47,6 +49,7 @@ defmodule Brando.Mixfile do
           "guides/deployment.md"
         ],
         groups_for_extras: [
+          Introduction: ["guides/overview.md"],
           Upgrading: [
             "guides/migrating_to_054.md"
           ],


### PR DESCRIPTION
Rescopes #627 into a finishable documentation entry-point and coverage task. Adds a task-oriented 0.54 guide index as the ExDoc homepage, links it from README, and audits every original topic with an explicit guide/partial/stub/missing classification and prioritized remaining deliverables.

The audit found nine heading-only files among 23 guide files. It retains those gaps as follow-up writing work rather than marking them documented. Also corrects obsolete image-tool dependencies in README and registers README as an external resource so its embedded module documentation recompiles when edited.

Validation: local Markdown links/anchors and source references checked; ExDoc generated; homepage routing and generated guide links inspected. No application runtime behavior changes.

Closes #627 under its revised scope. The detailed guides listed in the audit remain follow-up work.

CI note: the legacy-2 shard failed in `draft-media.spec.js` while waiting for two gallery uploads. The exact case (`a mixed gallery field recovers its order and later deletions`) passed locally on this branch with the isolated database reset and its consumer assets rebuilt. This PR changes no gallery or upload behavior. The CI failure remains visible: https://github.com/brandocms/brando/actions/runs/34047890500/job/101526174683.
