### PR TITLE
fix: record a modal's opener at open time, not on the next frame

### DIFF
--- a/assets/src/hooks/Modal/index.js
+++ b/assets/src/hooks/Modal/index.js
@@ -93,6 +93,13 @@ export default app => ({
   },
 
   onOpened() {
+    // Remember who opened it *now*, before anything else can move focus, so
+    // closing returns the user to the control they were on rather than to the
+    // top of the page. During a server patch the previously focused control
+    // may already be gone (focus sits on <body>); `focusOpened` fills that in
+    // once LiveView has restored it.
+    this.opener = this.openerCandidate() || this.opener
+
     // LiveView restores the previously focused control after a save reply.
     // Take focus on the next frame, so the reply cannot move focus back
     // behind a newly opened dialog.
@@ -100,13 +107,20 @@ export default app => ({
     this.openFrame = requestAnimationFrame(() => this.focusOpened())
   },
 
+  openerCandidate() {
+    const active = document.activeElement
+    return active && active !== document.body && !this.el.contains(active) ? active : null
+  },
+
   focusOpened() {
     if (!this.el.isConnected || !this.isOpen()) return
 
-    // Remember who opened it *before* moving focus, so closing returns the user
-    // to the control they were on rather than to the top of the page.
-    const active = document.activeElement
-    this.opener = active && !this.el.contains(active) ? active : this.opener
+    // A fast keyboard user (or a test) can reach a control inside the dialog
+    // before this frame runs. Taking focus then would yank it off that control
+    // and, because the opener was never recorded, strand the user on close.
+    if (this.el.contains(document.activeElement)) return
+
+    this.opener = this.opener || this.openerCandidate()
 
     // `show_modal/1` reveals the dialog with a 200ms transition, and this runs
     // the instant `display` changes — before its contents have a layout box, so


### PR DESCRIPTION
## Summary

E2E legacy-2 has been failing intermittently on `modal-design.spec.js:107` ("variable sections retain edits and Escape closes only the nested picker"): it failed on two of four CI runs of byte-identical code today, and 2 of 8 repeated local runs on unmodified `next`.

Root cause is in the Modal hook, not the test. It captured the opener element and took focus inside a `requestAnimationFrame` callback. If a control inside the dialog was reached before that frame ran, the opener was never recorded and focus was yanked off that control. On Escape nothing was restored, so `expect(opener).toBeFocused()` saw `<body>`.

Fix:
- capture the opener synchronously when the open transition is observed;
- keep the deferred capture only as a fallback for server-driven opens that leave focus on `<body>` during the patch;
- if focus is already inside the dialog when the frame runs, leave it there.

## Test plan

- [x] `-g "variable sections" --repeat-each 12 --retries 0`: 12 passed (before: 2 of 8 failed)
- [x] Full `tests/modal-design.spec.js`: 5 passed
- [ ] CI E2E shards

🤖 Generated with [Claude Code](https://claude.com/claude-code)