### PR TITLE
fix: associate a field's help-text instructions with its control

### DIFF
--- a/assets/css/components/Form/FieldBase.css
+++ b/assets/css/components/Form/FieldBase.css
@@ -134,6 +134,13 @@
     }
 
     .help-text {
+      /* Always rendered so `aria-describedby` can name it; an empty one is
+         hidden. The class sets `display: flex`, which would otherwise win
+         over the browser's own `[hidden]` rule. */
+      &[hidden] {
+        display: none;
+      }
+
       font-size: 10px;
       line-height: normal;
       margin-top: 2px;

--- a/e2e/e2e/playwright/tests/accessibility/form-a11y.spec.js
+++ b/e2e/e2e/playwright/tests/accessibility/form-a11y.spec.js
@@ -29,7 +29,8 @@ test.describe('Accessible form validation', () => {
     // added together with its content is not reliably announced.
     const errors = page.locator('#page_title-error')
     await expect(errors).toHaveAttribute('role', 'alert')
-    await expect(title).toHaveAttribute('aria-describedby', 'page_title-error')
+    // Instructions first, then the message — the order they should be read in.
+    await expect(title).toHaveAttribute('aria-describedby', 'page_title-instructions page_title-error')
 
     await page.getByTestId('submit').click()
     await syncLV(page)

--- a/lib/brando_admin/components/form/input.ex
+++ b/lib/brando_admin/components/form/input.ex
@@ -670,12 +670,15 @@ defmodule BrandoAdmin.Components.Form.Input do
   # Every control the admin renders passes through `input/1`, so the accessible
   # state of a field is decided here rather than in the ~20 wrapper components.
   #
-  # `Primitives.field_base/1` renders the message container as
+  # `Primitives.field_base/1` renders the instructions container as
+  # `"<field id>-instructions"` and the message container as
   # `"<field id>-error"`, and both derive that id from the field the same way
-  # (`process_input_id/1` mirrors `Primitives.field_id/1`), so the reference is
-  # always to an element that exists. It points there unconditionally: the
-  # container is rendered whether or not it currently holds a message, and an
-  # empty one contributes nothing to the accessible description.
+  # (`process_input_id/1` mirrors `Primitives.field_id/1`), so the references
+  # are always to elements that exist. It points at both unconditionally: each
+  # container is rendered whether or not it currently holds anything, and an
+  # empty one contributes nothing to the accessible description. Instructions
+  # come first — a screen reader should read what the field wants before what
+  # went wrong with it.
   #
   # A hidden input has no accessible presence to annotate, so it is skipped —
   # marking it invalid would announce a field the user cannot see or reach.
@@ -691,7 +694,7 @@ defmodule BrandoAdmin.Components.Form.Input do
 
     assigns
     |> assign(:aria_invalid, (field_invalid?(field) && "true") || nil)
-    |> assign(:aria_describedby, "#{assigns.id}-error")
+    |> assign(:aria_describedby, "#{assigns.id}-instructions #{assigns.id}-error")
     |> assign(:aria_required, (field_required?(field) && "true") || nil)
   end
 

--- a/lib/brando_admin/components/form/primitives.ex
+++ b/lib/brando_admin/components/form/primitives.ex
@@ -117,33 +117,40 @@ defmodule BrandoAdmin.Components.Form.Primitives do
           {render_slot(@header)}
         </div>
       </div>
-      <%= if @raw_instructions || @meta do %>
-        <div :if={@meta_top} class={["meta", @left_justify_meta && "left"]}>
-          <%= if @raw_instructions do %>
-            <div class="help-text">
-              ↳ <span>{@raw_instructions}</span>
-            </div>
-            <div :if={@meta != []} class="extra">
-              {render_slot(@meta)}
-            </div>
-          <% end %>
-        </div>
-      <% end %>
+      <.field_meta :if={@meta_top} f_id={@f_id} instructions={@raw_instructions} left={@left_justify_meta} meta={@meta} />
       <div class="field-base" id={"#{@f_id}-field-base"}>
         {render_slot(@inner_block)}
       </div>
-      <%= if @raw_instructions || @meta do %>
-        <div :if={!@meta_top} class={["meta", @left_justify_meta && "left"]}>
-          <%= if @raw_instructions do %>
-            <div class="help-text">
-              ↳ <span>{@raw_instructions}</span>
-            </div>
-            <div :if={@meta != []} class="extra">
-              {render_slot(@meta)}
-            </div>
-          <% end %>
-        </div>
-      <% end %>
+      <.field_meta :if={!@meta_top} f_id={@f_id} instructions={@raw_instructions} left={@left_justify_meta} meta={@meta} />
+    </div>
+    """
+  end
+
+  # The instructions container is rendered whether or not the field has any,
+  # and always under `"<field id>-instructions"`, for the same reason the error
+  # container is: `Input.input/1` names both in `aria-describedby` without
+  # being told they exist, and an empty container contributes nothing to the
+  # accessible description. `hidden` keeps an empty one out of the layout; a
+  # hidden element that is directly referenced is still read.
+  #
+  # `field_base/1` renders the meta block in one of two positions, never both,
+  # so the id is emitted once.
+  attr :f_id, :string, required: true
+  attr :instructions, :any, required: true
+  attr :left, :any, required: true
+  attr :meta, :list, required: true
+
+  defp field_meta(assigns) do
+    ~H"""
+    <div class={["meta", @left && "left"]}>
+      <div id={"#{@f_id}-instructions"} class="help-text" hidden={!@instructions}>
+        <%= if @instructions do %>
+          ↳ <span>{@instructions}</span>
+        <% end %>
+      </div>
+      <div :if={@instructions && @meta != []} class="extra">
+        {render_slot(@meta)}
+      </div>
     </div>
     """
   end
@@ -628,8 +635,9 @@ defmodule BrandoAdmin.Components.Form.Primitives do
           region has to already be in the accessibility tree when content is
           inserted into it — a `role="alert"` element that appears *with* its
           message is not reliably announced. It also carries the single id that
-          `Input.input/1` points `aria-describedby` at; the messages used to be
-          sibling spans that each claimed the same id. --%>
+          `Input.input/1` points `aria-describedby` at (after the instructions
+          container); the messages used to be sibling spans that each claimed
+          the same id. --%>
     <div id={"#{@f_id}-error"} class="field-errors" role="alert">
       <span :for={error <- @errors} class="field-error">
         {@translate_fn.(error)}

--- a/test/brando_admin/components/form/input_accessibility_test.exs
+++ b/test/brando_admin/components/form/input_accessibility_test.exs
@@ -36,27 +36,51 @@ defmodule BrandoAdmin.Components.Form.InputAccessibilityTest do
     )
   end
 
+  defp render_field_base(form, field, opts \\ []) do
+    render_component(
+      &Primitives.field_base/1,
+      Enum.into(opts, %{field: form[field], label: "Title", inner_block: []})
+    )
+  end
+
   describe "aria-describedby" do
-    test "points at the field's message container" do
+    test "names the field's instructions container, then its message container" do
       html = render_input(form(%{}, []), :title)
 
-      assert html =~ ~s(aria-describedby="page_title-error")
+      assert html =~ ~s(aria-describedby="page_title-instructions page_title-error")
     end
 
-    test "matches the id `field_base/1` gives that container" do
+    test "matches the ids `field_base/1` gives those containers" do
       form = form(%{"title" => ""}, title: "can't be blank")
 
       input = render_input(form, :title)
+      wrapper = render_field_base(form, :title, instructions: "Shown in the browser tab")
 
-      wrapper =
-        render_component(&Primitives.field_base/1, %{
-          field: form[:title],
-          label: "Title",
-          inner_block: []
-        })
-
-      assert input =~ ~s(aria-describedby="page_title-error")
+      assert input =~ ~s(aria-describedby="page_title-instructions page_title-error")
+      assert wrapper =~ ~s(id="page_title-instructions")
       assert wrapper =~ ~s(id="page_title-error")
+    end
+
+    test "a field with instructions exposes them in its description, with or without an error" do
+      # Issue #2755: the help text under the label carries the format or
+      # constraint the field actually needs, and used to be a bare div that
+      # nothing pointed at.
+      for form <- [form(%{}, []), form(%{"title" => ""}, title: "can't be blank")] do
+        wrapper = render_field_base(form, :title, instructions: "Shown in the browser tab")
+
+        assert [container] = Regex.run(~r/<div id="page_title-instructions"[^>]*>.*?<\/div>/s, wrapper)
+        assert container =~ "Shown in the browser tab"
+        refute container =~ "hidden"
+      end
+    end
+
+    test "a field without instructions renders the container empty and hidden" do
+      wrapper = render_field_base(form(%{}, []), :title)
+
+      assert [container] = Regex.run(~r/<div id="page_title-instructions"[^>]*>.*?<\/div>/s, wrapper)
+      assert container =~ ~s(hidden)
+      refute container =~ "↳"
+      assert container |> String.replace(~r/<[^>]+>/, "") |> String.trim() == ""
     end
   end
 
@@ -115,7 +139,7 @@ defmodule BrandoAdmin.Components.Form.InputAccessibilityTest do
 
       assert html =~ "<textarea"
       assert html =~ ~s(aria-invalid="true")
-      assert html =~ ~s(aria-describedby="page_title-error")
+      assert html =~ ~s(aria-describedby="page_title-instructions page_title-error")
     end
 
     test "a checkbox is annotated on the visible control, not the hidden partner" do


### PR DESCRIPTION
## Summary

Follow-up to #2752. A field's `help-text` instructions were a bare `div` with no id, so nothing pointed at them: a screen reader user got the label, the required state and, after a failed save, the error, but never the format or constraint the field actually wanted.

This mirrors what #2752 did for errors rather than threading a new attribute through the ~20 wrapper components:

- `Primitives.field_base/1` always renders the instructions container as `"<field id>-instructions"`, derived from the same `field_id/1` the error container uses. An empty one carries `hidden`, and a small CSS rule lets `hidden` win over the class's `display: flex`. The meta block is rendered in one of two positions, never both, so the id is emitted once. The duplicated meta markup is now a private `field_meta/1` component.
- `Input.input/1` emits `aria-describedby` as `"<id>-instructions <id>-error"`. Instructions first, then the error, which is the order a screen reader should read them in.
- The `meta` slot (counters and controls) is unchanged and stays out of the description.

A field without instructions references an empty hidden container, which contributes nothing, so what it announces is unchanged.

Closes #2755

## Test plan

- [x] `mix test test/brando_admin/components/form/input_accessibility_test.exs` (new tests: instructions in the description with and without an error; empty hidden container without instructions; ids match between `field_base/1` and `input/1`)
- [x] `mix test test/brando_admin/components/form/input_test.exs test/brando_admin/components/form/error_display_test.exs`
- [x] E2E `tests/accessibility/form-a11y.spec.js` after rebuilding the admin CSS
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)
