### PR TITLE
Prevent duplicate drop listeners in LegacyImageUpload

### DIFF
--- a/assets/src/hooks/LegacyImageUpload/index.js
+++ b/assets/src/hooks/LegacyImageUpload/index.js
@@ -15,6 +15,7 @@ export default (app) => ({
 
   mounted() {
     this.attachListenersOnUpdate = false
+    this.canvasListenerController = null
     this.multi = this.el.hasAttribute('data-upload-multi')
     this.files = []
     this.configTarget = this.el.hasAttribute('data-upload-config-target')
@@ -81,6 +82,13 @@ export default (app) => ({
   },
 
   attachListeners() {
+    // Abort previous canvas listeners to prevent duplicates
+    if (this.canvasListenerController) {
+      this.canvasListenerController.abort()
+    }
+    this.canvasListenerController = new AbortController()
+    const { signal } = this.canvasListenerController
+
     this.$uploadCanvases = Dom.all(this.el, '.upload-canvas')
 
     this.$uploadCanvases.forEach((uploadCanvas) => {
@@ -94,17 +102,17 @@ export default (app) => ({
         } else {
           e.preventDefault()
         }
-      })
+      }, { signal })
 
       uploadCanvas.addEventListener('dragenter', () => {
         uploadCanvas.classList.add('dragging')
-      })
+      }, { signal })
       uploadCanvas.addEventListener('dragover', () => {
         uploadCanvas.classList.add('dragging')
-      })
+      }, { signal })
       uploadCanvas.addEventListener('dragleave', () => {
         uploadCanvas.classList.remove('dragging')
-      })
+      }, { signal })
 
       uploadCanvas.addEventListener('drop', async (event) => {
         event.preventDefault()
@@ -123,7 +131,7 @@ export default (app) => ({
             await this.upload(files[i])
           }
         }
-      })
+      }, { signal })
     })
   },
 


### PR DESCRIPTION
## Summary

Maintenance fix for the 0.54 line. `attachListeners` in the LegacyImageUpload hook re-registered its drag and drop handlers on every call without removing the previous set, so a re-rendered upload canvas could fire the drop handler more than once and upload the same file twice. The listeners now share an `AbortController` that is aborted before the next attach.

Written on 2026-04-16 against a 0.54 project and cherry-picked from a local `main`. Not needed on `next`: 0.55 got its own guard in February and then removed this hook when image and file vars moved to LiveView uploads.

## Test plan

- [x] Drop a file on a picture block in a 0.54 project after the form has re-rendered; one upload, not two

🤖 Generated with [Claude Code](https://claude.com/claude-code)