### PR TITLE
fix: pin shared previews to an immutable asset set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -502,6 +502,20 @@
 
 #### Fixes
 
+- **Shared preview links no longer break on deploy.** The stored preview HTML
+  links the digested asset names of the build it was rendered with, and the
+  next release removed those files. Sharing now pins the preview to an
+  immutable asset set: the active uploaded set when it is self-contained,
+  otherwise a copy of the release's `priv/static` captured into
+  `site_assets/sets/capture-<identity>` and registered without activation.
+  `Brando.Plug.SiteAssets` serves the content-addressed files of every set an
+  unexpired preview references at their original URLs, and now sends a
+  `content-type` header. `Brando.Assets.SiteAssets.Retention` protects pinned,
+  active, and build-referenced sets from pruning and is the API deployment
+  tooling must use to delete sets. Run the `brando_173_add_asset_set_to_previews`
+  upgrade migration; previews created before it keep the legacy behaviour and
+  must be recreated if already broken.
+
 - Container blocks render without reading a module-only `multi` flag, restoring
   insertion, nested content and copy/paste after the footnote changes.
 

--- a/guides/tenancy_and_environments.md
+++ b/guides/tenancy_and_environments.md
@@ -733,6 +733,68 @@ and deployment configuration at creation time. A later asset activation or
 target edit therefore affects new builds, never an artifact already being
 reviewed or deployed.
 
+### Shared previews pin an asset set
+
+A shared preview link (`/__p__/:preview_key`) stores fully rendered HTML, and
+that markup links the digested stylesheet and script names of the build it was
+rendered with. To keep the link working after a deploy or an activation,
+`Brando.LivePreview.share/5` pins the preview to an immutable asset set before
+rendering, records it in `sites_previews.asset_set_id`, and renders manifest,
+inline critical CSS, and asset URLs from that set even if another set is
+activated in the meantime:
+
+- when the active uploaded set is self-contained (every file its Vite manifest
+  lists is present), the preview reuses it;
+- otherwise Brando captures the effective build into
+  `sets/capture-<identity>`: the release's `priv/static` overlaid with the
+  active set, if any. Files are copied rather than symlinked, the copy is
+  published by an atomic rename from `staging/`, and the identity is derived
+  from the file listing and manifest, so sharing the same release twice reuses
+  one capture. Set `config :brando, :release_static_path` when the release
+  assets live outside the endpoint application's `priv/static`.
+
+`Brando.Plug.SiteAssets` serves a pinned set at the original URLs: after the
+active set misses, it looks the path up in every set an unexpired preview of
+that site still references. Only the content-addressed files a set's manifest
+lists (entries, chunks, CSS, imported fonts and images, plus their source
+maps) are served this way, so an old capture never shadows un-hashed files
+such as `favicon.ico`, and compiled CSS or JavaScript that uses root-relative
+`/assets/...` URLs keeps resolving without any rewriting or build changes.
+Previews created before this feature have no reference and are served as
+before; they cannot be repaired from a later manifest and must be recreated.
+
+A capture failure fails sharing visibly instead of storing a preview tied to
+ephemeral release files. Preview expiry and the frozen unsaved content are
+unchanged.
+
+### Pruning contract
+
+`Brando.Assets.SiteAssets.Retention` owns the deletion decision. A set is
+protected while it is active, while an unexpired preview references it
+(`expires_at` is compared directly, so expired rows the purge worker has not
+removed yet never prolong protection), or while a queued or running static
+build still needs it as its asset source. Deletion runs under the same
+per-scope advisory lock that sharing holds while it captures, renders, and
+saves a preview, so a set cannot disappear underneath a preview acquiring it.
+
+```elixir
+# Ordinary retention: keep the five newest uploaded sets, skip protected ones
+Brando.Assets.SiteAssets.Retention.prune_sets(keep: 5)
+Brando.Assets.SiteAssets.Retention.prune_sets(site, keep: 5)
+
+# Inspect without deleting
+Brando.Assets.SiteAssets.Retention.prunable_sets(site, keep: 5)
+
+# One set; refused with {:error, :asset_set_protected} while in use
+Brando.Assets.SiteAssets.Retention.delete_set(set_id)
+```
+
+Captured sets never count against `:keep` and are removed by the preview purge
+worker once the last preview that needs them has expired. Deployment tooling
+such as Florist must call this API instead of deleting set directories by age
+or count; protected sets may temporarily exceed the configured count. The
+admin assets screen marks sets that are in use by previews or builds.
+
 ## Build and publish static sites
 
 Declare public paths in your application's web SSG module:

--- a/lib/brando/assets/site_assets.ex
+++ b/lib/brando/assets/site_assets.ex
@@ -7,25 +7,37 @@ defmodule Brando.Assets.SiteAssets do
   the complete regular-file listing as a `MapSet` and the optional Vite
   manifest in `:persistent_term`, making non-matching request rejection a
   memory lookup with no filesystem access.
