### PR TITLE
fix: update a root block's Liquid variable preview on edit

### DIFF
--- a/e2e/e2e/playwright/tests/blocks/block-liquid-nesting.spec.js
+++ b/e2e/e2e/playwright/tests/blocks/block-liquid-nesting.spec.js
@@ -88,6 +88,10 @@ test('nested Liquid regions keep following blocks in their container after patch
   await following.getByLabel('Caption', { exact: true }).fill('Following caption edited')
   await awaitBlockDebounce(page)
   await assertStructure()
+  // Root blocks post their vars as `entry_block[block][vars][i][value]`; the
+  // inline preview must pick that up before a save (#2797).
+  await expect(nested.locator('.rendered-variable')).toHaveText('Nested caption edited')
+  await expect(following.locator('.rendered-variable')).toHaveText('Following caption edited')
 
   await page.getByTestId('submit').click()
   await expect(page).toHaveURL(/\/admin\/pages$/)

--- a/lib/brando_admin/components/form/block.ex
+++ b/lib/brando_admin/components/form/block.ex
@@ -2558,14 +2558,25 @@ defmodule BrandoAdmin.Components.Form.Block do
   def maybe_update_fragment(socket, _), do: socket
 
   # if the target param updated is a var and it's not an image or file, we extract the value
-  # and update the liquex block var
+  # and update the liquex block var.
+  #
+  # A child block's inputs are named `child_block[vars][i][value]`; a root block
+  # wraps its block in an entry_block, so its inputs are
+  # `entry_block[block][vars][i][value]`. Both shapes arrive here with the form
+  # name as the first segment and `value` as the last, and `params` is the map
+  # under that first segment — so the var is at the path in between.
   def maybe_update_liquex_block_var(socket, [_block_type, "vars", idx, "value"] = params_target, params) do
-    var_target =
-      params_target
-      |> List.delete_at(0)
-      |> List.delete_at(-1)
+    update_liquex_block_var_from_target(socket, params_target, idx, params)
+  end
 
-    value = params |> get_in(var_target) |> Map.get("value")
+  def maybe_update_liquex_block_var(socket, [_block_type, "block", "vars", idx, "value"] = params_target, params) do
+    update_liquex_block_var_from_target(socket, params_target, idx, params)
+  end
+
+  def maybe_update_liquex_block_var(socket, _, _), do: socket
+
+  defp update_liquex_block_var_from_target(socket, params_target, idx, params) do
+    value = get_in(params, List.delete_at(params_target, 0))
 
     # `key` and `type` describe the var's *definition*, which this screen never
     # edits — only `value` changes here. Read them from the changeset rather
@@ -2580,8 +2591,6 @@ defmodule BrandoAdmin.Components.Form.Block do
       {var_key, var_type} -> update_liquex_block_var(socket, var_key, var_type, %{value: value})
     end
   end
-
-  def maybe_update_liquex_block_var(socket, _, _), do: socket
 
   # The var changesets are in the same order the form rendered them, so the
   # params index addresses the same var. Returns nils rather than raising if it

--- a/test/brando_admin/components/form/block/liquid_var_preview_test.exs
+++ b/test/brando_admin/components/form/block/liquid_var_preview_test.exs
@@ -1,0 +1,137 @@
+defmodule BrandoAdmin.Components.Form.Block.LiquidVarPreviewTest do
+  # Editing a string var must update the inline Liquid preview (`liquid_splits`)
+  # for both block shapes. A child block's inputs are named
+  # `child_block[vars][i][value]`; a root block wraps its block in an
+  # entry_block, so its inputs are `entry_block[block][vars][i][value]`. The
+  # root shape used to fall through to the no-op clause, leaving `{{ caption }}`
+  # stale until save and reopen — issue #2797.
+  use ExUnit.Case, async: false
+  use Brando.ConnCase
+
+  alias Brando.Factory
+  alias BrandoAdmin.Components.Form.Block
+  alias BrandoAdmin.Components.Form.BlockField
+  alias Ecto.Changeset
+  alias Phoenix.Component
+
+  defp create_module(user) do
+    {:ok, module} =
+      Brando.Content.create_module(
+        %{
+          name: %{"en" => "Caption var"},
+          namespace: %{"en" => "test"},
+          help_text: %{"en" => "help"},
+          class: "captionvar",
+          code: "<figure>{% ref refs.heading %}<figcaption>{{ caption }}</figcaption></figure>",
+          refs: [
+            %{
+              name: "heading",
+              uid: "refheading",
+              description: "heading ref",
+              data: %{type: "header", data: %{text: "Heading", level: 2}}
+            }
+          ],
+          vars: [
+            %{type: :string, key: "caption", label: "Caption", value: "Original caption"}
+          ]
+        },
+        user
+      )
+
+    module
+  end
+
+  defp child_changeset(module, user) do
+    BlockField.build_block(module.id, user.id, nil, "Elixir.Brando.Pages.Page.Blocks", :module)
+  end
+
+  defp root_changeset(module, user) do
+    %Brando.Pages.Page.Blocks{}
+    |> Changeset.change()
+    |> Changeset.put_assoc(:block, child_changeset(module, user))
+  end
+
+  defp socket_for(:root, module, user) do
+    changeset = root_changeset(module, user)
+    uid = changeset |> Changeset.get_assoc(:block) |> Changeset.get_field(:uid)
+    build_socket(changeset, uid, :root, module)
+  end
+
+  defp socket_for(:child, module, user) do
+    changeset = child_changeset(module, user)
+    build_socket(changeset, Changeset.get_field(changeset, :uid), :child, module)
+  end
+
+  defp build_socket(changeset, uid, belongs_to, module) do
+    %Phoenix.LiveView.Socket{}
+    |> Component.assign(:form, Block.build_form_from_changeset(changeset, uid, belongs_to))
+    |> Component.assign(:belongs_to, belongs_to)
+    |> Component.assign(:module_id, module.id)
+    |> Component.assign(:uid, uid)
+    |> Component.assign(:liquid_splits, [
+      "<figure>",
+      {:ref, "heading"},
+      "<figcaption>",
+      {:module_variable, "caption", "Original caption"},
+      "</figcaption></figure>"
+    ])
+  end
+
+  defp rendered_caption(socket) do
+    Enum.find_value(socket.assigns.liquid_splits, fn
+      {:module_variable, "caption", value} -> value
+      _ -> nil
+    end)
+  end
+
+  setup do
+    user = Factory.insert(:random_user)
+    {:ok, user: user, module: create_module(user)}
+  end
+
+  test "a root block's var edit updates the rendered variable", %{user: user, module: module} do
+    socket = socket_for(:root, module, user)
+
+    # What the browser submits for a root block: the form name, then the
+    # entry_block's `block` assoc, then the var.
+    target = ["entry_block", "block", "vars", "0", "value"]
+    params = %{"block" => %{"vars" => %{"0" => %{"value" => "Edited caption"}}}}
+
+    socket = Block.maybe_update_liquex_block_var(socket, target, params)
+
+    assert rendered_caption(socket) == "Edited caption"
+  end
+
+  test "a child block's var edit updates the rendered variable", %{user: user, module: module} do
+    socket = socket_for(:child, module, user)
+
+    target = ["child_block", "vars", "0", "value"]
+    params = %{"vars" => %{"0" => %{"value" => "Edited caption"}}}
+
+    socket = Block.maybe_update_liquex_block_var(socket, target, params)
+
+    assert rendered_caption(socket) == "Edited caption"
+  end
+
+  test "an unrelated target leaves the rendered variable alone", %{user: user, module: module} do
+    socket = socket_for(:root, module, user)
+
+    target = ["entry_block", "block", "description"]
+    params = %{"block" => %{"description" => "typing"}}
+
+    socket = Block.maybe_update_liquex_block_var(socket, target, params)
+
+    assert rendered_caption(socket) == "Original caption"
+  end
+
+  test "a var index the changeset does not have is skipped, not crashed", %{user: user, module: module} do
+    socket = socket_for(:root, module, user)
+
+    target = ["entry_block", "block", "vars", "7", "value"]
+    params = %{"block" => %{"vars" => %{"7" => %{"value" => "Nope"}}}}
+
+    socket = Block.maybe_update_liquex_block_var(socket, target, params)
+
+    assert rendered_caption(socket) == "Original caption"
+  end
+end


### PR DESCRIPTION
## Summary

Editing a string var on a **root** module block left the inline Liquid preview (`{{ caption }}`) stale until save and reopen. Child blocks were fine.

Root cause: `maybe_update_liquex_block_var/3` only matched the child input shape `child_block[vars][i][value]`. A root block wraps its block in an entry_block, so its inputs are `entry_block[block][vars][i][value]`, and the extra `block` segment fell through to the no-op clause.

Fix:
- match both target shapes and share the value extraction;
- read the value from the full target path, so a missing var map skips the update instead of raising on `nil`;
- unit test covering the root shape, the child shape, an unrelated target, and an out-of-range var index;
- the existing browser regression for Liquid nesting now asserts the rendered variable updates **before** save, while keeping the save/reopen checks.

Closes #2797

## Test plan

- [x] `mix test test/brando_admin/components/form/block/liquid_var_preview_test.exs` (root-shape test fails without the fix, passes with it)
- [x] `mix test test/brando_admin/components/form/block/ref_events_test.exs`
- [x] E2E `tests/blocks/block-liquid-nesting.spec.js` with `--reset`: 2 passed
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)
