### PR TITLE
feat: warn in the module editor when a ref sits inside a conditional

### DIFF
--- a/assets/css/components/Alert.css
+++ b/assets/css/components/Alert.css
@@ -11,6 +11,10 @@
     background-color: #ffedeb;
   }
 
+  &.warning {
+    background-color: #fff6de;
+  }
+
   .form-tab .row & {
     width: 100%;
     flex-basis: 100%;

--- a/assets/css/components/Form/BlockEditor.css
+++ b/assets/css/components/Form/BlockEditor.css
@@ -226,6 +226,39 @@
       border-radius: 0 0 10px 10px;
     }
 
+    .module-code-lint {
+      margin-top: 12px;
+
+      .alert {
+        margin-bottom: 0;
+        padding: 14px 16px;
+        border-radius: 10px;
+        gap: 12px;
+      }
+
+      .content {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        gap: 8px;
+      }
+
+      p {
+        width: 100%;
+        margin: 0;
+        font-size: 13px;
+        line-height: 1.4;
+      }
+
+      code {
+        padding: 5px 8px;
+        border-radius: 6px;
+        background: white;
+        border: 1px solid #00000014;
+        font-size: 12px;
+      }
+    }
+
     .module-code-help {
       display: flex;
       flex-wrap: wrap;

--- a/e2e/e2e/playwright/tests/configuration/modules.spec.js
+++ b/e2e/e2e/playwright/tests/configuration/modules.spec.js
@@ -40,9 +40,14 @@ async function clickVarChipAction(page, label, outcome) {
   await outcome()
 }
 
+// Click a line, not the editor box: the page has more than one CodeMirror
+// (the SVG field is one too), and a click in the empty area below a short
+// document leaves focus on <body>, so the typed replacement goes nowhere.
 async function replaceModuleCode(page, code) {
   await openModuleTab(page, 'Template')
-  await page.click('.cm-editor')
+  const editor = page.locator('#module_code-code .cm-editor')
+  await editor.locator('.cm-line').first().click()
+  await expect(editor.locator('.cm-content')).toBeFocused()
   await page.keyboard.down('ControlOrMeta')
   await page.keyboard.press('A')
   await page.keyboard.up('ControlOrMeta')
@@ -88,6 +93,23 @@ test('create a simple text module', async ({ page }) => {
   await syncLV(page)
   await expect(page.getByRole('link', { name: 'New text module', exact: true })).toBeVisible()
   await expect(page.getByText('Helpful text', { exact: true })).toBeVisible()
+})
+
+// A `{% ref %}` inside `{% if %}`/`{% unless %}`/`{% for %}`/`{% hide %}` never
+// gets an input in the block editor, because those regions are stripped before
+// the code is split into slots. The editor says so instead of staying silent.
+test('warns when a ref sits inside a conditional, and clears once it is declared at the top level', async ({ page }) => {
+  await openNewModule(page)
+
+  const lint = page.locator('.module-code-lint')
+  await expect(lint).toHaveCount(0)
+
+  await replaceModuleCode(page, '{% if show %}{% ref refs.text %}{% endif %}')
+  await expect(lint).toContainText('Reference text sits inside a conditional')
+  await expect(lint).toContainText('headless_ref refs.text')
+
+  await replaceModuleCode(page, '{% headless_ref refs.text %}{% if refs.text.active %}shown{% endif %}')
+  await expect(lint).toHaveCount(0)
 })
 
 test('create, edit, duplicate, persist and delete refs and vars', async ({ page }) => {

--- a/lib/brando_admin/components/form/block/liquid_preview.ex
+++ b/lib/brando_admin/components/form/block/liquid_preview.ex
@@ -30,6 +30,43 @@ defmodule BrandoAdmin.Components.Form.Block.LiquidPreview do
     end
   end
 
+  @ref_tag ~r/{%-?\s*ref\s+refs\.(\w+)/
+
+  @doc """
+  Names the refs that only appear inside regions `strip_logic/1` removes.
+
+  Such a ref never gets an editable slot in the block editor: the region it
+  sits in is gone before the code is split into slots. A ref that is also
+  rendered at the top level keeps its slot and is not reported. Malformed
+  code reports nothing — the preview already surfaces that error.
+
+  Uses the region scan alone, not the HTML cleanup pass, so the answer depends
+  only on where the ref sits in the Liquid structure.
+  """
+  @spec stripped_refs(String.t() | nil) :: [String.t()]
+  def stripped_refs(nil), do: []
+
+  def stripped_refs(code) when is_binary(code) do
+    case scan(code, [], []) do
+      {:ok, visible} ->
+        reachable = MapSet.new(ref_names(visible))
+
+        code
+        |> ref_names()
+        |> Enum.reject(&MapSet.member?(reachable, &1))
+        |> Enum.uniq()
+
+      {:error, _} ->
+        []
+    end
+  end
+
+  defp ref_names(code) do
+    @ref_tag
+    |> Regex.scan(code, capture: :all_but_first)
+    |> List.flatten()
+  end
+
   defp scan(code, stack, acc) do
     case :binary.match(code, ["{%", "{{"]) do
       :nomatch ->

--- a/lib/brando_admin/live/content/module_form_live.ex
+++ b/lib/brando_admin/live/content/module_form_live.ex
@@ -12,6 +12,7 @@ defmodule BrandoAdmin.Content.ModuleFormLive do
   alias Brando.Content.Var
   alias Brando.Villain.Blocks.TextBlock
   alias BrandoAdmin.Components.Content
+  alias BrandoAdmin.Components.Form.Block.LiquidPreview
   alias BrandoAdmin.Components.Form.Input
   alias BrandoAdmin.Components.Form.Input.Blocks.TipTapLinkDialog
   alias BrandoAdmin.Components.Form.ModuleProps
@@ -47,6 +48,7 @@ defmodule BrandoAdmin.Content.ModuleFormLive do
          |> assign_entry(entry_id)
          |> assign_current_user(token)
          |> assign_form()
+         |> assign_stripped_refs()
          |> set_admin_locale()
          |> maybe_use_public_library_context()}
 
@@ -97,6 +99,7 @@ defmodule BrandoAdmin.Content.ModuleFormLive do
                 <code>&lcub;% ref refs.name %&rcub;</code>
                 <code>&lcub;&lcub; variable_key &rcub;&rcub;</code>
               </div>
+              <.stripped_refs_warning refs={@stripped_refs} />
             </div>
           </section>
 
@@ -440,6 +443,7 @@ defmodule BrandoAdmin.Content.ModuleFormLive do
 
     socket
     |> assign(:form, updated_form)
+    |> assign_stripped_refs()
     |> then(&{:noreply, &1})
   end
 
@@ -534,6 +538,7 @@ defmodule BrandoAdmin.Content.ModuleFormLive do
               socket
               |> assign(:entry, entry)
               |> assign(:form, module_form(entry, user, socket.assigns.shared_library?))
+              |> assign_stripped_refs()
 
             :listing when socket.assigns.shared_library? ->
               push_navigate(socket, to: "/admin/config/content/shared_library")
@@ -568,6 +573,7 @@ defmodule BrandoAdmin.Content.ModuleFormLive do
 
         socket
         |> assign(:form, form)
+        |> assign_stripped_refs()
         |> then(&{:noreply, &1})
     end
   end
@@ -643,6 +649,57 @@ defmodule BrandoAdmin.Content.ModuleFormLive do
       if shared_library?, do: Changeset.put_change(changeset, :version_note, ""), else: changeset
     end)
     |> to_form([])
+  end
+
+  # `LiquidPreview.strip_logic/1` removes `{% if %}`, `{% unless %}`, `{% for %}`
+  # and `{% hide %}` regions before the block editor splits module code into
+  # ref slots, so a `{% ref %}` inside one of them never gets an input. The
+  # module still saves and the front end still renders it — nothing else would
+  # tell the author. This is a lint, not an error: it never blocks saving.
+  defp assign_stripped_refs(%{assigns: %{form: form}} = socket) do
+    changeset = form.source
+
+    refs =
+      if Changeset.get_field(changeset, :type) == :liquid do
+        changeset |> Changeset.get_field(:code) |> LiquidPreview.stripped_refs()
+      else
+        []
+      end
+
+    assign(socket, :stripped_refs, refs)
+  end
+
+  attr :refs, :list, required: true
+
+  defp stripped_refs_warning(%{refs: []} = assigns) do
+    ~H"""
+    """
+  end
+
+  defp stripped_refs_warning(assigns) do
+    assigns = assign(assigns, :example, List.first(assigns.refs))
+
+    ~H"""
+    <div class="module-code-lint" role="status">
+      <.alert type={:warning}>
+        <p>
+          {ngettext(
+            "Reference %{refs} sits inside a conditional, loop or hide region, so the block editor cannot show an input for it.",
+            "References %{refs} sit inside conditional, loop or hide regions, so the block editor cannot show inputs for them.",
+            length(@refs),
+            refs: Enum.join(@refs, ", ")
+          )}
+        </p>
+        <p>
+          {gettext(
+            "Declare the reference at the top level with headless_ref and read it inside the condition. Saving is not blocked."
+          )}
+        </p>
+        <code>&lcub;% headless_ref refs.{@example} %&rcub;</code>
+        <code>&lcub;% if refs.{@example}.active %&rcub; … &lcub;% endif %&rcub;</code>
+      </.alert>
+    </div>
+    """
   end
 
   defp maybe_require_version_note(changeset, true),

--- a/test/brando_admin/components/form/block/liquid_preview_test.exs
+++ b/test/brando_admin/components/form/block/liquid_preview_test.exs
@@ -171,4 +171,61 @@ defmodule BrandoAdmin.Components.Form.Block.LiquidPreviewTest do
     assert LiquidPreview.strip_logic("{% raw %}unfinished") == {:error, {:unclosed_tag, "raw"}}
     assert LiquidPreview.strip_logic("{% comment %}unfinished") == {:error, {:unclosed_tag, "comment"}}
   end
+
+  describe "stripped_refs/1" do
+    test "names a ref that only appears inside a stripped region" do
+      for {_, opening, closing} <- @regions do
+        code = "{% ref refs.visible %}{% #{opening} %}<div>{% ref refs.hidden %}</div>{% #{closing} %}"
+        assert LiquidPreview.stripped_refs(code) == ["hidden"]
+      end
+    end
+
+    test "reports each hidden ref once, in source order, however deeply nested" do
+      code = """
+      {% if a %}{% ref refs.one %}{% for x in xs %}{% ref refs.two %}{% ref refs.one %}{% endfor %}{% endif %}
+      {% hide %}{% ref refs.three %}{% endhide %}
+      """
+
+      assert LiquidPreview.stripped_refs(code) == ["one", "two", "three"]
+    end
+
+    test "does not report a ref that is also rendered at the top level" do
+      code = "{% ref refs.text %}{% if a %}{% ref refs.text %}{% endif %}"
+      assert LiquidPreview.stripped_refs(code) == []
+    end
+
+    test "does not report headless_ref declarations or plain reads inside a region" do
+      # The supported pattern: declare the slot at the top level, read it inside.
+      code = """
+      {% headless_ref refs.text %}
+      {% if refs.text.active %}<div>{{ refs.text.data.data.text }}</div>{% else %}<div>No text</div>{% endif %}
+      """
+
+      assert LiquidPreview.stripped_refs(code) == []
+    end
+
+    test "recognizes trim markers and loose whitespace in the ref tag" do
+      assert LiquidPreview.stripped_refs("{% if a %}{%-  ref   refs.spaced -%}{% endif %}") == ["spaced"]
+    end
+
+    test "ignores ref tags inside raw, comment and quoted strings" do
+      code = """
+      {% if a %}{% raw %}{% ref refs.rawref %}{% endraw %}{% endif %}
+      {% comment %}{% ref refs.commented %}{% endcomment %}
+      {{ '{% ref refs.quoted %}' }}
+      """
+
+      # A `{% ref %}` inside raw/comment is never a slot at all, and one in a
+      # quoted string is text. None are "hidden by a conditional": inside a
+      # region the raw body is dropped with it, so `rawref` is reported as
+      # unreachable — it is.
+      assert LiquidPreview.stripped_refs(code) == ["rawref"]
+    end
+
+    test "reports nothing for malformed code or no code" do
+      assert LiquidPreview.stripped_refs("{% if a %}{% ref refs.text %}") == []
+      assert LiquidPreview.stripped_refs("") == []
+      assert LiquidPreview.stripped_refs(nil) == []
+    end
+  end
 end

--- a/test/brando_admin/live/content/module_form_live_test.exs
+++ b/test/brando_admin/live/content/module_form_live_test.exs
@@ -11,6 +11,38 @@ defmodule BrandoAdmin.Live.Content.ModuleFormLiveTest do
   alias BrandoAdmin.Content.ModuleFormLive
   alias Ecto.Changeset
 
+  describe "stripped refs lint" do
+    defp validate(code, type) do
+      entry = %Module{type: type, code: ""}
+      user = %Brando.Users.User{id: 1}
+
+      socket =
+        %Phoenix.LiveView.Socket{}
+        |> Phoenix.Component.assign(:entry, entry)
+        |> Phoenix.Component.assign(:current_user, user)
+        |> Phoenix.Component.assign(:shared_library?, false)
+        |> Phoenix.Component.assign(:form, to_form(Changeset.change(entry), []))
+
+      assert {:noreply, socket} =
+               ModuleFormLive.handle_event("validate", %{"module" => %{"code" => code}}, socket)
+
+      socket.assigns.stripped_refs
+    end
+
+    test "validate names a ref hidden inside a conditional" do
+      assert validate("{% if show %}{% ref refs.text %}{% endif %}", :liquid) == ["text"]
+    end
+
+    test "validate clears the warning once the ref is declared at the top level" do
+      code = "{% headless_ref refs.text %}{% if refs.text.active %}{{ refs.text.data.data.text }}{% endif %}"
+      assert validate(code, :liquid) == []
+    end
+
+    test "heex modules are not linted" do
+      assert validate("{% if show %}{% ref refs.text %}{% endif %}", :heex) == []
+    end
+  end
+
   test "create_ref/2 initializes text refs with default styles preset" do
     changeset =
       %Module{}


### PR DESCRIPTION
## Summary

`LiquidPreview.strip_logic/1` removes `{% if %}`, `{% unless %}`, `{% for %}` and `{% hide %}` regions before the block editor splits module code into ref slots. A `{% ref refs.x %}` inside one of those regions never gets an editable input, and nothing told the module author: the module saves, the front end renders, the editor just shows no field.

This adds a lint to the module editor (Content → Modules):

- `LiquidPreview.stripped_refs/1` names the refs that only appear inside stripped regions. It reuses the same region scan as `strip_logic/1`, so the answer can't drift from what the block editor actually does. A ref also rendered at the top level is not reported, and malformed code reports nothing (the preview already surfaces that).
- `ModuleFormLive` computes it on mount, on every validate, and after save, and renders a warning alert under the code editor for Liquid modules. It names the offending refs and shows the supported pattern: `{% headless_ref refs.x %}` at the top level, then read `refs.x` inside the condition.
- It is a lint, not an error. Saving is not blocked.

Closes #2796

## Test plan

- [x] `mix test test/brando_admin/components/form/block/liquid_preview_test.exs` (7 new `stripped_refs/1` tests)
- [x] `mix test test/brando_admin/live/content/module_form_live_test.exs` (validate sets/clears the lint, HEEx modules skipped)
- [x] E2E `tests/configuration/modules.spec.js` with `--reset`, including a new test that types a conditional ref, sees the warning, then declares it headless and sees it clear
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)