+
+  Shared previews pin the set they were rendered against (see
+  `with_preview_set/2` and `Brando.Assets.SiteAssets.Capture`). A pinned set
+  keeps serving its content-addressed build output at the original URLs until
+  the last preview that references it expires, so a later activation or release
+  cannot break a link that has already been shared. `Brando.Assets.SiteAssets.Retention`
+  owns the pruning rules that protect those sets.
   """
 
   import Ecto.Query, only: [from: 2]
 
+  alias Brando.Assets.SiteAssets.Capture
+  alias Brando.Assets.SiteAssets.Retention
   alias Brando.Assets.SiteAssetSet
   alias Brando.Repo
   alias Brando.Sites.Site
   alias Brando.Tenant
+  alias Brando.Tenant.Lock
   alias Brando.Tenant.Registry
   alias Brando.Tenant.Storage
 
   @public_opts [prefix: "public"]
   @cache_keys_key {:brando, :site_assets, :cache_keys}
+  @override_key {:brando, :site_assets, :override}
 
   @type scope :: Site.t() | nil
   @type cached_set :: %{
           set: SiteAssetSet.t(),
           path: String.t(),
           files: MapSet.t(String.t()),
+          pinned: MapSet.t(String.t()),
           manifest: map() | nil
         }
 
@@ -40,6 +52,10 @@ defmodule Brando.Assets.SiteAssets do
           {:ok, SiteAssetSet.t()} | {:error, term()}
   def register_set(%Site{} = site, path, metadata) when is_binary(path) and is_map(metadata) do
     register(site, path, metadata)
+  end
+
+  def register_set(nil, path, metadata) when is_binary(path) and is_map(metadata) do
+    register(nil, path, metadata)
   end
 
   def register_set(site_key, path, metadata)
@@ -113,6 +129,121 @@ defmodule Brando.Assets.SiteAssets do
     end
   end
 
+  @doc """
+  Returns cached file, pinned-file, and manifest information for any registered
+  set, active or not. The listing is scanned once and kept in `:persistent_term`
+  until `forget_set/1` or `invalidate_cache/0` runs.
+  """
+  @spec set_cache(SiteAssetSet.t()) :: {:ok, cached_set()} | {:error, term()}
+  def set_cache(%SiteAssetSet{id: id} = asset_set) do
+    key = set_cache_key(id)
+
+    case :persistent_term.get(key, :not_cached) do
+      :not_cached ->
+        with {:ok, cached} <- build_cache(asset_set) do
+          store(key, cached)
+          {:ok, cached}
+        end
+
+      cached ->
+        {:ok, cached}
+    end
+  end
+
+  @doc "Drops the runtime caches for one set, including the pinned listing of its scope."
+  @spec forget_set(SiteAssetSet.t()) :: :ok
+  def forget_set(%SiteAssetSet{id: id} = asset_set) do
+    :persistent_term.erase(set_cache_key(id))
+    invalidate_pinned(asset_set)
+  end
+
+  @doc """
+  Resolves the immutable set a shared preview must be pinned to and runs `fun`
+  with that set installed as the process-local asset source.
+
+  The scope's advisory lock is held for the whole call, so pruning cannot
+  remove the set while the preview is being captured, rendered, or saved. The
+  set is the active uploaded set when it is self-contained; otherwise the
+  effective release build is captured into a registered set first. Templates
+  rendered inside `fun` read the pinned manifest and critical CSS even if
+  another set is activated concurrently.
+  """
+  @spec with_preview_set(scope(), (SiteAssetSet.t() -> result)) :: {:ok, result} | {:error, term()}
+        when result: var
+  def with_preview_set(site \\ nil, fun) when is_function(fun, 1) do
+    Lock.with(lock_key(site), fn -> pin_and_run(site, fun) end)
+  end
+
+  defp pin_and_run(site, fun) do
+    with {:ok, asset_set} <- Capture.ensure_set(site),
+         {:ok, cached} <- set_cache(asset_set) do
+      with_override(cached, fn -> fun.(asset_set) end)
+    end
+  end
+
+  @doc "Runs `fun` with `asset_set` as the process-local manifest and file source."
+  @spec with_set(SiteAssetSet.t(), (-> result)) :: {:ok, result} | {:error, term()} when result: var
+  def with_set(%SiteAssetSet{} = asset_set, fun) when is_function(fun, 0) do
+    with {:ok, cached} <- set_cache(asset_set), do: with_override(cached, fun)
+  end
+
+  @doc "Returns the process-local set installed by `with_set/2`, if any."
+  @spec override() :: cached_set() | nil
+  def override, do: Process.get(@override_key)
+
+  @doc """
+  Resolves a request path to a file in the active set or, failing that, in a
+  set pinned by an unexpired shared preview for the same scope. Pinned lookups
+  only cover the content-addressed files listed in a set's Vite manifest, so an
+  old set never shadows un-hashed files such as favicons.
+  """
+  @spec serve_path(scope(), String.t()) :: String.t() | nil
+  def serve_path(site, relative_path) when is_binary(relative_path) do
+    active_file(site, relative_path) || pinned_file(site, relative_path)
+  end
+
+  @doc "Returns cached information for every set still pinned by a preview in the scope."
+  @spec pinned_sets(scope()) :: [cached_set()]
+  def pinned_sets(site \\ nil) do
+    key = pinned_cache_key(scope_key(site))
+
+    case :persistent_term.get(key, :not_cached) do
+      :not_cached -> warm_pinned(site)
+      pinned -> pinned
+    end
+  end
+
+  @doc "Clears the pinned-set listing for a scope so the next request rebuilds it."
+  @spec invalidate_pinned(scope() | SiteAssetSet.t()) :: :ok
+  def invalidate_pinned(scope \\ nil) do
+    :persistent_term.erase(pinned_cache_key(scope_key(scope)))
+    :ok
+  end
+
+  @doc "The advisory-lock key serializing capture, activation-sensitive pinning, and pruning."
+  @spec lock_key(scope() | SiteAssetSet.t()) :: String.t()
+  def lock_key(scope) do
+    case scope_key(scope) do
+      :standalone -> "site-assets:standalone"
+      {:site_id, site_id} -> "site-assets:#{site_id}"
+    end
+  end
+
+  @doc "Lists every output file a Vite manifest references: entries, chunks, CSS, and assets."
+  @spec manifest_files(map() | nil) :: [String.t()]
+  def manifest_files(nil), do: []
+
+  def manifest_files(manifest) when is_map(manifest) do
+    manifest
+    |> Map.values()
+    |> Enum.filter(&is_map/1)
+    |> Enum.flat_map(fn entry ->
+      [Map.get(entry, "file") | List.wrap(Map.get(entry, "css")) ++ List.wrap(Map.get(entry, "assets"))]
+    end)
+    |> Enum.filter(&is_binary/1)
+    |> Enum.uniq()
+  end
+
   @doc "Warms every persisted active set. Safe to call during application boot."
   @spec warm() :: :ok
   def warm do
@@ -143,20 +274,22 @@ defmodule Brando.Assets.SiteAssets do
     :ok
   end
 
-  @doc "Returns the current scope's cached uploaded Vite manifest, if present."
+  @doc """
+  Returns the Vite manifest of the process-local override set or, without one,
+  of the current scope's active set.
+  """
   @spec current_manifest() :: map() | nil
   def current_manifest do
-    case current_scope() do
-      {:ok, site} -> cached(site) |> cached_value(:manifest)
-      :error -> nil
+    case override() do
+      %{manifest: manifest} -> manifest
+      nil -> current_scope() |> scope_cached() |> cached_value(:manifest)
     end
   end
 
-  @doc "Resolves a regular file within the current active set."
+  @doc "Resolves a regular file within the override set or the current active set."
   @spec current_file(String.t()) :: String.t() | nil
   def current_file(relative_path) when is_binary(relative_path) do
-    with {:ok, site} <- current_scope(),
-         %{files: files, path: root} <- cached(site),
+    with %{files: files, path: root} <- override() || scope_cached(current_scope()),
          normalized when is_binary(normalized) <- normalize_relative_path(relative_path),
          true <- MapSet.member?(files, normalized) do
       Path.join(root, normalized)
@@ -165,12 +298,32 @@ defmodule Brando.Assets.SiteAssets do
     end
   end
 
-  @doc "Returns the current scope's active set root for static export tooling."
+  @doc "Returns the override or active set root for static export tooling."
   @spec current_root() :: String.t() | nil
   def current_root do
-    case current_scope() do
-      {:ok, site} -> cached(site) |> cached_value(:path)
-      :error -> nil
+    case override() do
+      %{path: path} -> path
+      nil -> current_scope() |> scope_cached() |> cached_value(:path)
+    end
+  end
+
+  @doc """
+  Resolves the scope of the current process: the tenant site in multi-site
+  mode, `nil` for standalone installations, and `:error` without site context.
+  """
+  @spec current_scope() :: {:ok, scope()} | :error
+  def current_scope do
+    case Tenant.mode() do
+      :multi ->
+        with site_key when is_binary(site_key) <- Tenant.current_site_key(),
+             site when not is_nil(site) <- Brando.Tenant.Cache.get_site(site_key) do
+          {:ok, site}
+        else
+          _missing_context -> :error
+        end
+
+      _standalone ->
+        {:ok, nil}
     end
   end
 
@@ -257,9 +410,77 @@ defmodule Brando.Assets.SiteAssets do
   defp build_cache(%SiteAssetSet{} = asset_set) do
     with {:ok, files, _size} <- scan_files(asset_set.path),
          {:ok, manifest} <- read_manifest(asset_set.path) do
-      {:ok, %{set: asset_set, path: asset_set.path, files: files, manifest: manifest}}
+      {:ok,
+       %{
+         set: asset_set,
+         path: asset_set.path,
+         files: files,
+         pinned: pinned_files(files, manifest),
+         manifest: manifest
+       }}
     end
   end
+
+  # Only content-addressed build output may be served from a pinned set. Source
+  # maps sit beside their hashed owners, so they are pinned when present.
+  defp pinned_files(files, manifest) do
+    manifest
+    |> manifest_files()
+    |> Enum.flat_map(&[&1, &1 <> ".map"])
+    |> MapSet.new()
+    |> MapSet.intersection(files)
+  end
+
+  defp active_file(site, relative_path) do
+    case cached(site) do
+      %{files: files, path: root} ->
+        if MapSet.member?(files, relative_path), do: Path.join(root, relative_path)
+
+      nil ->
+        nil
+    end
+  end
+
+  defp pinned_file(site, relative_path) do
+    site
+    |> pinned_sets()
+    |> Enum.find_value(fn %{pinned: pinned, path: root} ->
+      if MapSet.member?(pinned, relative_path), do: Path.join(root, relative_path)
+    end)
+  end
+
+  defp warm_pinned(site) do
+    pinned =
+      site
+      |> Retention.preview_pinned_sets()
+      |> Enum.flat_map(fn asset_set ->
+        case set_cache(asset_set) do
+          {:ok, cached} -> [cached]
+          {:error, _reason} -> []
+        end
+      end)
+
+    store(pinned_cache_key(scope_key(site)), pinned)
+    pinned
+  rescue
+    _migration_not_applied_yet ->
+      store(pinned_cache_key(scope_key(site)), [])
+      []
+  end
+
+  defp with_override(cached, fun) do
+    previous = Process.get(@override_key)
+    Process.put(@override_key, cached)
+
+    try do
+      {:ok, fun.()}
+    after
+      if previous, do: Process.put(@override_key, previous), else: Process.delete(@override_key)
+    end
+  end
+
+  defp scope_cached({:ok, site}), do: cached(site)
+  defp scope_cached(:error), do: nil
 
   defp read_manifest(root) do
     path = Path.join(root, "manifest.json")
@@ -316,21 +537,6 @@ defmodule Brando.Assets.SiteAssets do
     _migration_not_applied_yet -> nil
   end
 
-  defp current_scope do
-    case Tenant.mode() do
-      :multi ->
-        with site_key when is_binary(site_key) <- Tenant.current_site_key(),
-             site when not is_nil(site) <- Brando.Tenant.Cache.get_site(site_key) do
-          {:ok, site}
-        else
-          _missing_context -> :error
-        end
-
-      _standalone ->
-        {:ok, nil}
-    end
-  end
-
   defp scope_query(nil), do: from(asset_set in SiteAssetSet, where: is_nil(asset_set.site_id))
 
   defp scope_query(%Site{id: site_id}),
@@ -347,9 +553,12 @@ defmodule Brando.Assets.SiteAssets do
   defp scope_key(%Site{id: site_id}), do: {:site_id, site_id}
 
   defp cache_key(scope_key), do: {:brando, :site_assets, :active, scope_key}
+  defp pinned_cache_key(scope_key), do: {:brando, :site_assets, :pinned, scope_key}
+  defp set_cache_key(set_id), do: {:brando, :site_assets, :set, set_id}
 
-  defp put_cache(scope_key, value) do
-    key = cache_key(scope_key)
+  defp put_cache(scope_key, value), do: store(cache_key(scope_key), value)
+
+  defp store(key, value) do
     :persistent_term.put(key, value)
 
     keys = :persistent_term.get(@cache_keys_key, [])

--- a/lib/brando/assets/site_assets/capture.ex
+++ b/lib/brando/assets/site_assets/capture.ex
@@ -1,0 +1,248 @@
+defmodule Brando.Assets.SiteAssets.Capture do
+  @moduledoc """
+  Materializes the frontend build a shared preview depends on into a
+  persistent, registered asset set.
+
+  Ordinary releases keep their compiled assets inside `priv/static`, which the
+  next deploy replaces. A preview link must outlive that, so before rendering,
+  the effective build is copied into `sets/capture-<identity>` beside uploaded
+  sets and registered without activation. The identity is derived from the
+  merged file listing and the Vite manifest, so repeated shares of one release
+  reuse a single capture. Files are copied rather than symlinked, and a capture
+  is published by an atomic rename out of a staging directory, so a concurrent
+  reader never sees a partial set.
+
+  When an uploaded set is active and self-contained (every file its manifest
+  lists is present), it is reused directly. An uploaded set that relies on
+  release fallback files is merged with the release, uploaded files taking
+  precedence, so the pinned copy is complete.
+  """
+
+  alias Brando.Assets.SiteAssets
+  alias Brando.Assets.SiteAssetSet
+  alias Brando.Repo
+
+  @source "release_capture"
+  @excluded_top_level ~w(media)
+  @public_opts [prefix: "public"]
+
+  @doc "The metadata `source` value marking sets Brando captured itself."
+  @spec source() :: String.t()
+  def source, do: @source
+
+  @doc "Returns true for sets Brando captured from a release rather than uploaded sets."
+  @spec captured?(SiteAssetSet.t()) :: boolean()
+  def captured?(%SiteAssetSet{metadata: metadata}), do: Map.get(metadata || %{}, "source") == @source
+
+  @doc """
+  Returns a registered set that fully covers the scope's effective frontend
+  assets, capturing the release build when necessary.
+
+  Call under the scope's asset lock; `Brando.Assets.SiteAssets.with_preview_set/2`
+  does so.
+  """
+  @spec ensure_set(SiteAssets.scope()) :: {:ok, SiteAssetSet.t()} | {:error, term()}
+  def ensure_set(site) do
+    case SiteAssets.active_set(site) do
+      nil -> capture(site, [release_root()])
+      %SiteAssetSet{} = active -> ensure_from_active(site, active)
+    end
+  end
+
+  defp ensure_from_active(site, active) do
+    with {:ok, cached} <- SiteAssets.set_cache(active) do
+      if self_contained?(cached),
+        do: {:ok, active},
+        else: capture(site, [release_root(), active.path])
+    end
+  end
+
+  @doc """
+  The release's compiled static directory. Override it with
+  `config :brando, :release_static_path` when the assets are not under the
+  endpoint application's `priv/static`.
+  """
+  @spec release_root() :: String.t()
+  def release_root do
+    Brando.config(:release_static_path) ||
+      Application.app_dir(Brando.endpoint().config(:otp_app), "priv/static")
+  end
+
+  defp self_contained?(%{manifest: nil}), do: false
+
+  defp self_contained?(%{manifest: manifest, files: files}) do
+    manifest
+    |> SiteAssets.manifest_files()
+    |> Enum.all?(&MapSet.member?(files, &1))
+  end
+
+  defp capture(site, sources) do
+    with {:ok, listing} <- merged_listing(sources),
+         {:ok, identity} <- identity(listing) do
+      name = "capture-" <> identity
+      reuse_or_publish(site, name, existing(site, name), listing, identity)
+    end
+  end
+
+  defp reuse_or_publish(site, name, %SiteAssetSet{path: path} = asset_set, listing, identity) do
+    if File.dir?(path) do
+      {:ok, asset_set}
+    else
+      # A stale row whose directory is gone must not be handed out; capture again.
+      Repo.delete(asset_set, @public_opts)
+      SiteAssets.forget_set(asset_set)
+      publish(site, name, listing, identity)
+    end
+  end
+
+  defp reuse_or_publish(site, name, nil, listing, identity), do: publish(site, name, listing, identity)
+
+  defp existing(site, name) do
+    site
+    |> SiteAssets.list_sets()
+    |> Enum.find(&(&1.name == name))
+  end
+
+  defp publish(site, name, listing, identity) do
+    final_path = Path.join(SiteAssets.sets_root(site), name)
+    staging = Path.join(staging_root(site), "#{name}-#{Brando.Utils.random_string(8)}")
+
+    with :ok <- copy_listing(listing, staging),
+         :ok <- move_into_place(staging, final_path),
+         {:ok, asset_set} <- register(site, name, final_path, identity) do
+      {:ok, asset_set}
+    else
+      {:error, reason} ->
+        File.rm_rf(staging)
+        {:error, {:asset_capture_failed, reason}}
+    end
+  end
+
+  defp register(site, name, final_path, identity) do
+    now = DateTime.utc_now()
+    metadata = %{source: @source, revision: identity, uploaded_at: now, captured_at: now}
+
+    case SiteAssets.register_set(site, final_path, metadata) do
+      {:ok, asset_set} ->
+        {:ok, asset_set}
+
+      {:error, %Ecto.Changeset{errors: errors}} = error ->
+        # Another process registered the same identity first.
+        case {Keyword.has_key?(errors, :name), existing(site, name)} do
+          {true, %SiteAssetSet{} = asset_set} -> {:ok, asset_set}
+          _not_a_duplicate -> error
+        end
+
+      error ->
+        error
+    end
+  end
+
+  defp merged_listing(sources) do
+    Enum.reduce_while(sources, {:ok, %{}}, fn root, {:ok, acc} ->
+      case list_files(root) do
+        {:ok, files} -> {:cont, {:ok, Map.merge(acc, files)}}
+        {:error, reason} -> {:halt, {:error, reason}}
+      end
+    end)
+  end
+
+  defp list_files(root) do
+    if File.dir?(root), do: walk(root, root, %{}), else: {:ok, %{}}
+  end
+
+  defp walk(root, directory, acc) do
+    case File.ls(directory) do
+      {:ok, entries} ->
+        Enum.reduce_while(entries, {:ok, acc}, &walk_entry(root, directory, &1, &2))
+
+      {:error, reason} ->
+        {:error, {:asset_directory_scan_failed, directory, reason}}
+    end
+  end
+
+  defp walk_entry(root, directory, entry, {:ok, acc}) do
+    path = Path.join(directory, entry)
+
+    if directory == root and entry in @excluded_top_level,
+      do: {:cont, {:ok, acc}},
+      else: path |> File.stat() |> walk_stat(root, path, acc)
+  end
+
+  # `File.stat/1` follows symlinks so linked files are captured by content.
+  defp walk_stat({:ok, %{type: :directory}}, root, path, acc) do
+    case walk(root, path, acc) do
+      {:ok, nested} -> {:cont, {:ok, nested}}
+      {:error, reason} -> {:halt, {:error, reason}}
+    end
+  end
+
+  defp walk_stat({:ok, %{type: :regular, size: size}}, root, path, acc),
+    do: {:cont, {:ok, Map.put(acc, Path.relative_to(path, root), {path, size})}}
+
+  defp walk_stat({:ok, _special}, _root, _path, acc), do: {:cont, {:ok, acc}}
+  defp walk_stat({:error, :enoent}, _root, _path, acc), do: {:cont, {:ok, acc}}
+
+  defp walk_stat({:error, reason}, _root, path, _acc),
+    do: {:halt, {:error, {:asset_file_stat_failed, path, reason}}}
+
+  defp identity(listing) when map_size(listing) == 0, do: {:error, :no_frontend_assets}
+
+  defp identity(listing) do
+    hash =
+      listing
+      |> Enum.sort()
+      |> Enum.reduce(:crypto.hash_init(:sha256), fn {relative, {_path, size}}, acc ->
+        :crypto.hash_update(acc, "#{relative}\t#{size}\n")
+      end)
+
+    with {:ok, hash} <- hash_manifest(hash, listing) do
+      {:ok, hash |> :crypto.hash_final() |> Base.encode16(case: :lower) |> binary_part(0, 16)}
+    end
+  end
+
+  defp hash_manifest(hash, listing) do
+    case Map.fetch(listing, "manifest.json") do
+      {:ok, {path, _size}} ->
+        case File.read(path) do
+          {:ok, json} -> {:ok, :crypto.hash_update(hash, json)}
+          {:error, reason} -> {:error, {:asset_manifest_read_failed, path, reason}}
+        end
+
+      :error ->
+        {:ok, hash}
+    end
+  end
+
+  defp copy_listing(listing, staging) do
+    Enum.reduce_while(listing, :ok, fn {relative, {source, _size}}, :ok ->
+      destination = Path.join(staging, relative)
+
+      with :ok <- File.mkdir_p(Path.dirname(destination)),
+           {:ok, _bytes} <- File.copy(source, destination) do
+        {:cont, :ok}
+      else
+        {:error, reason} -> {:halt, {:error, {:asset_copy_failed, source, reason}}}
+      end
+    end)
+  end
+
+  defp move_into_place(staging, final_path) do
+    with :ok <- File.mkdir_p(Path.dirname(final_path)) do
+      case File.rename(staging, final_path) do
+        :ok ->
+          :ok
+
+        {:error, reason} when reason in [:eexist, :enotempty, :eisdir] ->
+          # Published by an earlier attempt that failed before registering.
+          File.rm_rf(staging)
+          :ok
+
+        {:error, reason} ->
+          {:error, {:asset_publish_failed, final_path, reason}}
+      end
+    end
+  end
+
+  defp staging_root(site), do: site |> SiteAssets.sets_root() |> Path.dirname() |> Path.join("staging")
+end

--- a/lib/brando/assets/site_assets/retention.ex
+++ b/lib/brando/assets/site_assets/retention.ex
@@ -1,0 +1,196 @@
+defmodule Brando.Assets.SiteAssets.Retention do
+  @moduledoc """
+  Decides which registered asset sets may be deleted, and deletes them.
+
+  A set is protected while any of these hold:
+
+    * it is the scope's active set;
+    * an unexpired shared preview references it. `sites_previews.expires_at`
+      is compared directly, so expired rows the purge worker has not removed
+      yet never prolong protection;
+    * a queued or running static build still needs it as its asset source.
+
+  Deletion runs under the scope's asset lock, the same lock
+  `Brando.Assets.SiteAssets.with_preview_set/2` holds while a preview is
+  captured, rendered, and saved, so a set cannot disappear underneath a preview
+  that is acquiring it. Deployment tooling such as Florist must call
+  `prune_sets/2` or `delete_set/1` instead of removing directories by age or
+  count; protected sets may temporarily exceed the configured `:keep` count.
+  """
+
+  import Ecto.Query, only: [from: 2]
+
+  alias Brando.Assets.SiteAssets
+  alias Brando.Assets.SiteAssets.Capture
+  alias Brando.Assets.SiteAssetSet
+  alias Brando.Repo
+  alias Brando.Sites.Preview
+  alias Brando.SSG.Build
+  alias Brando.Tenant.Lock
+  alias Brando.Tenant.Registry
+
+  require Logger
+
+  @public_opts [prefix: "public"]
+  @busy_build_statuses [:queued, :building]
+  @default_keep 5
+
+  @doc "Sets in the scope that an unexpired shared preview still references."
+  @spec preview_pinned_sets(SiteAssets.scope()) :: [SiteAssetSet.t()]
+  def preview_pinned_sets(site \\ nil) do
+    referenced = preview_referenced_ids()
+
+    site
+    |> SiteAssets.list_sets()
+    |> Enum.filter(&MapSet.member?(referenced, &1.id))
+  end
+
+  @doc "IDs of every set in the scope that must not be deleted right now."
+  @spec protected_set_ids(SiteAssets.scope()) :: MapSet.t(pos_integer())
+  def protected_set_ids(site \\ nil) do
+    referenced = MapSet.union(preview_referenced_ids(), build_referenced_ids())
+
+    site
+    |> SiteAssets.list_sets()
+    |> Enum.filter(&(&1.active or MapSet.member?(referenced, &1.id)))
+    |> MapSet.new(& &1.id)
+  end
+
+  @doc "Returns true when the set is active or still referenced by a preview or build."
+  @spec protected?(SiteAssetSet.t()) :: boolean()
+  def protected?(%SiteAssetSet{id: id} = asset_set) do
+    asset_set
+    |> scope()
+    |> protected_set_ids()
+    |> MapSet.member?(id)
+  end
+
+  @doc """
+  Sets ordinary retention would delete: uploaded sets beyond the newest
+  `:keep` (default #{@default_keep}) plus every captured set, minus protected
+  sets. Captured sets exist only for previews and never count against `:keep`.
+  """
+  @spec prunable_sets(SiteAssets.scope() | keyword(), keyword()) :: [SiteAssetSet.t()]
+  def prunable_sets(site \\ nil, opts \\ [])
+  def prunable_sets(opts, []) when is_list(opts), do: prunable_sets(nil, opts)
+
+  def prunable_sets(site, opts) do
+    keep = Keyword.get(opts, :keep, @default_keep)
+    protected = protected_set_ids(site)
+
+    {uploaded, captured} =
+      site
+      |> SiteAssets.list_sets()
+      |> Enum.split_with(&(not Capture.captured?(&1)))
+
+    (Enum.drop(uploaded, keep) ++ captured)
+    |> Enum.reject(&MapSet.member?(protected, &1.id))
+  end
+
+  @doc "Deletes every prunable set in the scope under the asset lock and returns the deleted sets."
+  @spec prune_sets(SiteAssets.scope() | keyword(), keyword()) :: {:ok, [SiteAssetSet.t()]}
+  def prune_sets(site \\ nil, opts \\ [])
+  def prune_sets(opts, []) when is_list(opts), do: prune_sets(nil, opts)
+
+  def prune_sets(site, opts) do
+    Lock.with(SiteAssets.lock_key(site), fn ->
+      {:ok, site |> prunable_sets(opts) |> Enum.flat_map(&delete_now/1)}
+    end)
+  end
+
+  @doc "Deletes captured sets no preview or build needs any more. Uploaded sets are left to `prune_sets/2`."
+  @spec prune_captured_sets(SiteAssets.scope()) :: {:ok, [SiteAssetSet.t()]}
+  def prune_captured_sets(site \\ nil) do
+    Lock.with(SiteAssets.lock_key(site), fn ->
+      protected = protected_set_ids(site)
+
+      deleted =
+        site
+        |> SiteAssets.list_sets()
+        |> Enum.filter(&(Capture.captured?(&1) and not MapSet.member?(protected, &1.id)))
+        |> Enum.flat_map(&delete_now/1)
+
+      {:ok, deleted}
+    end)
+  end
+
+  @doc "Deletes one set unless it is protected."
+  @spec delete_set(SiteAssetSet.t() | pos_integer()) :: {:ok, SiteAssetSet.t()} | {:error, term()}
+  def delete_set(set_id) when is_integer(set_id) do
+    case Repo.get(SiteAssetSet, set_id, @public_opts) do
+      nil -> {:error, :asset_set_not_found}
+      asset_set -> delete_set(asset_set)
+    end
+  end
+
+  def delete_set(%SiteAssetSet{id: id} = asset_set) do
+    Lock.with(SiteAssets.lock_key(asset_set), fn ->
+      cond do
+        is_nil(Repo.get(SiteAssetSet, id, @public_opts)) -> {:error, :asset_set_not_found}
+        protected?(asset_set) -> {:error, :asset_set_protected}
+        true -> delete(asset_set)
+      end
+    end)
+  end
+
+  defp delete_now(asset_set) do
+    case delete(asset_set) do
+      {:ok, deleted} -> [deleted]
+      {:error, _reason} -> []
+    end
+  end
+
+  defp delete(asset_set) do
+    with {:ok, deleted} <- Repo.delete(asset_set, @public_opts) do
+      SiteAssets.forget_set(deleted)
+      remove_directory(deleted)
+      {:ok, deleted}
+    end
+  end
+
+  # The registry row is gone, so the set can no longer be activated or pinned.
+  # A directory that cannot be removed is logged rather than failing the prune.
+  defp remove_directory(%SiteAssetSet{path: path} = asset_set) do
+    with {:ok, site} <- scope_site(asset_set),
+         true <- Path.dirname(Path.expand(path)) == site |> SiteAssets.sets_root() |> Path.expand(),
+         {:ok, _removed} <- File.rm_rf(path) do
+      :ok
+    else
+      _problem -> Logger.warning("Could not remove asset set directory #{inspect(path)}")
+    end
+  end
+
+  defp preview_referenced_ids do
+    now = DateTime.utc_now() |> DateTime.truncate(:second)
+
+    from(preview in Preview,
+      where: preview.expires_at > ^now and not is_nil(preview.asset_set_id),
+      select: preview.asset_set_id,
+      distinct: true
+    )
+    |> Repo.all(@public_opts)
+    |> MapSet.new()
+  end
+
+  defp build_referenced_ids do
+    from(build in Build,
+      where: build.status in ^@busy_build_statuses and not is_nil(build.asset_set_id),
+      select: build.asset_set_id,
+      distinct: true
+    )
+    |> Repo.all(@public_opts)
+    |> MapSet.new()
+  end
+
+  defp scope(%SiteAssetSet{site_id: nil}), do: nil
+  defp scope(%SiteAssetSet{site_id: site_id}), do: %Brando.Sites.Site{id: site_id}
+
+  defp scope_site(%SiteAssetSet{site_id: nil}), do: {:ok, nil}
+
+  defp scope_site(%SiteAssetSet{site_id: site_id}) do
+    case Registry.get_site(site_id) do
+      nil -> {:error, :site_not_found}
+      site -> {:ok, site}
+    end
+  end
+end

--- a/lib/brando/assets/vite.ex
+++ b/lib/brando/assets/vite.ex
@@ -197,29 +197,35 @@ defmodule Brando.Assets.Vite do
     end
 
     def critical_css(scope \\ :app) do
-      cache_key = Brando.Tenant.cache_key(config(scope).critical_css_cache_key)
+      # A process-local set override (shared preview rendering) must read that
+      # set's critical CSS rather than the cached active-set result.
+      if scope == :app and Brando.Assets.SiteAssets.override() do
+        build_critical_css(scope)
+      else
+        cache_key = Brando.Tenant.cache_key(config(scope).critical_css_cache_key)
 
-      case :persistent_term.get(cache_key, nil) do
-        nil ->
-          manifest = Manifest.read(scope)
+        case :persistent_term.get(cache_key, nil) do
+          nil ->
+            res = build_critical_css(scope)
+            :persistent_term.put(cache_key, res)
+            res
 
-          critical_css_files =
-            get_in(manifest, [Access.key(:critical), Access.key(:css_files, [])])
+          res ->
+            res
+        end
+      end
+    end
 
-          res =
-            if critical_css_files == [] do
-              "/* no critical css */"
-            else
-              Brando.env()
-              |> critical_css(critical_css_files)
-              |> Phoenix.HTML.raw()
-            end
+    defp build_critical_css(scope) do
+      manifest = Manifest.read(scope)
+      critical_css_files = get_in(manifest, [Access.key(:critical), Access.key(:css_files, [])])
 
-          :persistent_term.put(cache_key, res)
-          res
-
-        res ->
-          res
+      if critical_css_files == [] do
+        "/* no critical css */"
+      else
+        Brando.env()
+        |> critical_css(critical_css_files)
+        |> Phoenix.HTML.raw()
       end
     end
 

--- a/lib/brando/live_preview.ex
+++ b/lib/brando/live_preview.ex
@@ -66,6 +66,7 @@ defmodule Brando.LivePreview do
     opts_to_document: []
 
   require Logger
+  alias Brando.Assets.SiteAssets
   alias Brando.Exception.LivePreviewError
   alias Brando.Utils
   alias Brando.Worker
@@ -422,39 +423,64 @@ defmodule Brando.LivePreview do
   end
 
   @doc """
-  Renders the entry, stores in DB and returns URL
+  Renders the entry against a pinned frontend asset set, stores the HTML, and
+  returns the shareable URL.
+
+  The asset set is resolved and locked before rendering (see
+  `Brando.Assets.SiteAssets.with_preview_set/2`), so the stored markup, its
+  inline critical CSS, and the digested files it links stay available for the
+  preview's whole lifetime even if a deploy or activation replaces the
+  current assets. A capture failure fails sharing instead of storing a preview
+  tied to ephemeral release files.
   """
   def share(schema_module, changeset, user, updated_entry_assocs \\ %{}, target \\ nil) do
-    with :ok <- Brando.Authorization.Preview.authorize_share(user, changeset) do
-      cache_key = build_cache_key(:erlang.system_time())
-      entry_struct = prepare_entry_struct(changeset, updated_entry_assocs)
+    with :ok <- Brando.Authorization.Preview.authorize_share(user, changeset),
+         {:ok, scope} <- preview_asset_scope(),
+         {:ok, result} <-
+           SiteAssets.with_preview_set(
+             scope,
+             &store_preview(schema_module, changeset, user, updated_entry_assocs, target, &1)
+           ) do
+      result
+    end
+  end
 
-      expiry_days = Brando.config(:preview_expiry_days) || 2
+  defp preview_asset_scope do
+    case SiteAssets.current_scope() do
+      {:ok, scope} -> {:ok, scope}
+      :error -> {:error, :missing_site_context}
+    end
+  end
 
-      html =
-        schema_module
-        |> render(entry_struct, cache_key, include_meta: true, target: target)
-        |> Utils.term_to_binary()
+  defp store_preview(schema_module, changeset, user, updated_entry_assocs, target, asset_set) do
+    cache_key = build_cache_key(:erlang.system_time())
+    entry_struct = prepare_entry_struct(changeset, updated_entry_assocs)
+    expiry_days = Brando.config(:preview_expiry_days) || 2
 
-      preview_key = Utils.random_string(12)
-      expires_at = DateTime.add(DateTime.utc_now(), expiry_days, :day)
+    html =
+      schema_module
+      |> render(entry_struct, cache_key, include_meta: true, target: target)
+      |> Utils.term_to_binary()
 
-      preview = %{
-        html: html,
-        preview_key: preview_key,
-        expires_at: expires_at,
-        creator_id: user.id
-      }
+    expires_at = DateTime.add(DateTime.utc_now(), expiry_days, :day)
 
-      with :ok <- Brando.Authorization.Preview.authorize_share(user, changeset),
-           {:ok, preview} <- Brando.Sites.create_preview(preview, :system) do
-        %{id: preview.id}
-        |> Brando.Tenant.Job.attach()
-        |> Worker.PreviewPurger.new(scheduled_at: expires_at, tags: [:preview_purger])
-        |> Oban.insert()
+    preview = %{
+      html: html,
+      preview_key: Utils.random_string(12),
+      expires_at: expires_at,
+      creator_id: user.id,
+      asset_set_id: asset_set.id
+    }
 
-        {:ok, Brando.Sites.Preview.__absolute_url__(preview), expiry_days}
-      end
+    with {:ok, preview} <- Brando.Sites.create_preview(preview, :system) do
+      SiteAssets.invalidate_pinned(asset_set)
+
+      %{id: preview.id}
+      |> Brando.Tenant.Job.attach()
+      |> Worker.PreviewPurger.new(scheduled_at: expires_at, tags: [:preview_purger])
+      |> Oban.insert()
+
+      {:ok, Brando.Sites.Preview.__absolute_url__(preview), expiry_days}
     end
   end
 

--- a/lib/brando/plug/site_assets.ex
+++ b/lib/brando/plug/site_assets.ex
@@ -1,10 +1,14 @@
 defmodule Brando.Plug.SiteAssets do
   @moduledoc """
-  Serves files from the active persistent frontend asset set.
+  Serves files from the active persistent frontend asset set, or from a set a
+  shared preview has pinned.
 
-  Place this plug before the application's release `Plug.Static`. A cached
-  `MapSet` rejects misses without touching the filesystem; misses fall through
-  unchanged so release assets remain the fallback.
+  Place this plug before the application's release `Plug.Static`. Cached
+  `MapSet`s reject misses without touching the filesystem; misses fall through
+  unchanged so release assets remain the fallback. Pinned sets only serve the
+  content-addressed files their Vite manifest lists, at their original URLs,
+  so a preview rendered against an older build keeps loading its stylesheets,
+  chunks, and fonts after the active set or release changes.
   """
 
   import Plug.Conn, only: [halt: 1, put_resp_header: 3, send_file: 3]
@@ -20,13 +24,13 @@ defmodule Brando.Plug.SiteAssets do
 
   @impl Plug
   def call(%Plug.Conn{method: method} = conn, _opts) when method in @allowed_methods do
-    with {:ok, site} <- request_scope(conn),
-         %{files: files, path: root} <- SiteAssets.cached(site),
-         relative_path when is_binary(relative_path) <- relative_path(conn.path_info),
-         true <- MapSet.member?(files, relative_path) do
+    with relative_path when is_binary(relative_path) <- relative_path(conn.path_info),
+         {:ok, site} <- request_scope(conn),
+         file when is_binary(file) <- SiteAssets.serve_path(site, relative_path) do
       conn
+      |> put_resp_header("content-type", MIME.from_path(relative_path))
       |> put_resp_header("cache-control", "public, max-age=31536000, immutable")
-      |> send_file(200, Path.join(root, relative_path))
+      |> send_file(200, file)
       |> halt()
     else
       _miss -> conn

--- a/lib/brando/sites/preview.ex
+++ b/lib/brando/sites/preview.ex
@@ -21,4 +21,10 @@ defmodule Brando.Sites.Preview do
     attribute :expires_at, :datetime, required: true
     attribute :html, :text, required: true
   end
+
+  relations do
+    # The immutable frontend asset set the stored HTML was rendered against.
+    # Legacy previews created before pinning keep a nil reference.
+    relation :asset_set, :belongs_to, module: Brando.Assets.SiteAssetSet
+  end
 end

--- a/lib/brando/workers/preview_purger.ex
+++ b/lib/brando/workers/preview_purger.ex
@@ -6,8 +6,14 @@ defmodule Brando.Worker.PreviewPurger do
     queue: :default,
     max_attempts: 3
 
+  alias Brando.Assets.SiteAssets
+  alias Brando.Assets.SiteAssets.Retention
+  alias Brando.Assets.SiteAssetSet
   alias Brando.Sites
   alias Brando.Tenant.Job, as: TenantJob
+  alias Brando.Tenant.Registry
+
+  require Logger
 
   @impl Oban.Worker
   def perform(%Oban.Job{} = job), do: TenantJob.run(job, fn -> perform_tenant(job) end)
@@ -25,10 +31,43 @@ defmodule Brando.Worker.PreviewPurger do
           {:snooze, max(remaining, 1)}
         else
           case Sites.delete_preview(id, :system) do
-            {:ok, _} -> :ok
+            {:ok, _} -> release_asset_set(preview.asset_set_id)
             {:error, _} -> :ok
           end
         end
+    end
+  end
+
+  # The preview no longer pins its asset set. Drop the scope's pinned listing
+  # and remove captured release sets nothing references any more.
+  defp release_asset_set(nil), do: :ok
+
+  defp release_asset_set(asset_set_id) do
+    case Brando.Repo.get(SiteAssetSet, asset_set_id, prefix: "public") do
+      nil ->
+        :ok
+
+      asset_set ->
+        SiteAssets.invalidate_pinned(asset_set)
+
+        with {:ok, scope} <- asset_scope(asset_set) do
+          Retention.prune_captured_sets(scope)
+        end
+
+        :ok
+    end
+  rescue
+    exception ->
+      Logger.warning("Preview purge could not prune asset sets: #{Exception.message(exception)}")
+      :ok
+  end
+
+  defp asset_scope(%SiteAssetSet{site_id: nil}), do: {:ok, nil}
+
+  defp asset_scope(%SiteAssetSet{site_id: site_id}) do
+    case Registry.get_site(site_id) do
+      nil -> {:error, :site_not_found}
+      site -> {:ok, site}
     end
   end
 

--- a/lib/brando_admin/components/form.ex
+++ b/lib/brando_admin/components/form.ex
@@ -1816,10 +1816,22 @@ defmodule BrandoAdmin.Components.Form do
             type: "info"
           })
 
-        {:error, _} ->
+        {:error, :forbidden} ->
           push_event(socket, "b:alert", %{
             title: gettext("Cannot share preview"),
             message: gettext("You do not have permission to export this entry."),
+            type: "error"
+          })
+
+        {:error, reason} ->
+          Logger.error("Sharing a preview failed: #{inspect(reason)}")
+
+          push_event(socket, "b:alert", %{
+            title: gettext("Cannot share preview"),
+            message:
+              gettext(
+                "The frontend assets for this preview could not be captured, so no link was created. Check the server log and try again."
+              ),
             type: "error"
           })
       end

--- a/lib/brando_admin/live/config/asset_live.ex
+++ b/lib/brando_admin/live/config/asset_live.ex
@@ -6,6 +6,8 @@ defmodule BrandoAdmin.Sites.AssetLive do
   use Gettext, backend: Brando.Gettext
 
   alias Brando.Assets.SiteAssets
+  alias Brando.Assets.SiteAssets.Capture
+  alias Brando.Assets.SiteAssets.Retention
   alias Brando.Tenant
   alias BrandoAdmin.Components.Workspace
 
@@ -141,6 +143,7 @@ defmodule BrandoAdmin.Sites.AssetLive do
                   <td class="frontend-assets-build__identity">
                     <h3>{asset_set.name}</h3>
                     <code>{asset_set.metadata["revision"] || asset_set.path}</code>
+                    <p :if={Capture.captured?(asset_set)}>{gettext("Captured from a release for shared previews")}</p>
                   </td>
                   <td class="frontend-assets-build__uploaded">{format_datetime(asset_set.uploaded_at)}</td>
                   <td class="frontend-assets-build__bundle">
@@ -149,7 +152,7 @@ defmodule BrandoAdmin.Sites.AssetLive do
                   <td class="frontend-assets-build__status">
                     <span class={["frontend-assets-status", asset_set.active && "active"]}>
                       <span aria-hidden="true"></span>
-                      {if asset_set.active, do: gettext("Active"), else: gettext("Available")}
+                      {status_label(asset_set, @protected_ids)}
                     </span>
                   </td>
                   <td class="frontend-assets-build__actions row-actions">
@@ -205,11 +208,21 @@ defmodule BrandoAdmin.Sites.AssetLive do
   end
 
   defp refresh(socket) do
-    sets = SiteAssets.list_sets(socket.assigns.scope_site)
+    scope_site = socket.assigns.scope_site
+    sets = SiteAssets.list_sets(scope_site)
 
     socket
     |> assign(:sets, sets)
     |> assign(:active_set, Enum.find(sets, & &1.active))
+    |> assign(:protected_ids, Retention.protected_set_ids(scope_site))
+  end
+
+  defp status_label(%{active: true}, _protected_ids), do: gettext("Active")
+
+  defp status_label(asset_set, protected_ids) do
+    if MapSet.member?(protected_ids, asset_set.id),
+      do: gettext("In use by shared previews or builds"),
+      else: gettext("Available")
   end
 
   defp scope_site(socket) do

--- a/priv/repo/migrations/20260912000000_add_asset_set_to_previews.exs
+++ b/priv/repo/migrations/20260912000000_add_asset_set_to_previews.exs
@@ -1,0 +1,11 @@
+defmodule Brando.Repo.Migrations.AddAssetSetToPreviews do
+  use Ecto.Migration
+
+  def change do
+    alter table(:sites_previews) do
+      add :asset_set_id, references(:site_asset_sets, prefix: "public", on_delete: :nilify_all)
+    end
+
+    create index(:sites_previews, [:asset_set_id])
+  end
+end

--- a/priv/templates/brando.upgrade/migrations/brando_173_add_asset_set_to_previews.exs
+++ b/priv/templates/brando.upgrade/migrations/brando_173_add_asset_set_to_previews.exs
@@ -1,0 +1,11 @@
+defmodule Brando.Repo.Migrations.Brando173AddAssetSetToPreviews do
+  use Ecto.Migration
+
+  def change do
+    alter table(:sites_previews) do
+      add :asset_set_id, references(:site_asset_sets, prefix: "public", on_delete: :nilify_all)
+    end
+
+    create index(:sites_previews, [:asset_set_id])
+  end
+end

--- a/test/brando/assets/preview_pinning_test.exs
+++ b/test/brando/assets/preview_pinning_test.exs
@@ -1,0 +1,343 @@
+defmodule Brando.Assets.PreviewPinningTest do
+  use ExUnit.Case, async: false
+  use Brando.ConnCase
+
+  import Ecto.Query, only: [from: 2]
+
+  alias Brando.Assets.SiteAssets
+  alias Brando.Assets.SiteAssets.Capture
+  alias Brando.Assets.SiteAssets.Retention
+  alias Brando.Assets.SiteAssetSet
+  alias Brando.Assets.Vite.Manifest
+  alias Brando.LivePreview
+  alias Brando.Pages.Page
+  alias Brando.Sites.Preview
+  alias Brando.Tenant
+  alias Brando.Tenant.Registry
+
+  @public_opts [prefix: "public"]
+
+  setup do
+    root = Path.join(System.tmp_dir!(), "brando-preview-pinning-#{System.unique_integer([:positive])}")
+    release = Path.join(root, "release")
+
+    put_test_env(:tenancy_mode, :none)
+    put_test_env(:media_path, Path.join(root, "media"))
+    put_test_env(:sites_path, Path.join(root, "sites"))
+    put_test_env(:site_assets_path, Path.join(root, "site_assets"))
+    put_test_env(:release_static_path, release)
+    reset_caches()
+
+    on_exit(fn ->
+      File.rm_rf(root)
+      Tenant.put_prefix(nil)
+      reset_caches()
+      Brando.Tenant.Cache.clear()
+    end)
+
+    user = Brando.Factory.insert(:random_user, avatar: nil)
+    %{root: root, release: release, user: user}
+  end
+
+  test "captures the release into a persistent set once and renders against it", %{release: release} do
+    write_release(release, "aaaa")
+
+    assert {:ok, {set, manifest, critical}} =
+             SiteAssets.with_preview_set(nil, fn set ->
+               {set, Manifest.read(:app), Manifest.critical_css() |> Phoenix.HTML.safe_to_string()}
+             end)
+
+    assert Capture.captured?(set)
+    refute set.active
+    assert set.name =~ ~r/^capture-[0-9a-f]{16}$/
+    assert set.metadata["source"] == Capture.source()
+    assert manifest.entries.files == ["/assets/main-aaaa.js"]
+    assert manifest.entries.css_files == ["/assets/main-aaaa.css"]
+    assert critical =~ "critical-aaaa"
+    assert SiteAssets.override() == nil
+
+    copied = Path.join(set.path, "assets/main-aaaa.js")
+    assert File.regular?(copied)
+    assert {:ok, %File.Stat{type: :regular}} = File.lstat(copied)
+    assert File.read!(copied) == "js-aaaa"
+    refute File.exists?(Path.join(set.path, "media/upload.jpg"))
+    assert File.ls!(Path.dirname(Path.dirname(set.path))) |> Enum.sort() == ["sets", "staging"]
+    assert File.ls!(Path.join(Path.dirname(Path.dirname(set.path)), "staging")) == []
+
+    assert {:ok, again} = SiteAssets.with_preview_set(nil, & &1)
+    assert again.id == set.id
+    assert length(SiteAssets.list_sets()) == 1
+  end
+
+  test "serves a pinned set's digested files at their original URLs after a deploy", %{
+    release: release,
+    user: user
+  } do
+    write_release(release, "aaaa")
+    assert {:ok, set} = SiteAssets.with_preview_set(nil, & &1)
+    pin_preview(set, user, 3_600)
+
+    # A deploy replaces every digested filename and removes the old release.
+    File.rm_rf!(release)
+    write_release(release, "bbbb")
+    SiteAssets.invalidate_pinned()
+
+    for {path, body, type} <- [
+          {"assets/main-aaaa.css", "css-aaaa", "text/css"},
+          {"assets/main-aaaa.js", "js-aaaa", "text/javascript"},
+          {"assets/font-aaaa.woff2", "font-aaaa", "font/woff2"},
+          {"assets/main-aaaa.js.map", "map-aaaa", "application/octet-stream"}
+        ] do
+      served = Brando.Plug.SiteAssets.call(conn(path), [])
+      assert served.halted, "expected #{path} to be served from the pinned set"
+      assert served.status == 200
+      assert served.resp_body == body
+      assert Plug.Conn.get_resp_header(served, "content-type") == [type]
+    end
+
+    # Un-hashed files never come from a pinned set, and the current release is
+    # left to the application's own Plug.Static.
+    refute Brando.Plug.SiteAssets.call(conn("favicon.ico"), []).halted
+    refute Brando.Plug.SiteAssets.call(conn("manifest.json"), []).halted
+    refute Brando.Plug.SiteAssets.call(conn("assets/main-bbbb.css"), []).halted
+  end
+
+  test "activation during rendering cannot mix sets in the snapshot", %{release: release} do
+    write_release(release, "aaaa")
+    next_path = create_set(nil, "next-build", "js-next", "next.css")
+    assert {:ok, next} = SiteAssets.register_set(next_path)
+
+    assert {:ok, {inside_manifest, inside_critical}} =
+             SiteAssets.with_preview_set(nil, fn _set ->
+               assert {:ok, _active} = SiteAssets.activate_set(next.id)
+               {Manifest.read(:app), Manifest.critical_css() |> Phoenix.HTML.safe_to_string()}
+             end)
+
+    assert inside_manifest.entries.files == ["/assets/main-aaaa.js"]
+    assert inside_critical =~ "critical-aaaa"
+    assert Manifest.read(:app).entries.files == ["/assets/next-build.js"]
+  end
+
+  test "reuses a self-contained uploaded set and merges a partial one with the release", %{release: release} do
+    write_release(release, "aaaa")
+
+    full_path = create_set(nil, "full-upload", "js-full", "full.css")
+    assert {:ok, full} = SiteAssets.register_set(full_path)
+    assert {:ok, _active} = SiteAssets.activate_set(full.id)
+    assert {:ok, pinned} = SiteAssets.with_preview_set(nil, & &1)
+    assert pinned.id == full.id
+    refute Enum.any?(SiteAssets.list_sets(), &Capture.captured?/1)
+
+    partial_path = Path.join(SiteAssets.sets_root(nil), "partial-upload")
+    File.mkdir_p!(Path.join(partial_path, "assets"))
+    File.write!(Path.join(partial_path, "assets/partial.js"), "js-partial")
+    File.write!(Path.join(partial_path, "favicon.ico"), "icon-partial")
+
+    partial_manifest = %{
+      "src/main.js" => %{"isEntry" => true, "file" => "assets/partial.js", "css" => ["assets/main-aaaa.css"]}
+    }
+
+    File.write!(Path.join(partial_path, "manifest.json"), Jason.encode!(partial_manifest))
+    assert {:ok, partial} = SiteAssets.register_set(partial_path)
+    assert {:ok, _active} = SiteAssets.activate_set(partial.id)
+
+    assert {:ok, merged} = SiteAssets.with_preview_set(nil, & &1)
+    assert Capture.captured?(merged)
+    assert File.read!(Path.join(merged.path, "assets/partial.js")) == "js-partial"
+    assert File.read!(Path.join(merged.path, "assets/main-aaaa.css")) == "css-aaaa"
+    assert File.read!(Path.join(merged.path, "favicon.ico")) == "icon-partial"
+    assert Jason.decode!(File.read!(Path.join(merged.path, "manifest.json"))) == partial_manifest
+  end
+
+  test "a pinned set is protected until its last preview expires, even before purging", %{
+    release: release,
+    user: user
+  } do
+    write_release(release, "aaaa")
+    assert {:ok, set} = SiteAssets.with_preview_set(nil, & &1)
+    preview = pin_preview(set, user, 3_600)
+
+    assert Retention.prunable_sets() == []
+    assert Retention.protected?(set)
+    assert {:error, :asset_set_protected} = Retention.delete_set(set)
+    assert {:ok, []} = Retention.prune_captured_sets()
+    assert File.dir?(set.path)
+
+    Repo.update!(Ecto.Changeset.change(preview, expires_at: ~U[2020-01-01 00:00:00Z]))
+
+    assert [%SiteAssetSet{id: id}] = Retention.prunable_sets()
+    assert id == set.id
+    assert {:ok, [_deleted]} = Retention.prune_captured_sets()
+    refute File.dir?(set.path)
+    assert Repo.get(SiteAssetSet, set.id, @public_opts) == nil
+    assert Repo.get(Preview, preview.id).asset_set_id == nil
+    assert SiteAssets.pinned_sets() == []
+  end
+
+  test "ordinary retention keeps the newest uploaded sets and never deletes the active one" do
+    sets =
+      for {name, uploaded_at} <- [
+            {"oldest", "2026-01-01T00:00:00Z"},
+            {"middle", "2026-02-01T00:00:00Z"},
+            {"newest", "2026-03-01T00:00:00Z"}
+          ] do
+        path = create_set(nil, name, "js-#{name}", "#{name}.css")
+        assert {:ok, set} = SiteAssets.register_set(path, %{uploaded_at: uploaded_at})
+        set
+      end
+
+    [oldest, middle, newest] = sets
+    assert {:ok, _active} = SiteAssets.activate_set(oldest.id)
+
+    assert Enum.map(Retention.prunable_sets(keep: 1), & &1.id) == [middle.id]
+    assert {:ok, [deleted]} = Retention.prune_sets(keep: 1)
+    assert deleted.id == middle.id
+    refute File.dir?(middle.path)
+    assert File.dir?(oldest.path)
+    assert File.dir?(newest.path)
+    assert Enum.map(SiteAssets.list_sets(), & &1.id) == [newest.id, oldest.id]
+  end
+
+  test "the purge worker releases the pin and prunes the captured set", %{release: release, user: user} do
+    write_release(release, "aaaa")
+    assert {:ok, set} = SiteAssets.with_preview_set(nil, & &1)
+    preview = pin_preview(set, user, -60)
+
+    assert :ok = Brando.Worker.PreviewPurger.perform(%Oban.Job{args: %{"id" => preview.id}})
+    refute Repo.get(Preview, preview.id)
+    assert Repo.get(SiteAssetSet, set.id, @public_opts) == nil
+    refute File.dir?(set.path)
+  end
+
+  test "sharing pins the preview to a captured set and fails visibly without assets", %{
+    release: release,
+    user: user
+  } do
+    write_release(release, "aaaa")
+
+    changeset =
+      %Page{title: "Shared draft", language: :en, entry_blocks: []} |> Map.put(:key, "about") |> Ecto.Changeset.change()
+
+    assert {:ok, url, _days} = LivePreview.share(Page, changeset, user)
+    preview = Repo.one!(from(preview in Preview, order_by: [desc: preview.id], limit: 1))
+    assert url =~ preview.preview_key
+    assert [set] = SiteAssets.list_sets()
+    assert preview.asset_set_id == set.id
+    assert Capture.captured?(set)
+    assert Retention.protected?(set)
+
+    File.rm_rf!(release)
+    Retention.prune_captured_sets()
+    assert File.dir?(set.path)
+    Repo.update!(Ecto.Changeset.change(preview, expires_at: ~U[2020-01-01 00:00:00Z]))
+    assert {:ok, [_deleted]} = Retention.prune_captured_sets()
+
+    before = Repo.aggregate(Preview, :count)
+    assert {:error, :no_frontend_assets} = LivePreview.share(Page, changeset, user)
+    assert Repo.aggregate(Preview, :count) == before
+    assert SiteAssets.list_sets() == []
+  end
+
+  test "another site's pinned set is never served", %{release: release, user: user} do
+    put_test_env(:tenancy_mode, :multi)
+    Brando.Tenant.Cache.clear()
+    write_release(release, "aaaa")
+
+    {:ok, acme} = create_site("Pin Acme", "pin-acme", "pin.acme.test")
+    {:ok, beta} = create_site("Pin Beta", "pin-beta", "pin.beta.test")
+
+    assert {:ok, set} = SiteAssets.with_preview_set(acme, & &1)
+    assert set.site_id == acme.id
+    pin_preview(set, user, 3_600)
+
+    served = Brando.Plug.SiteAssets.call(conn("assets/main-aaaa.js", "pin.acme.test"), [])
+    assert served.halted
+    assert served.resp_body == "js-aaaa"
+    refute Brando.Plug.SiteAssets.call(conn("assets/main-aaaa.js", "pin.beta.test"), []).halted
+    assert Retention.protected_set_ids(beta) == MapSet.new()
+    assert Retention.protected_set_ids(acme) == MapSet.new([set.id])
+  end
+
+  defp write_release(release, digest) do
+    File.mkdir_p!(Path.join(release, "assets"))
+    File.mkdir_p!(Path.join(release, "media"))
+    File.write!(Path.join(release, "media/upload.jpg"), "mutable media")
+    File.write!(Path.join(release, "favicon.ico"), "icon-#{digest}")
+    File.write!(Path.join(release, "assets/main-#{digest}.js"), "js-#{digest}")
+    File.write!(Path.join(release, "assets/main-#{digest}.js.map"), "map-#{digest}")
+    File.write!(Path.join(release, "assets/main-#{digest}.css"), "css-#{digest}")
+    File.write!(Path.join(release, "assets/font-#{digest}.woff2"), "font-#{digest}")
+    File.write!(Path.join(release, "assets/critical-#{digest}.js"), "critical-js-#{digest}")
+    File.write!(Path.join(release, "assets/critical-#{digest}.css"), "critical-#{digest}")
+
+    manifest = %{
+      "js/index.js" => %{
+        "isEntry" => true,
+        "file" => "assets/main-#{digest}.js",
+        "css" => ["assets/main-#{digest}.css"],
+        "assets" => ["assets/font-#{digest}.woff2"]
+      },
+      "js/critical.js" => %{
+        "isEntry" => true,
+        "name" => "critical",
+        "file" => "assets/critical-#{digest}.js",
+        "css" => ["assets/critical-#{digest}.css"]
+      }
+    }
+
+    File.write!(Path.join(release, "manifest.json"), Jason.encode!(manifest))
+  end
+
+  defp pin_preview(set, user, seconds_from_now) do
+    Repo.insert!(%Preview{
+      creator_id: user.id,
+      preview_key: Ecto.UUID.generate(),
+      html: Brando.Utils.term_to_binary("<main>Pinned</main>"),
+      expires_at: DateTime.utc_now() |> DateTime.add(seconds_from_now, :second) |> DateTime.truncate(:second),
+      asset_set_id: set.id
+    })
+  end
+
+  defp create_set(site, name, js_content, css_file) do
+    path = Path.join(SiteAssets.sets_root(site), name)
+    File.mkdir_p!(Path.join(path, "assets"))
+    File.write!(Path.join([path, "assets", "#{name}.js"]), js_content)
+    File.write!(Path.join([path, "assets", css_file]), "body{}")
+
+    manifest = %{
+      "src/main.js" => %{"isEntry" => true, "file" => "assets/#{name}.js", "css" => ["assets/#{css_file}"]}
+    }
+
+    File.write!(Path.join(path, "manifest.json"), Jason.encode!(manifest))
+    path
+  end
+
+  defp create_site(name, key, domain) do
+    {:ok, site} =
+      Registry.create_site(%{
+        name: name,
+        key: key,
+        languages: ["en"],
+        default_language: "en",
+        status: :active,
+        delivery_mode: :dynamic
+      })
+
+    {:ok, _environment} =
+      Registry.create_environment(site, %{name: "Production", key: "production", live: true, domain: domain})
+
+    {:ok, Registry.get_site(site.id)}
+  end
+
+  defp conn(relative_path, host \\ "standalone.test") do
+    :get
+    |> Plug.Test.conn("https://#{host}/#{relative_path}")
+    |> Map.put(:host, host)
+  end
+
+  defp reset_caches do
+    SiteAssets.invalidate_cache()
+    :persistent_term.erase({:vite, "cache_manifest"})
+    :persistent_term.erase({:vite, "critical_css"})
+  end
+end


### PR DESCRIPTION
Closes #2795.

## Summary

- Shared preview links stored HTML that referenced the digested asset names of the release they were rendered with; the next deploy deleted those files and the page rendered unstyled with no JavaScript.
- `Brando.LivePreview.share/5` now pins the preview to an immutable asset set before rendering, under the scope's advisory lock, and stores it in `sites_previews.asset_set_id`. The manifest, inline critical CSS, and asset URLs are rendered from that set even if another set is activated concurrently.
- The set is the active uploaded set when it is self-contained. Otherwise `Brando.Assets.SiteAssets.Capture` copies the effective build (release `priv/static`, overlaid with a partial active set) into `site_assets/sets/capture-<identity>` and registers it without activation. Copies are real files, published by atomic rename from a staging directory, and deduplicated by a listing-plus-manifest identity. A capture failure fails sharing visibly.
- `Brando.Plug.SiteAssets` serves the content-addressed files of every set an unexpired preview references, at their original URLs. It also sends a `content-type` header now.
- `Brando.Assets.SiteAssets.Retention` owns pruning: active, preview-pinned (by `expires_at` directly), and queued/building SSG-referenced sets are protected. Captured sets are removed by the preview purger once their last preview expires. `prune_sets/2` and `delete_set/1` are the API Florist's `keep_sets` pruning should call (#2689).
- Upgrade migration `brando_173_add_asset_set_to_previews`. Old previews keep a nil reference and legacy behaviour.

## Where this deviates from the issue

The issue proposes a `/__assets__/<set-id>/…` namespace with URL rewriting. Vite output is content-addressed, so a relative path already identifies one immutable file. Falling back from the active set to preview-pinned sets at the original URLs covers CSS `url(/assets/…)`, static and dynamic chunk imports, fonts, and inline critical CSS without rewriting HTML, CSS, or JavaScript, and needs no consumer build changes. Only files listed in a set's Vite manifest (plus their source maps) are served from a pinned set, so an old capture never shadows un-hashed files such as `favicon.ico`. A separate reservation table is unnecessary because sharing holds the same per-scope lock that pruning takes.

## Validation

- `mix test --warnings-as-errors`: 2338 checks pass in a container with `pg_dump` and `rsync` available (Elixir 1.20.4 / OTP 28.4.3, Postgres 16).
- New `test/brando/assets/preview_pinning_test.exs` covers release capture and reuse, serving after a simulated deploy with content types, activation mid-render, partial-upload merging, retention protection until expiry (unpurged rows included), `keep` retention, the purge worker, the share flow including visible capture failure, and multi-site scoping.
- `mix format --check-formatted` passes; credo findings on touched files are pre-existing.
- Not run: the E2E Playwright suite (no pnpm/playwright on this machine).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
