### PR TITLE
Fix nested Liquid block previews and modal focus after saves

### DIFF
--- a/assets/src/hooks/Modal/index.js
+++ b/assets/src/hooks/Modal/index.js
@@ -72,6 +72,7 @@ export default app => ({
   destroyed() {
     this.el.removeEventListener('keydown', this.onKeydown)
     this.observer?.disconnect()
+    cancelAnimationFrame(this.openFrame)
     clearTimeout(this.focusTimer)
     // A modal removed from the DOM while open would otherwise strand focus on
     // nothing, dropping the caret back to <body>.
@@ -92,6 +93,16 @@ export default app => ({
   },
 
   onOpened() {
+    // LiveView restores the previously focused control after a save reply.
+    // Take focus on the next frame, so the reply cannot move focus back
+    // behind a newly opened dialog.
+    cancelAnimationFrame(this.openFrame)
+    this.openFrame = requestAnimationFrame(() => this.focusOpened())
+  },
+
+  focusOpened() {
+    if (!this.el.isConnected || !this.isOpen()) return
+
     // Remember who opened it *before* moving focus, so closing returns the user
     // to the control they were on rather than to the top of the page.
     const active = document.activeElement
@@ -116,6 +127,7 @@ export default app => ({
   },
 
   restoreFocus() {
+    cancelAnimationFrame(this.openFrame)
     const opener = this.opener
     this.opener = null
     // Only take focus back if it is still inside the modal; if something else

--- a/e2e/e2e/playwright/tests/blocks/block-copy-paste.spec.js
+++ b/e2e/e2e/playwright/tests/blocks/block-copy-paste.spec.js
@@ -128,7 +128,8 @@ test.describe('Block Copy/Paste', () => {
 
     // Add Single Asset block (has a string var "String label")
     await page.getByRole('button', { name: 'Add block' }).click()
-    await page.getByRole('button', { name: 'MEDIA' }).click()
+    await page.getByRole('navigation', { name: 'Module groups' })
+      .getByRole('button', { name: 'MEDIA' }).click()
     await page.getByRole('button', { name: 'Single Asset' }).click()
     await syncLV(page)
 
@@ -360,7 +361,8 @@ test.describe('Block Copy/Paste', () => {
     // Source entry with a block carrying an identifiable var value
     await createPage(page, 'Cross Entry Source', 'cross-entry-source')
     await page.getByRole('button', { name: 'Add block' }).click()
-    await page.getByRole('button', { name: 'MEDIA' }).click()
+    await page.getByRole('navigation', { name: 'Module groups' })
+      .getByRole('button', { name: 'MEDIA' }).click()
     await page.getByRole('button', { name: 'Single Asset' }).click()
     await syncLV(page)
 

--- a/e2e/e2e/playwright/tests/blocks/block-liquid-nesting.spec.js
+++ b/e2e/e2e/playwright/tests/blocks/block-liquid-nesting.spec.js
@@ -1,0 +1,130 @@
+import { test, expect } from '../../test-support/setupAuth'
+import { awaitBlockDebounce, syncLV } from '../../utils'
+
+async function createModule(page, name, code) {
+  const response = await page.request.post('/__e2e/db/factory', {
+    data: {
+      schema: 'Brando.Content.Module',
+      creator_id: 1,
+      fields: ['id'],
+      attributes: {
+        name: { en: name, no: name },
+        namespace: { en: 'LIQUID NESTING', no: 'LIQUID NESTING' },
+        help_text: { en: 'Liquid preview regression' },
+        class: 'liquid-nesting',
+        type: 'liquid',
+        code,
+        multi: false,
+        datasource: false,
+        refs: [{
+          name: 'heading',
+          description: 'Heading',
+          data: { type: 'header', data: { text: 'Original heading', level: 2 } },
+        }],
+        vars: [{
+          type: 'string', key: 'caption', label: 'Caption', value: 'Original caption',
+          placement: 'content', width: 'full',
+        }],
+      },
+    },
+  })
+  expect(response.ok(), await response.text()).toBeTruthy()
+}
+
+async function addModule(page, name) {
+  await page.getByRole('button', { name: 'Add block', exact: true }).last().click()
+  await page.getByRole('navigation', { name: 'Module groups' })
+    .getByRole('button', { name: /^LIQUID NESTING\b/ }).click()
+  await page.getByRole('button', { name, exact: true }).click()
+  await syncLV(page)
+}
+
+test('nested Liquid regions keep following blocks in their container after patches and save', async ({ page }) => {
+  const errors = []
+  page.on('pageerror', error => errors.push(error.message))
+  page.on('console', message => {
+    if (message.type() === 'error') errors.push(message.text())
+  })
+
+  await createModule(page, 'Nested regions', `
+    <article data-liquid-test="nested">
+      {% ref refs.heading %}{{ caption }}
+      {% if true %}<div>{% if true %}<span>hidden if</span>{% endif %}</div>{% endif %}
+      {% for row in rows %}<div>{% for col in row.cols %}<span>hidden loop</span>{% endfor %}</div>{% endfor %}
+      {% unless false %}<div>{% unless false %}<span>hidden unless</span>{% endunless %}</div>{% endunless %}
+      {% hide %}<div>{% hide %}<span>hidden hide</span>{% endhide %}</div>{% endhide %}
+    </article>
+  `)
+  await createModule(page, 'Following block', '<article data-liquid-test="following">{% ref refs.heading %}{{ caption }}</article>')
+
+  await page.goto('/admin/pages/create')
+  await syncLV(page)
+  await page.getByLabel('Title', { exact: true }).fill('Nested Liquid regions')
+  await page.getByLabel('URI', { exact: true }).fill('nested-liquid-regions')
+  await addModule(page, 'Nested regions')
+  await addModule(page, 'Following block')
+
+  const blocks = page.locator('#block-field-blocks > .entry-block')
+  const nested = blocks.filter({ has: page.locator('[data-liquid-test="nested"]') })
+  const following = blocks.filter({ has: page.locator('[data-liquid-test="following"]') })
+  const assertStructure = async () => {
+    await expect(blocks).toHaveCount(2)
+    await expect(nested).toHaveCount(1)
+    await expect(following).toHaveCount(1)
+    await expect(nested.locator('.entry-block')).toHaveCount(0)
+    await expect(following.locator('.entry-block')).toHaveCount(0)
+    await expect(page.locator('.block-liquex-preview > .alert[role="alert"]')).toHaveCount(0)
+    await expect(nested.locator('.block-liquex-preview')).not.toContainText('hidden')
+    await expect(page.locator('#block-field-blocks')).not.toContainText(/\{%\s*end(?:if|for|unless|hide)/)
+  }
+
+  await assertStructure()
+  await nested.locator('.header-block textarea').fill('Nested heading edited')
+  await awaitBlockDebounce(page)
+  await nested.getByLabel('Caption', { exact: true }).fill('Nested caption edited')
+  await awaitBlockDebounce(page)
+  await following.locator('.header-block textarea').fill('Following heading edited')
+  await awaitBlockDebounce(page)
+  await following.getByLabel('Caption', { exact: true }).fill('Following caption edited')
+  await awaitBlockDebounce(page)
+  await assertStructure()
+
+  await page.getByTestId('submit').click()
+  await expect(page).toHaveURL(/\/admin\/pages$/)
+  await page.getByRole('link', { name: 'Nested Liquid regions', exact: true }).click()
+  await syncLV(page)
+  await assertStructure()
+  await expect(nested.locator('.header-block textarea')).toHaveValue('Nested heading edited')
+  await expect(following.locator('.header-block textarea')).toHaveValue('Following heading edited')
+  await expect(nested.getByLabel('Caption', { exact: true })).toHaveValue('Nested caption edited')
+  await expect(following.getByLabel('Caption', { exact: true })).toHaveValue('Following caption edited')
+  await expect(nested.locator('.rendered-variable')).toHaveText('Nested caption edited')
+  await expect(following.locator('.rendered-variable')).toHaveText('Following caption edited')
+  expect(errors.filter(message => /stream container|phx-update|LiveView/i.test(message))).toEqual([])
+})
+
+test('a malformed template keeps unsaved ref controls editable', async ({ page }, testInfo) => {
+  await createModule(page, 'Incomplete region', '<article>{% ref refs.heading %}{% if true %}<div>unfinished')
+  await page.goto('/admin/pages/create')
+  await syncLV(page)
+  await page.getByLabel('Title', { exact: true }).fill('Incomplete Liquid region')
+  await page.getByLabel('URI', { exact: true }).fill('incomplete-liquid-region')
+  await addModule(page, 'Incomplete region')
+
+  const block = page.locator('#block-field-blocks > .entry-block')
+  const preview = block.locator('.block-liquex-preview')
+  await expect(preview.locator(':scope > .alert[role="alert"]')).toContainText('The module preview is unavailable')
+  await expect(preview.locator('article')).toHaveCount(0)
+  await expect(preview.locator('.header-block textarea')).toHaveValue('Original heading')
+  await preview.locator('.header-block textarea').fill('Keep this unsaved heading')
+  await awaitBlockDebounce(page)
+  await block.getByLabel('Caption', { exact: true }).fill('Trigger another patch')
+  await awaitBlockDebounce(page)
+  await expect(preview.locator('.header-block textarea')).toHaveValue('Keep this unsaved heading')
+  await expect(block).toHaveCount(1)
+
+  await page.setViewportSize({ width: 1440, height: 1000 })
+  await block.screenshot({ path: testInfo.outputPath('liquid-preview-error-desktop.png') })
+  await page.setViewportSize({ width: 390, height: 844 })
+  await block.screenshot({ path: testInfo.outputPath('liquid-preview-error-mobile.png') })
+})

--- a/e2e/e2e/playwright/tests/modal-design.spec.js
+++ b/e2e/e2e/playwright/tests/modal-design.spec.js
@@ -10,8 +10,7 @@ async function fixture(page, schema, attributes) {
 }
 
 async function linkDestination(page, clientId) {
-  // Create a routable destination after the application has loaded its router.
-  // Legacy datasource seeds can contain a missing-route diagnostic as their URL.
+  // Give this test a distinct routable destination alongside the shared seeds.
   const client = clientId ? { id: clientId } : await fixture(page, 'E2eProject.Projects.Client', { name: 'Link client', slug: 'link-client', status: 'published', language: 'en' })
   return fixture(page, 'E2eProject.Projects.Project', { title: 'Linked Project Alpha', slug: 'linked-project-alpha', introduction: '<p>Link destination.</p>', client_id: client.id, status: 'published', language: 'en' })
 }
@@ -66,7 +65,7 @@ test('link picker aligns metadata and keeps the selected content through parent 
   await modal.getByLabel('Content', { exact: true }).check()
   await modal.getByRole('button', { name: /All content/ }).click()
   await expect(modal.getByRole('button', { name: /All content/ })).toHaveAttribute('aria-pressed', 'true')
-  await modal.locator('.identifier-picker-results input').fill('alpha')
+  await modal.locator('.identifier-picker-results input').fill('linked project')
   await expect(modal.locator('.identifier-options .identifier:visible')).toHaveCount(1)
   await expect(modal.locator('[id$="-result-count"]')).toHaveText('1')
   await modal.getByLabel('Link text', { exact: true }).fill('Pending link text')

--- a/e2e/e2e/playwright/tests/pages/permalink.spec.js
+++ b/e2e/e2e/playwright/tests/pages/permalink.spec.js
@@ -73,6 +73,7 @@ test('dismissal continues editing and uses the saved URL for the next change', a
 test('escape dismisses the prompt and completes Save and create new', async ({ page }) => {
   await createPage(page)
   const dialog = await changeUrl(page, 'our-studio', 'new')
+  await expect.poll(() => dialog.evaluate(el => el.contains(document.activeElement))).toBe(true)
   await page.keyboard.press('Escape')
   await expect(dialog).not.toBeVisible()
   await expect(page).toHaveURL(/\/admin\/pages\/create$/)

--- a/e2e/priv/repo/e2e_seeds.exs
+++ b/e2e/priv/repo/e2e_seeds.exs
@@ -381,6 +381,10 @@ end
 |> E2eProject.Repo.insert!()
 
 # Create test projects for datasource selection and their identifiers
+# Seeding runs before any request loads the route helpers. The localized URL
+# resolver checks exported functions, so load the helpers before building URLs.
+Code.ensure_loaded!(E2eProjectWeb.Router.Helpers)
+
 project1 =
   %E2eProject.Projects.Project{
     title: "Test Project Alpha",

--- a/lib/brando_admin/components/form/block.ex
+++ b/lib/brando_admin/components/form/block.ex
@@ -47,6 +47,7 @@ defmodule BrandoAdmin.Components.Form.Block do
   alias Brando.Content.BlockSlots
   alias Brando.Content.BlockSlots.Lifecycle, as: CollectionLifecycle
   alias BrandoAdmin.Components.Form.Block.Events
+  alias BrandoAdmin.Components.Form.Block.LiquidPreview
   alias BrandoAdmin.Components.Form.BlockField
   alias BrandoAdmin.Components.Form.BlockField.Ops
   alias Ecto.Changeset
@@ -1615,11 +1616,6 @@ defmodule BrandoAdmin.Components.Form.Block do
     if block_initialized do
       socket
     else
-      module_code =
-        module_code
-        |> liquid_strip_logic()
-        |> emphasize_datasources(assigns)
-
       belongs_to = socket.assigns.belongs_to
       changeset = socket.assigns.form.source
       entry = socket.assigns.entry
@@ -1636,39 +1632,47 @@ defmodule BrandoAdmin.Components.Form.Block do
         end
 
       splits =
-        ~r/{% (?:ref|headless_ref) refs.(\w+) %}|<.*?>|\{\{\s?(.*?)\s?\}\}|{% picture ([a-zA-Z0-9_.?|"-]+) {.*} %}/
-        |> Regex.split(module_code, include_captures: true)
-        |> Enum.map(fn chunk ->
-          case Regex.run(
-                 ~r/^{% (?:ref|headless_ref) refs.(?<ref>\w+) %}$|^{{ (?<content>[\w\s.|\"\']+) }}$|^{% picture (?<picture>[a-zA-Z0-9_.?|"-]+) {.*} %}$/,
-                 chunk,
-                 capture: :all_names
-               ) do
-            nil ->
-              chunk
+        case LiquidPreview.strip_logic(module_code) do
+          {:ok, module_code} ->
+            module_code = emphasize_datasources(module_code, assigns)
 
-            ["content", "", ""] ->
-              {:content, "content"}
+            ~r/{% (?:ref|headless_ref) refs.(\w+) %}|<.*?>|\{\{\s?(.*?)\s?\}\}|{% picture ([a-zA-Z0-9_.?|"-]+) {.*} %}/
+            |> Regex.split(module_code, include_captures: true)
+            |> Enum.map(fn chunk ->
+              case Regex.run(
+                     ~r/^{% (?:ref|headless_ref) refs.(?<ref>\w+) %}$|^{{ (?<content>[\w\s.|\"\']+) }}$|^{% picture (?<picture>[a-zA-Z0-9_.?|"-]+) {.*} %}$/,
+                     chunk,
+                     capture: :all_names
+                   ) do
+                nil ->
+                  chunk
 
-            ["content | renderless", "", ""] ->
-              {:content, "content"}
+                ["content", "", ""] ->
+                  {:content, "content"}
 
-            ["entry." <> variable, "", ""] ->
-              {:entry_variable, variable, liquid_render_entry_variable(variable, entry)}
+                ["content | renderless", "", ""] ->
+                  {:content, "content"}
 
-            [module_variable, "", ""] ->
-              {:module_variable, module_variable, liquid_render_module_variable(module_variable, vars)}
+                ["entry." <> variable, "", ""] ->
+                  {:entry_variable, variable, liquid_render_entry_variable(variable, entry)}
 
-            ["", "entry." <> pic = pic_var, ""] ->
-              {:entry_picture, pic_var, liquid_render_entry_picture_src(pic, socket.assigns)}
+                [module_variable, "", ""] ->
+                  {:module_variable, module_variable, liquid_render_module_variable(module_variable, vars)}
 
-            ["", pic, ""] ->
-              {:module_picture, pic, liquid_render_module_picture_src(pic, vars)}
+                ["", "entry." <> pic = pic_var, ""] ->
+                  {:entry_picture, pic_var, liquid_render_entry_picture_src(pic, socket.assigns)}
 
-            ["", "", ref] ->
-              {:ref, ref}
-          end
-        end)
+                ["", pic, ""] ->
+                  {:module_picture, pic, liquid_render_module_picture_src(pic, vars)}
+
+                ["", "", ref] ->
+                  {:ref, ref}
+              end
+            end)
+
+          {:error, reason} ->
+            [{:liquid_error, reason}]
+        end
 
       socket
       |> assign(:liquid_splits, splits)
@@ -2668,14 +2672,6 @@ defmodule BrandoAdmin.Components.Form.Block do
          #{gettext("Content from datasource will be inserted here")}
       </div>
       """
-    )
-  end
-
-  defp liquid_strip_logic(module_code) do
-    Regex.replace(
-      ~r/(({% hide %}(?:.*?){% endhide %}))|((?:{%(?:-)? for (\w+) in [a-zA-Z0-9_.?|"-]+ (?:-)?%})(?:.*?)(?:{%(?:-)? endfor (?:-)?%}))|(<img.*?src="{{(?:-)? .*? (?:-)?}}".*?>)|({%(?:-)? assign .*? (?:-)?%})|(((?:{%(?:-)? if .*? (?:-)?%})(?:.*?)(?:{%(?:-)? endif (?:-)?%})))|(((?:{%(?:-)? unless .*? (?:-)?%})(?:.*?)(?:{%(?:-)? endunless (?:-)?%})))|(data-moonwalk-run(?:="\w+")|data-moonwalk-run|data-moonwalk-section(?:="\w+")|data-moonwalk-section|href(?:="[a-zA-Z0-9{}|._\s]+")|id(?:="{{[a-zA-Z0-9{}._\s]+}}"))/s,
-      module_code,
-      ""
     )
   end
 

--- a/lib/brando_admin/components/form/block/liquid_preview.ex
+++ b/lib/brando_admin/components/form/block/liquid_preview.ex
@@ -36,7 +36,7 @@ defmodule BrandoAdmin.Components.Form.Block.LiquidPreview do
         finish(code, stack, acc)
 
       {offset, _length} ->
-        <<text::binary-size(offset), remaining::binary>> = code
+        {text, remaining} = :erlang.split_binary(code, offset)
         acc = keep(text, stack, acc)
 
         with {:ok, name, token, rest} <- take_token(remaining) do
@@ -47,7 +47,7 @@ defmodule BrandoAdmin.Components.Form.Block.LiquidPreview do
 
   defp scan_token(name, token, rest, stack, acc) when name in ["raw", "comment"] do
     with {:ok, size} <- opaque_length(rest, name) do
-      <<body::binary-size(size), remaining::binary>> = rest
+      {body, remaining} = :erlang.split_binary(rest, size)
       scan(remaining, stack, keep([token, body], stack, acc))
     end
   end
@@ -82,7 +82,7 @@ defmodule BrandoAdmin.Components.Form.Block.LiquidPreview do
         {:error, {:unclosed_tag, "comment"}}
 
       {offset, _} ->
-        <<_text::binary-size(offset), remaining::binary>> = code
+        {_text, remaining} = :erlang.split_binary(code, offset)
 
         with {:ok, name, token, rest} <- take_token(remaining) do
           length = length + offset + byte_size(token)
@@ -93,7 +93,7 @@ defmodule BrandoAdmin.Components.Form.Block.LiquidPreview do
 
             name when name in ["raw", "comment"] ->
               with {:ok, size} <- opaque_length(rest, name) do
-                <<_body::binary-size(size), tail::binary>> = rest
+                {_body, tail} = :erlang.split_binary(rest, size)
                 comment_length(tail, length + size)
               end
 
@@ -138,7 +138,7 @@ defmodule BrandoAdmin.Components.Form.Block.LiquidPreview do
 
   defp extract_token(code, name, {:ok, length}) do
     size = length + 2
-    <<token::binary-size(size), rest::binary>> = code
+    {token, rest} = :erlang.split_binary(code, size)
     {:ok, name, token, rest}
   end
 

--- a/lib/brando_admin/components/form/block/liquid_preview.ex
+++ b/lib/brando_admin/components/form/block/liquid_preview.ex
@@ -1,0 +1,169 @@
+defmodule BrandoAdmin.Components.Form.Block.LiquidPreview do
+  @moduledoc false
+
+  @regions ~w(if unless for hide)
+  @end_tags Map.new(@regions, &{"end" <> &1, &1})
+  @tag_name ~r/\A{%-?\s*(\w+|#)/
+  @end_raw ~r/{%-?\s*endraw\s*-?%}/
+
+  # These non-Liquid substitutions retain the editor's existing behavior.
+  @cleanup ~r/(<img.*?src="{{(?:-)? .*? (?:-)?}}".*?>)|(data-moonwalk-run(?:="\w+")|data-moonwalk-run|data-moonwalk-section(?:="\w+")|data-moonwalk-section|href(?:="[a-zA-Z0-9{}|._\s]+")|id(?:="{{[a-zA-Z0-9{}._\s]+}}"))/s
+
+  @type error ::
+          {:unclosed_tag, String.t()}
+          | {:unexpected_end, String.t()}
+          | {:mismatched_end, String.t(), String.t()}
+          | :unterminated_tag
+          | :unterminated_output
+
+  @doc """
+  Removes complete editor-hidden Liquid regions without evaluating expressions.
+
+  Source outside those regions is preserved until the existing HTML cleanup pass.
+  Quoted strings, output tokens, and raw/comment bodies cannot change the region
+  stack. Malformed boundaries return an error, never partially stripped HTML.
+  """
+  @spec strip_logic(String.t()) :: {:ok, String.t()} | {:error, error()}
+  def strip_logic(code) do
+    with {:ok, stripped} <- scan(code, [], []) do
+      {:ok, Regex.replace(@cleanup, stripped, "")}
+    end
+  end
+
+  defp scan(code, stack, acc) do
+    case :binary.match(code, ["{%", "{{"]) do
+      :nomatch ->
+        finish(code, stack, acc)
+
+      {offset, _length} ->
+        <<text::binary-size(offset), remaining::binary>> = code
+        acc = keep(text, stack, acc)
+
+        with {:ok, name, token, rest} <- take_token(remaining) do
+          scan_token(name, token, rest, stack, acc)
+        end
+    end
+  end
+
+  defp scan_token(name, token, rest, stack, acc) when name in ["raw", "comment"] do
+    with {:ok, size} <- opaque_length(rest, name) do
+      <<body::binary-size(size), remaining::binary>> = rest
+      scan(remaining, stack, keep([token, body], stack, acc))
+    end
+  end
+
+  defp scan_token(name, _token, rest, stack, acc) when name in @regions do
+    scan(rest, [name | stack], acc)
+  end
+
+  defp scan_token(name, token, rest, stack, acc) do
+    case Map.fetch(@end_tags, name) do
+      {:ok, opening} -> close_region(name, opening, rest, stack, acc)
+      :error when name == "assign" -> scan(rest, stack, acc)
+      :error -> scan(rest, stack, keep(token, stack, acc))
+    end
+  end
+
+  # Raw ends at its first closing marker, even when its contents are not Liquid.
+  defp opaque_length(code, "raw") do
+    case Regex.run(@end_raw, code, return: :index) do
+      [{offset, length}] -> {:ok, offset + length}
+      nil -> {:error, {:unclosed_tag, "raw"}}
+    end
+  end
+
+  defp opaque_length(code, "comment"), do: comment_length(code, 0)
+
+  # Comments can contain other comments and raw regions. Their tokens must not
+  # affect the surrounding if/for/hide stack, including after an inner comment.
+  defp comment_length(code, length) do
+    case :binary.match(code, ["{%", "{{"]) do
+      :nomatch ->
+        {:error, {:unclosed_tag, "comment"}}
+
+      {offset, _} ->
+        <<_text::binary-size(offset), remaining::binary>> = code
+
+        with {:ok, name, token, rest} <- take_token(remaining) do
+          length = length + offset + byte_size(token)
+
+          case name do
+            "endcomment" ->
+              {:ok, length}
+
+            name when name in ["raw", "comment"] ->
+              with {:ok, size} <- opaque_length(rest, name) do
+                <<_body::binary-size(size), tail::binary>> = rest
+                comment_length(tail, length + size)
+              end
+
+            _ ->
+              comment_length(rest, length)
+          end
+        end
+    end
+  end
+
+  defp close_region(_name, opening, rest, [opening | stack], acc), do: scan(rest, stack, acc)
+  defp close_region(name, _opening, _rest, [], _acc), do: {:error, {:unexpected_end, name}}
+
+  defp close_region(name, _opening, _rest, [expected | _], _acc) do
+    {:error, {:mismatched_end, "end" <> expected, name}}
+  end
+
+  defp take_token("{%" <> body = code) do
+    name =
+      case Regex.run(@tag_name, code, capture: :all_but_first) do
+        [name] -> name
+        nil -> nil
+      end
+
+    # Inline comments also allow unmatched quotes in their contents.
+    length =
+      if name == "#" do
+        case :binary.match(body, "%}") do
+          {offset, 2} -> {:ok, offset + 2}
+          :nomatch -> {:error, :unterminated_tag}
+        end
+      else
+        token_length(body, :tag, nil, 0)
+      end
+
+    extract_token(code, name, length)
+  end
+
+  defp take_token("{{" <> body = code) do
+    extract_token(code, nil, token_length(body, :output, nil, 0))
+  end
+
+  defp extract_token(code, name, {:ok, length}) do
+    size = length + 2
+    <<token::binary-size(size), rest::binary>> = code
+    {:ok, name, token, rest}
+  end
+
+  defp extract_token(_code, _name, {:error, _} = error), do: error
+
+  defp token_length("", :tag, _quote, _length), do: {:error, :unterminated_tag}
+  defp token_length("", :output, _quote, _length), do: {:error, :unterminated_output}
+  defp token_length("%}" <> _rest, :tag, nil, length), do: {:ok, length + 2}
+  defp token_length("}}" <> _rest, :output, nil, length), do: {:ok, length + 2}
+
+  defp token_length(<<quote, rest::binary>>, kind, nil, length) when quote in [?", ?'] do
+    token_length(rest, kind, quote, length + 1)
+  end
+
+  defp token_length(<<quote, rest::binary>>, kind, quote, length) do
+    token_length(rest, kind, nil, length + 1)
+  end
+
+  defp token_length(<<_byte, rest::binary>>, kind, quote, length) do
+    token_length(rest, kind, quote, length + 1)
+  end
+
+  defp keep(text, [], acc), do: [text | acc]
+  defp keep(_text, _stack, acc), do: acc
+
+  defp finish(code, [], acc), do: {:ok, IO.iodata_to_binary(Enum.reverse([code | acc]))}
+  defp finish(_code, [name | _], _acc), do: {:error, {:unclosed_tag, name}}
+end

--- a/lib/brando_admin/components/form/block/render.ex
+++ b/lib/brando_admin/components/form/block/render.ex
@@ -1058,7 +1058,23 @@ defmodule BrandoAdmin.Components.Form.Block.Render do
   end
 
   def module_content(assigns) do
-    assigns = assign(assigns, :footnote_refs, footnote_ref_names(assigns.block_form.source))
+    # On a malformed template, render the actual ref controls without template
+    # HTML. Resolve from the current form so newly added, unsaved refs retain
+    # their inputs too; identity-only carried_refs cannot preserve their data.
+    liquid_splits =
+      case assigns.liquid_splits do
+        [{:liquid_error, _reason} = error] ->
+          refs = Changeset.get_assoc(assigns.block_form.source, :refs, :struct)
+          [error | Enum.map(refs, &{:ref, &1.name})]
+
+        splits ->
+          splits
+      end
+
+    assigns =
+      assigns
+      |> assign(:footnote_refs, footnote_ref_names(assigns.block_form.source))
+      |> assign(:liquid_splits, liquid_splits)
 
     ~H"""
     <div class="block-content">
@@ -1094,6 +1110,12 @@ defmodule BrandoAdmin.Components.Form.Block.Render do
         <div class="block-liquex-preview">
           <%= for split <- @liquid_splits do %>
             <%= case split do %>
+              <% {:liquid_error, _reason} -> %>
+                <div class="alert danger" role="alert">
+                  {gettext(
+                    "The module preview is unavailable because its Liquid tags are incomplete or mismatched. Check the module template. You can still edit the fields below."
+                  )}
+                </div>
               <% {:ref, ref} -> %>
                 <.ref
                   refs_field={@block_form[:refs]}
@@ -1452,7 +1474,7 @@ defmodule BrandoAdmin.Components.Form.Block.Render do
   @doc """
   Hidden identity inputs for refs the module code does not render.
 
-  `liquid_strip_logic/1` removes `{% if %}` / `{% for %}` / `{% hide %}` regions
+  `LiquidPreview.strip_logic/1` removes `{% if %}` / `{% for %}` / `{% hide %}` regions
   before the code is split into ref slots, so a `{% ref refs.x %}` inside one
   produces no inputs at all. `refs` is `on_replace: :delete_if_exists`, so once
   *any* ref renders, the params carry a shortened list and `cast_assoc(:refs)`

--- a/test/brando/content/conditional_refs_test.exs
+++ b/test/brando/content/conditional_refs_test.exs
@@ -2,7 +2,7 @@ defmodule Brando.Content.ConditionalRefsTest do
   # B5 verification — are refs inside `{% if %}` / `{% for %}` regions deleted
   # on the first keystroke?
   #
-  # `liquid_strip_logic/1` (block.ex) removes those regions from the module code
+  # `LiquidPreview.strip_logic/1` removes those regions from the module code
   # before the editor splits it into ref slots, so no inputs render for a ref
   # that lives inside one. `refs` is `on_replace: :delete_if_exists`, so the
   # question is what `cast_assoc(:refs)` does when params list a subset.
@@ -13,6 +13,8 @@ defmodule Brando.Content.ConditionalRefsTest do
 
   alias Brando.Content.Block
   alias Brando.Factory
+  alias Brando.Villain.Blocks.HeaderBlock
+  alias BrandoAdmin.Components.Form.Block.Render
   alias Ecto.Changeset
 
   setup do
@@ -145,6 +147,64 @@ defmodule Brando.Content.ConditionalRefsTest do
         &BrandoAdmin.Components.Form.Block.Render.carried_refs/1,
         refs_field: Phoenix.Component.to_form(changeset, as: "block")[:refs],
         liquid_splits: splits
+      )
+    end
+  end
+
+  describe "malformed Liquid preview" do
+    test "renders every persisted ref without duplicating carried identity inputs", %{block: block} do
+      html = render_failed_preview(Changeset.change(block))
+      document = Floki.parse_fragment!(html)
+
+      assert html =~ "The module preview is unavailable"
+
+      for name <- ["visible", "conditional"] do
+        assert length(Floki.find(document, ~s(section[b-ref="#{name}"]))) == 1
+      end
+
+      for index <- [0, 1] do
+        assert length(Floki.find(document, ~s(input[name="block[refs][#{index}][id]"]))) == 1
+      end
+
+      assert Floki.find(document, ".block-carried-refs input") == []
+    end
+
+    test "new refs added to the current form retain their editable data", %{block: block} do
+      changeset = Changeset.change(block)
+      # The same cached error is used before and after a new ref is added.
+      refute render_failed_preview(changeset) =~ ~s(b-ref="fresh")
+
+      new_ref =
+        Changeset.change(%Brando.Content.Ref{
+          name: "fresh",
+          uid: "freshheader",
+          description: "A new heading",
+          data: %HeaderBlock{type: "header", data: %HeaderBlock.Data{text: "Unsaved heading", level: 2}}
+        })
+
+      updated = Changeset.put_assoc(changeset, :refs, Changeset.get_assoc(changeset, :refs) ++ [new_ref])
+      document = updated |> render_failed_preview() |> Floki.parse_fragment!()
+
+      assert document |> Floki.find(~s(section[b-ref="fresh"] textarea)) |> Floki.text() |> String.trim() ==
+               "Unsaved heading"
+
+      assert Floki.find(document, ~s(input[name="block[refs][2][name]"][value="fresh"])) != []
+      assert Floki.find(document, ~s(input[name="block[refs][2][uid]"][value="freshheader"])) != []
+      assert Floki.find(document, ".block-carried-refs input") == []
+    end
+
+    defp render_failed_preview(changeset) do
+      render_component(&Render.module_content/1,
+        block_form: Phoenix.Component.to_form(changeset, as: "block"),
+        liquid_splits: [{:liquid_error, {:unclosed_tag, "if"}}],
+        module_class: "failed-preview",
+        uid: "failedpreview",
+        is_datasource?: false,
+        has_table_template?: false,
+        target: nil,
+        target_ref: nil,
+        form_id: "page-form",
+        config_open: false
       )
     end
   end

--- a/test/brando_admin/components/form/block/liquid_preview_test.exs
+++ b/test/brando_admin/components/form/block/liquid_preview_test.exs
@@ -1,0 +1,174 @@
+defmodule BrandoAdmin.Components.Form.Block.LiquidPreviewTest do
+  use ExUnit.Case, async: true
+
+  alias BrandoAdmin.Components.Form.Block.LiquidPreview
+
+  @regions [
+    {"if", "if visible", "endif"},
+    {"unless", "unless hidden", "endunless"},
+    {"for", "for item in items", "endfor"},
+    {"hide", "hide", "endhide"}
+  ]
+
+  for {name, opening, closing} <- @regions do
+    test "strips nested #{name} regions through the outer closing tag" do
+      open = "{% #{unquote(opening)} %}"
+      close = "{% #{unquote(closing)} %}"
+
+      code =
+        "<article>{% ref refs.text %}" <>
+          open <> "<div>" <> open <> "<span>hidden</span>" <> close <> "</div>" <> close <> "</article>"
+
+      assert LiquidPreview.strip_logic(code) == {:ok, "<article>{% ref refs.text %}</article>"}
+    end
+
+    test "recognizes whitespace and trim markers for #{name}" do
+      open = "{%-\n\t#{unquote(opening)}\t-%}"
+      close = "{%\t#{unquote(closing)}\n%}"
+
+      assert LiquidPreview.strip_logic("before " <> open <> open <> "hidden" <> close <> close <> " after") ==
+               {:ok, "before  after"}
+    end
+  end
+
+  test "strips every pairing of region types without removing adjacent content" do
+    for {_, outer, outer_end} <- @regions, {_, inner, inner_end} <- @regions do
+      code = "a{% #{outer} %}<div>{% #{inner} %}<p>hidden</p>{% #{inner_end} %}</div>{% #{outer_end} %}b"
+      assert LiquidPreview.strip_logic(code) == {:ok, "ab"}
+    end
+  end
+
+  test "handles deeper nesting and preserves content between sequential regions" do
+    code = """
+    <section>
+    {% if a %}<div>{% if b %}<div>{% if c %}<div>hidden</div>{% endif %}</div>{% endif %}</div>{% endif %}
+    {% headless_ref refs.title %}
+    {% if d %}<p>hidden</p>{% endif %}
+    <p>Visible</p>
+    </section>
+    """
+
+    assert LiquidPreview.strip_logic(code) ==
+             {:ok, "<section>\n\n{% headless_ref refs.title %}\n\n<p>Visible</p>\n</section>\n"}
+  end
+
+  test "strips all branches of nested conditionals and loop fallbacks" do
+    code = """
+    {% if a %}a{% elsif b %}{% unless c %}c{% else %}d{% endunless %}{% else %}e{% endif %}
+    {% for item in items %}{% if item.active %}item{% endif %}{% else %}empty{% endfor %}
+    """
+
+    assert LiquidPreview.strip_logic(code) == {:ok, "\n\n"}
+  end
+
+  test "recognizes loop arguments without parsing their expressions" do
+    for expression <- ["rows limit: 2", "rows offset: 1 reversed", "(1..3)", "data['rows']"] do
+      code =
+        "<main>{% for row in #{expression} %}<div>{% for col in row.cols limit: 2 %}col{% endfor %}</div>{% endfor %}</main>"
+
+      assert LiquidPreview.strip_logic(code) == {:ok, "<main></main>"}
+    end
+  end
+
+  test "strips conditional attributes while preserving the surrounding element" do
+    code = ~s(<div class="card"{% if a %} data-a{% if b %} data-b{% endif %}{% endif %}>body</div>)
+    assert LiquidPreview.strip_logic(code) == {:ok, ~s(<div class="card">body</div>)}
+  end
+
+  test "preserves top-level refs, content, pictures, variables and Unicode source" do
+    code = """
+    <article class="blå">Æøå — 日本語
+    {% ref refs.text %}{% headless_ref refs.image %}
+    {{ entry.title }}{{ content | renderless }}
+    {% picture image { sizes: 'auto' } %}
+    {% datasource %}source{% enddatasource %}
+    </article>
+    """
+
+    assert LiquidPreview.strip_logic(code) == {:ok, code}
+    assert LiquidPreview.strip_logic("") == {:ok, ""}
+  end
+
+  test "refs inside stripped regions remain stripped" do
+    assert LiquidPreview.strip_logic("{% if a %}{% ref refs.hidden %}{% endif %}{% ref refs.visible %}") ==
+             {:ok, "{% ref refs.visible %}"}
+  end
+
+  test "quoted tag names and delimiters cannot close a region" do
+    code =
+      ~S(<article>{% if a %}<div>{% assign label = "%} {% endif %}" %}{{ '}} {% endif %}' }}</div>{% endif %}</article>)
+
+    assert LiquidPreview.strip_logic(code) == {:ok, "<article></article>"}
+  end
+
+  test "quoted opening tags cannot start a region" do
+    code = ~S({% assign label = "{% if a %}" %}{{ '{% if a %}' }}{% ref refs.text %})
+    assert LiquidPreview.strip_logic(code) == {:ok, ~S({{ '{% if a %}' }}{% ref refs.text %})}
+  end
+
+  test "backslashes retain Liquex's literal string semantics" do
+    assert LiquidPreview.strip_logic(~S({% assign path = 'folder\' %}kept)) == {:ok, "kept"}
+  end
+
+  test "assigns are removed as complete tokens including trim markers" do
+    code = ~S(before{%- assign label = '%} literal' -%}after)
+    assert LiquidPreview.strip_logic(code) == {:ok, "beforeafter"}
+  end
+
+  for name <- ["raw", "comment"] do
+    test "ignores tag-like content and unmatched quotes in #{name} bodies" do
+      opaque = "{%- #{unquote(name)} -%}{% endif %}{% if fake %}an unmatched ' quote{% end#{unquote(name)} %}"
+
+      assert LiquidPreview.strip_logic("{% if a %}<div>" <> opaque <> "</div>{% endif %}kept") == {:ok, "kept"}
+      assert LiquidPreview.strip_logic(opaque <> "{% if a %}hidden{% endif %}") == {:ok, opaque}
+    end
+  end
+
+  test "inline comments may contain unmatched quotes and opening tag text" do
+    code = ~S({% # don't treat {% if fake as an opener %}<p>kept</p>)
+    assert LiquidPreview.strip_logic(code) == {:ok, code}
+  end
+
+  test "nested comments and raw regions cannot expose comment contents to the region stack" do
+    comment = """
+    {% comment %}
+      {% if b %}{% comment %}inner{% endcomment %}{% endif %}
+      {% raw %}{% endcomment %}{% if fake %}{{ 'unfinished{% endraw %}
+    {% endcomment %}
+    """
+
+    assert LiquidPreview.strip_logic("{% if a %}<div>" <> comment <> "</div>{% endif %}kept") == {:ok, "kept"}
+    assert LiquidPreview.strip_logic(comment) == {:ok, comment}
+  end
+
+  test "retains the existing image and attribute cleanup" do
+    code =
+      ~S(<div data-moonwalk-run="once" data-moonwalk-section id="{{ entry.id }}"><a href="{{ url }}">link</a><img src="{{ image }}"><img src="/static.png"></div>)
+
+    assert LiquidPreview.strip_logic(code) ==
+             {:ok, ~S(<div   ><a >link</a><img src="/static.png"></div>)}
+  end
+
+  test "unclosed regions return an error instead of partial markup" do
+    for {name, opening, _} <- @regions do
+      assert LiquidPreview.strip_logic("<article>{% #{opening} %}<div>incomplete</article>") ==
+               {:error, {:unclosed_tag, name}}
+    end
+  end
+
+  test "unexpected and mismatched closing tags return an error" do
+    assert LiquidPreview.strip_logic("<article>{% endif %}</article>") == {:error, {:unexpected_end, "endif"}}
+
+    assert LiquidPreview.strip_logic("{% if a %}{% for row in rows %}{% endif %}{% endfor %}") ==
+             {:error, {:mismatched_end, "endfor", "endif"}}
+  end
+
+  test "unterminated tokens and opaque regions return errors" do
+    assert LiquidPreview.strip_logic("<div>{% if a") == {:error, :unterminated_tag}
+    assert LiquidPreview.strip_logic(~S({% assign a = 'unfinished %})) == {:error, :unterminated_tag}
+    assert LiquidPreview.strip_logic("{{ value") == {:error, :unterminated_output}
+    assert LiquidPreview.strip_logic("{% # unfinished") == {:error, :unterminated_tag}
+    assert LiquidPreview.strip_logic("{% raw %}unfinished") == {:error, {:unclosed_tag, "raw"}}
+    assert LiquidPreview.strip_logic("{% comment %}unfinished") == {:error, {:unclosed_tag, "comment"}}
+  end
+end


### PR DESCRIPTION
Nested Liquid regions can leave orphan closing HTML tags in the block editor, moving following blocks outside their container and breaking LiveView patches. Replace the non-greedy stripping regex with a scanner that matches complete `if`, `unless`, `for`, and `hide` regions by nesting depth.

The scanner respects quoted tokens, trim markers, and raw/comment bodies while retaining the existing image and attribute cleanup. Incomplete or mismatched Liquid boundaries show an inline error and render the current ref controls, preserving unsaved edits instead of inserting partially stripped HTML.

CI also exposed a modal focus bug after saves: LiveView restored focus behind a newly opened dialog, so Escape did not dismiss the permalink prompt. Defer the modal's initial focus until the next browser frame and cancel pending focus when it closes or unmounts.

Repair the existing E2E setup by loading route helpers before generating seeded identifier URLs, and scope two copy/paste selectors to the module-group navigation so `MEDIA` does not also match the `Media attachment` card.

Validation:

- 35 focused unit/component tests passed, covering nested regions, token boundaries, malformed templates, and persisted/unsaved refs.
- Both focused browser regressions passed: block structure and field persistence through edits/save/reopen, plus editable refs after a malformed template.
- All five previously failing CI browser tests passed locally after their fixes. The final modal change also passed the accessibility focus/return, nested-picker Escape, and link-picker design regressions.
- Desktop and mobile fallback screenshots checked.
- Test and E2E compilation passed with warnings treated as errors; E2E consumer asset builds, formatting, and diff checks passed.

The separate stale root-block variable preview discovered during browser testing is tracked in #2797.

Closes #2794.
